### PR TITLE
Add hf-secret detection for local modal runs

### DIFF
--- a/modal_training_gym/common/__init__.py
+++ b/modal_training_gym/common/__init__.py
@@ -6,6 +6,10 @@ framework's launcher merges ``COMMON_TRAINING_GYM_TAGS`` with its own
 its ``modal.App``.
 """
 
+from __future__ import annotations
+
+import os
+
 from modal_training_gym.utils.gpu import GPUType
 from modal_training_gym.utils.metadata import (
     METADATA_VOLUME_NAME,
@@ -21,11 +25,39 @@ COMMON_TRAINING_GYM_TAGS: dict[str, str] = {
     "_modal_job_type": "training",
 }
 
+
+def hf_secrets() -> list:
+    """Return a list of Modal Secrets providing ``HF_TOKEN`` to containers.
+
+    Priority:
+      1. Local ``HF_TOKEN`` env var → ``Secret.from_dict`` (also silences
+         the local-side ``huggingface_hub`` "unauthenticated" warning).
+      2. Named Modal secret ``huggingface-secret`` → used if it exists in
+         the workspace.
+      3. Empty list → container runs without an HF token.
+    """
+    from modal import Secret
+
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get(
+        "HUGGING_FACE_HUB_TOKEN"
+    )
+    if hf_token:
+        return [Secret.from_dict({"HF_TOKEN": hf_token})]
+
+    try:
+        secret = Secret.from_name("huggingface-secret")
+        secret.hydrate()
+        return [secret]
+    except Exception:
+        return []
+
+
 __all__ = [
     "COMMON_TRAINING_GYM_TAGS",
     "GPUType",
     "METADATA_VOLUME_NAME",
     "MetadataStore",
+    "hf_secrets",
     "vol_get",
     "vol_list",
     "vol_put",

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -182,7 +182,7 @@ def convert_checkpoint_to_hf(
     recipe: VllmRecipe | SglangRecipe,
 ) -> Checkpoint:
     import modal
-    from modal import App, Secret, Volume
+    from modal import App, Volume
 
     checkpoints_volume_name = checkpoint.checkpoints_volume_name
     if not checkpoints_volume_name:
@@ -202,6 +202,7 @@ def convert_checkpoint_to_hf(
         checkpoints_volume_name,
         create_if_missing=True,
     )
+    from modal_training_gym.common import hf_secrets
     from modal_training_gym.frameworks.slime.launcher import _build_slime_base_image
 
     image = _build_slime_base_image().add_local_python_source(
@@ -218,7 +219,7 @@ def convert_checkpoint_to_hf(
             checkpoints_mount_path: checkpoints_volume,
         },
         timeout=4 * 60 * 60,
-        secrets=[Secret.from_name("huggingface-secret")],
+        secrets=hf_secrets(),
         serialized=True,
         name="convert_megatron_to_hf",
     )

--- a/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
@@ -31,7 +31,9 @@ def build_sglang_serve_app(
     deployment_id: str | None = None,
 ) -> "App":
     import modal
-    from modal import App, Image, Secret, Volume
+    from modal import App, Image, Volume
+
+    from modal_training_gym.common import hf_secrets
 
     sglang_port = 8000
 
@@ -88,7 +90,7 @@ def build_sglang_serve_app(
         scaledown_window=10 * 60,
         timeout=24 * 60 * 60,
         volumes=volumes,
-        secrets=[Secret.from_name("huggingface-secret")],
+        secrets=hf_secrets(),
         serialized=True,
         include_source=False,
     )

--- a/modal_training_gym/deploy_recipes/vllm_recipe/serve_vllm.py
+++ b/modal_training_gym/deploy_recipes/vllm_recipe/serve_vllm.py
@@ -39,7 +39,9 @@ def build_vllm_serve_app(
     deployment_id: str | None = None,
 ) -> "App":
     import modal
-    from modal import App, Image, Secret, Volume
+    from modal import App, Image, Volume
+
+    from modal_training_gym.common import hf_secrets
 
     gpu = recipe.gpu or "H100"
     n_gpu = recipe.n_gpu or 1
@@ -88,7 +90,7 @@ def build_vllm_serve_app(
         scaledown_window=10 * 60,
         timeout=24 * 60 * 60,
         volumes=volumes,
-        secrets=[Secret.from_name("huggingface-secret")],
+        secrets=hf_secrets(),
         serialized=True,
         include_source=False,
     )

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -28,6 +28,8 @@ from pathlib import PurePosixPath
 from typing import Any
 from collections.abc import Callable
 from modal import App, Image, Secret, Volume
+
+from modal_training_gym.common import hf_secrets
 from modal.experimental import clustered
 
 import cloudpickle
@@ -295,7 +297,7 @@ def build_slime_app(
             checkpoints_mount_path: checkpoints_volume,
         },
         timeout=2 * 60 * 60,
-        secrets=[Secret.from_name("huggingface-secret")],
+        secrets=hf_secrets(),
         serialized=True,
         name="download",
     )
@@ -310,7 +312,7 @@ def build_slime_app(
         image=image,
         volumes={str(DATA_PATH): data_volume},
         timeout=2 * 60 * 60,
-        secrets=[Secret.from_name("huggingface-secret")],
+        secrets=hf_secrets(),
         serialized=True,
         name="prepare_dataset",
     )
@@ -410,7 +412,7 @@ def build_slime_app(
             checkpoints_mount_path: checkpoints_volume,
         },
         timeout=4 * 60 * 60,
-        secrets=[Secret.from_name("huggingface-secret")],
+        secrets=hf_secrets(),
         serialized=True,
         name="convert_to_hf",
     )


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
