### PR TITLE
Automatically deploy doc website changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Training Gym ships a dashboard that aggregates training runs, deployments,
 and eval results in one place. Deploy your own copy:
 
 ```bash
-git clone https://github.com/modal-projects/training-gym/
-modal deploy dashboards/app.py
+training-gym setup
 ```
 
 Modal prints a URL where you can watch jobs in progress.

--- a/docs-next/astro.config.mjs
+++ b/docs-next/astro.config.mjs
@@ -136,6 +136,7 @@ export default defineConfig({
             },
           ],
         },
+        { label: 'CLI Reference', link: '/reference/cli/' },
         { label: 'Support', link: '/support/' },
       ],
       editLink: {

--- a/docs-next/docs_next_app.py
+++ b/docs-next/docs_next_app.py
@@ -23,12 +23,20 @@ DOCS_DIR = Path(__file__).resolve().parent
 DIST_DIR = DOCS_DIR / "dist"
 REMOTE_DIST = "/assets/dist"
 
+
+if not modal.is_local():
+    pass
+elif not DIST_DIR.exists() or not any(DIST_DIR.iterdir()):
+    import subprocess
+
+    subprocess.check_call(["npm", "ci"], cwd=str(DOCS_DIR))
+    subprocess.check_call(["npm", "run", "build"], cwd=str(DOCS_DIR))
+
+
 image = (
     modal.Image.debian_slim(python_version="3.12")
     .pip_install("fastapi[standard]==0.118.0")
-    # `dist/` is gitignored, so use an explicit predicate to ensure Modal
-    # includes the generated static files in the deployment image.
-    .add_local_dir(DIST_DIR, remote_path=REMOTE_DIST, copy=True, ignore=lambda _: False)
+    .add_local_dir(DIST_DIR, remote_path=REMOTE_DIST, copy=True)
 )
 
 app = modal.App("training-gym-docs", image=image)

--- a/docs-next/src/content/docs/index.md
+++ b/docs-next/src/content/docs/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Gym SDK
 description: Reusable building blocks and runnable examples for RL post-training on Modal.
-editUrl: https://github.com/modal-projects/training-gym/edit/joy/fix-table-formatting-and-validate-repo-skills/README.md
+editUrl: https://github.com/modal-projects/training-gym/edit/joy/add-cli-to-website/README.md
 ---
 
 **[📖 Documentation](https://gym.modal.dev)** · **[Tutorials](https://gym.modal.dev/tutorials/)** · **[API Reference](https://gym.modal.dev/reference/)**
@@ -23,19 +23,35 @@ Or pin it in `pyproject.toml` for uv:
 training-gym = { git = "https://github.com/modal-projects/training-gym.git", branch = "main" }
 ```
 
-Then deploy the observability dashboard and import the building blocks:
-
-```bash
-training-gym setup
-```
+Then import the building blocks from your own script:
 
 ```python
 from modal_training_gym import TrainConfig
 ```
 
+## Agent set-up
+
+This repository includes an `AGENTS.md` and a `skills/` directory (symlinked to `.claude/skills/`) that teach Claude Code how to navigate the framework — W&B configuration, custom rollouts and generate functions, custom eval functions, and more.
+
+Clone the repo and run `claude` from its root; the skills load automatically based on what you ask for.
+
+## Observability dashboard
+
+Training Gym ships a dashboard that aggregates training runs, deployments,
+and eval results in one place. Deploy your own copy:
+
+```bash
+training-gym setup
+```
+
+Modal prints a URL where you can watch jobs in progress.
+
+![Gym Observability Dashboard](https://raw.githubusercontent.com/modal-projects/training-gym/joy/add-cli-to-website/assets/observability_dashboard.png)
+
+
 ## Tutorials
 
-The fastest path through the API is the [tutorials](https://github.com/modal-projects/training-gym/blob/joy/fix-table-formatting-and-validate-repo-skills/tutorials). Each one
+The fastest path through the API is the [tutorials](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials). Each one
 ships as a runnable `.py` **and** a paired `.ipynb` narrated cell-by-cell —
 the notebook is the canonical walkthrough. Each tutorial below has a one-click
 **Launch** button that opens the `.ipynb` in a fresh Modal Notebook; the first
@@ -58,32 +74,13 @@ rest of the cells run as-is.
 
 | Tutorial | Summary | Difficulty | Framework | Launch |
 |---|---|---|---|---|
-| [`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/joy/fix-table-formatting-and-validate-repo-skills/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) | Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare | Beginner | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/joy/make-claude-skills-not-scuffed/tutorials/rl/000_rl_basics/000_rl_basics.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
-| [`001_sandboxes`](https://github.com/modal-projects/training-gym/blob/joy/fix-table-formatting-and-validate-repo-skills/tutorials/rl/001_sandboxes/001_sandboxes.ipynb) | Code RL with Harbor hello-world and sandboxed verification | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/joy/make-claude-skills-not-scuffed/tutorials/rl/001_sandboxes/001_sandboxes.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
-| [`002_multiturn`](https://github.com/modal-projects/training-gym/blob/joy/fix-table-formatting-and-validate-repo-skills/tutorials/rl/002_multiturn/002_multiturn.ipynb) | Multi-turn number-guessing RL with custom generate and reward functions | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/joy/make-claude-skills-not-scuffed/tutorials/rl/002_multiturn/002_multiturn.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
+| [`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) | Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare | Beginner | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/000_rl_basics/000_rl_basics.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
+| [`001_sandboxes`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/001_sandboxes/001_sandboxes.ipynb) | Code RL with Harbor hello-world and sandboxed verification | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/001_sandboxes/001_sandboxes.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
+| [`002_multiturn`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/002_multiturn/002_multiturn.ipynb) | Multi-turn number-guessing RL with custom generate and reward functions | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/002_multiturn/002_multiturn.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
 <!-- END TUTORIAL TABLE -->
 
 See [`tutorials/README.md`](/tutorials/) for how to run the `.py`
 companions from the CLI and how to author a new tutorial.
-
-## Observability dashboard
-
-Training Gym ships a dashboard that aggregates training runs, deployments,
-and eval results in one place. Deploy your own copy:
-
-```bash
-training-gym setup
-```
-
-Or equivalently:
-
-```bash
-modal deploy dashboards/app.py
-```
-
-Modal prints a URL where you can watch jobs in progress.
-
-![Gym Observability Dashboard](https://raw.githubusercontent.com/modal-projects/training-gym/joy/fix-table-formatting-and-validate-repo-skills/assets/observability_dashboard.png)
 
 ## Multi-node access
 
@@ -95,7 +92,7 @@ for larger models — are still in Beta.
 
 
 ## Architecture
-![Architecture diagram](https://raw.githubusercontent.com/modal-projects/training-gym/joy/fix-table-formatting-and-validate-repo-skills/assets/training_gym_architecture_restyled.svg)
+![Architecture diagram](https://raw.githubusercontent.com/modal-projects/training-gym/joy/add-cli-to-website/assets/training_gym_architecture_restyled.svg)
 
 ## Documentation
 
@@ -113,7 +110,7 @@ Modal platform references:
 
 ## License
 
-[MIT](https://github.com/modal-projects/training-gym/blob/joy/fix-table-formatting-and-validate-repo-skills/LICENSE).
+[MIT](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/LICENSE).
 
 ---
 

--- a/docs-next/src/content/docs/reference/core/datasetconfig.md
+++ b/docs-next/src/content/docs/reference/core/datasetconfig.md
@@ -28,6 +28,10 @@ Load raw examples for local inspection or evaluation.
 
 Materialize training data to `path` (and eval splits to `eval_paths`).
 
+### `validate_prepared(self, path: 'str') -> 'None'`
+
+Sniff what `prepare()` wrote and confirm the columns the framework will index.
+
 ## Related Tutorials
 
 - [Multi-turn number-guessing RL with custom generate and reward functions](/tutorials/rl/002_multiturn/)

--- a/docs-next/src/content/docs/reference/core/harbordataset.md
+++ b/docs-next/src/content/docs/reference/core/harbordataset.md
@@ -49,6 +49,10 @@ Materialize training data to `path` (and eval splits to `eval_paths`).
 
 ### `to_pandas(self, *, formatted: 'bool' = False)`
 
+### `validate_prepared(self, path: 'str') -> 'None'`
+
+Sniff what `prepare()` wrote and confirm the columns the framework will index.
+
 ## Related Tutorials
 
 - [Code RL with Harbor hello-world and sandboxed verification](/tutorials/rl/001_sandboxes/)

--- a/docs-next/src/content/docs/reference/core/huggingfacedataset.md
+++ b/docs-next/src/content/docs/reference/core/huggingfacedataset.md
@@ -17,7 +17,7 @@ Dataset backed by a HuggingFace `datasets` repo.
 |-------|------|---------|-------------|
 | `dataset_id` | `str` | `""` |  |
 | `input_key` | `str` | `""` |  |
-| `label_key` | `str` | `""` |  |
+| `label_key` | `str` | `"label"` |  |
 | `apply_chat_template` | `bool` | `True` |  |
 | `hf_repo` | `str` | `""` |  |
 | `hf_split` | `str` | `"train"` |  |
@@ -40,5 +40,9 @@ Load raw examples for local inspection or evaluation.
 Materialize training data to `path` (and eval splits to `eval_paths`).
 
 ### `to_pandas(self, *, formatted: 'bool' = False)`
+
+### `validate_prepared(self, path: 'str') -> 'None'`
+
+Sniff what `prepare()` wrote and confirm the columns the framework will index.
 
 **Source:** [`modal_training_gym/common/dataset.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/common/dataset.py)

--- a/docs-next/src/content/docs/reference/deployment/modeldeployment.md
+++ b/docs-next/src/content/docs/reference/deployment/modeldeployment.md
@@ -27,6 +27,7 @@ ModelDeployment(**data)
 | `modal_app_id` | `str` |  |  |
 | `modal_app_url` | `str` |  |  |
 | `url` | `str` |  |  |
+| `status` | `str` |  |  |
 
 ## Methods
 

--- a/docs-next/src/content/docs/tutorials/index.md
+++ b/docs-next/src/content/docs/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorials
 description: Runnable Modal training examples across intro, RL, SFT, and infrastructure-focused walkthroughs.
-editUrl: https://github.com/modal-projects/training-gym/edit/joy/fix-table-formatting-and-validate-repo-skills/tutorials/README.md
+editUrl: https://github.com/modal-projects/training-gym/edit/joy/add-cli-to-website/tutorials/README.md
 ---
 
 The catalog of available tutorials — with difficulty, framework, cluster
@@ -19,7 +19,7 @@ content stripped of narration.
 ## Authoring a new tutorial
 
 Tutorials are generated from a Python source file under
-[`tutorial_generator/`](https://github.com/modal-projects/training-gym/tree/joy/fix-table-formatting-and-validate-repo-skills/tutorials/tutorial_generator). The generator AST-walks each
+[`tutorial_generator/`](https://github.com/modal-projects/training-gym/tree/joy/add-cli-to-website/tutorials/tutorial_generator). The generator AST-walks each
 source and emits `tutorials/<bucket>/<name>/<name>.py` + `tutorials/<bucket>/<name>/<name>.ipynb`.
 **Edit the source, not the generated files** — the pre-commit hook
 (`.pre-commit-config.yaml`) regenerates on commit, so hand-edits to the
@@ -74,5 +74,5 @@ are maps, the `.ipynb` is the walkthrough. Aim for roughly:
   cell-by-cell interactive invocation (`@notebook_only`).
 - Optional: a "Serve / evaluate / next step" tail, where relevant.
 
-[`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/joy/fix-table-formatting-and-validate-repo-skills/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) is the current
+[`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) is the current
 reference example for tutorial narration depth.

--- a/docs-next/src/content/docs/tutorials/rl/001_sandboxes.md
+++ b/docs-next/src/content/docs/tutorials/rl/001_sandboxes.md
@@ -21,8 +21,6 @@ Reward = fraction of test cases whose output matches expected.
 import json
 import re
 
-import modal
-
 from modal_training_gym import (
     DeploymentConfig,
     EvalConfig,


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
