### PR TITLE
Add typing extensions and tell users to use it with Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Pick a base model, a dataset, and an RL framework (GRPO, PPO, custom reward / ge
 
 ## Quickstart
 
+> [!NOTE]
+> **Python 3.12 is required.** Modal's `serialized=True` functions use
+> cloudpickle, which requires the local Python version to exactly match the
+> remote container's. All framework images ship Python 3.12, so running from
+> 3.11 or 3.13 will fail at app build time.
+
 Install with pip:
 
 ```bash

--- a/docs-next/src/content/docs/reference/models/qwen3_8b.md
+++ b/docs-next/src/content/docs/reference/models/qwen3_8b.md
@@ -25,4 +25,8 @@ Qwen3-8B (8 billion parameters) from Alibaba.
 
 Download or materialize weights into the model volume.
 
+## Related Tutorials
+
+- [On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student](/tutorials/rl/003_on_policy_distillation/)
+
 **Source:** [`modal_training_gym/common/models/qwen3_8b.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/common/models/qwen3_8b.py)

--- a/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
@@ -45,6 +45,8 @@ def build_sglang_serve_app(
             " /sgl-workspace/sglang/python/sglang/srt/entrypoints/http_server.py",
             "rm -rf /root/.cache/huggingface",
         )
+        # pydantic_core in the nightly image needs typing_extensions>=4.13 (Sentinel)
+        .uv_pip_install("typing_extensions>=4.13")
         .env(
             {
                 "HF_HUB_CACHE": "/root/.cache/huggingface",


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
