### PR TITLE
:tada: Add OPD as doc example

### DIFF
--- a/docs-next/src/content/docs/index.md
+++ b/docs-next/src/content/docs/index.md
@@ -1,7 +1,7 @@
 ---
 title: Training Gym SDK
 description: Reusable building blocks and runnable examples for RL post-training on Modal.
-editUrl: https://github.com/modal-projects/training-gym/edit/joy/add-cli-to-website/README.md
+editUrl: https://github.com/modal-projects/training-gym/edit/main/README.md
 ---
 
 **[📖 Documentation](https://gym.modal.dev)** · **[Tutorials](https://gym.modal.dev/tutorials/)** · **[API Reference](https://gym.modal.dev/reference/)**
@@ -10,6 +10,14 @@ Modal Training Gym is a Python SDK for **RL post-training** on [Modal](https://m
 Pick a base model, a dataset, and an RL framework (GRPO, PPO, custom reward / generate functions); the gym handles cluster topology, Ray/NCCL bring-up, volume mounts, checkpointing, and serving for eval and rollouts. SFT and plain distributed training are supported too — but RL is the happy path.
 
 ## Quickstart
+
+:::note[Note]
+**Python 3.12 is required.** Modal's `serialized=True` functions use
+cloudpickle, which requires the local Python version to exactly match the
+remote container's. All framework images ship Python 3.12, so running from
+3.11 or 3.13 will fail at app build time.
+:::
+
 
 Install with pip:
 
@@ -46,12 +54,12 @@ training-gym setup
 
 Modal prints a URL where you can watch jobs in progress.
 
-![Gym Observability Dashboard](https://raw.githubusercontent.com/modal-projects/training-gym/joy/add-cli-to-website/assets/observability_dashboard.png)
+![Gym Observability Dashboard](https://raw.githubusercontent.com/modal-projects/training-gym/main/assets/observability_dashboard.png)
 
 
 ## Tutorials
 
-The fastest path through the API is the [tutorials](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials). Each one
+The fastest path through the API is the [tutorials](https://github.com/modal-projects/training-gym/blob/main/tutorials). Each one
 ships as a runnable `.py` **and** a paired `.ipynb` narrated cell-by-cell —
 the notebook is the canonical walkthrough. Each tutorial below has a one-click
 **Launch** button that opens the `.ipynb` in a fresh Modal Notebook; the first
@@ -74,9 +82,10 @@ rest of the cells run as-is.
 
 | Tutorial | Summary | Difficulty | Framework | Launch |
 |---|---|---|---|---|
-| [`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) | Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare | Beginner | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/000_rl_basics/000_rl_basics.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
-| [`001_sandboxes`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/001_sandboxes/001_sandboxes.ipynb) | Code RL with Harbor hello-world and sandboxed verification | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/001_sandboxes/001_sandboxes.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
-| [`002_multiturn`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/002_multiturn/002_multiturn.ipynb) | Multi-turn number-guessing RL with custom generate and reward functions | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/002_multiturn/002_multiturn.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
+| [`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) | Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare | Beginner | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/alessio/add-opd-rl-tutorial/tutorials/rl/000_rl_basics/000_rl_basics.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
+| [`001_sandboxes`](https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/001_sandboxes/001_sandboxes.ipynb) | Code RL with Harbor hello-world and sandboxed verification | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/alessio/add-opd-rl-tutorial/tutorials/rl/001_sandboxes/001_sandboxes.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
+| [`002_multiturn`](https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/002_multiturn/002_multiturn.ipynb) | Multi-turn number-guessing RL with custom generate and reward functions | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/alessio/add-opd-rl-tutorial/tutorials/rl/002_multiturn/002_multiturn.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
+| [`003_on_policy_distillation`](https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.ipynb) | On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student | Intermediate | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/alessio/add-opd-rl-tutorial/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
 <!-- END TUTORIAL TABLE -->
 
 See [`tutorials/README.md`](/tutorials/) for how to run the `.py`
@@ -92,7 +101,7 @@ for larger models — are still in Beta.
 
 
 ## Architecture
-![Architecture diagram](https://raw.githubusercontent.com/modal-projects/training-gym/joy/add-cli-to-website/assets/training_gym_architecture_restyled.svg)
+![Architecture diagram](https://raw.githubusercontent.com/modal-projects/training-gym/main/assets/training_gym_architecture_restyled.svg)
 
 ## Documentation
 
@@ -110,7 +119,7 @@ Modal platform references:
 
 ## License
 
-[MIT](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/LICENSE).
+[MIT](https://github.com/modal-projects/training-gym/blob/main/LICENSE).
 
 ---
 

--- a/docs-next/src/content/docs/reference/core/datasetconfig.md
+++ b/docs-next/src/content/docs/reference/core/datasetconfig.md
@@ -17,6 +17,7 @@ Dataset configuration shared across training frameworks.
 | `input_key` | `str` | `""` |  |
 | `label_key` | `str` | `""` |  |
 | `apply_chat_template` | `bool` | `True` |  |
+| `always_prepare` | `bool` | `False` |  |
 
 ## Methods
 

--- a/docs-next/src/content/docs/reference/core/harbordataset.md
+++ b/docs-next/src/content/docs/reference/core/harbordataset.md
@@ -19,6 +19,7 @@ Dataset configuration shared across training frameworks.
 | `input_key` | `str` | `""` |  |
 | `label_key` | `str` | `""` |  |
 | `apply_chat_template` | `bool` | `True` |  |
+| `always_prepare` | `bool` | `False` |  |
 | `dataset_name` | `str` | `""` |  |
 | `path` | `str \| None` | `None` |  |
 | `task_root` | `str` | `""` |  |

--- a/docs-next/src/content/docs/reference/core/huggingfacedataset.md
+++ b/docs-next/src/content/docs/reference/core/huggingfacedataset.md
@@ -19,6 +19,7 @@ Dataset backed by a HuggingFace `datasets` repo.
 | `input_key` | `str` | `""` |  |
 | `label_key` | `str` | `"label"` |  |
 | `apply_chat_template` | `bool` | `True` |  |
+| `always_prepare` | `bool` | `False` |  |
 | `hf_repo` | `str` | `""` |  |
 | `hf_split` | `str` | `"train"` |  |
 | `hf_config` | `str \| None` | `None` |  |

--- a/docs-next/src/content/docs/reference/deployment/deploymentconfig.md
+++ b/docs-next/src/content/docs/reference/deployment/deploymentconfig.md
@@ -30,5 +30,6 @@ Build, deploy, and return a `ModelDeployment` handle.
 - [Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare](/tutorials/rl/000_rl_basics/)
 - [Code RL with Harbor hello-world and sandboxed verification](/tutorials/rl/001_sandboxes/)
 - [Multi-turn number-guessing RL with custom generate and reward functions](/tutorials/rl/002_multiturn/)
+- [On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student](/tutorials/rl/003_on_policy_distillation/)
 
 **Source:** [`modal_training_gym/common/deployment.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/common/deployment.py)

--- a/docs-next/src/content/docs/reference/evaluation/evalconfig.md
+++ b/docs-next/src/content/docs/reference/evaluation/evalconfig.md
@@ -35,5 +35,6 @@ Evaluate a deployed model on a dataset config.
 - [Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare](/tutorials/rl/000_rl_basics/)
 - [Code RL with Harbor hello-world and sandboxed verification](/tutorials/rl/001_sandboxes/)
 - [Multi-turn number-guessing RL with custom generate and reward functions](/tutorials/rl/002_multiturn/)
+- [On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student](/tutorials/rl/003_on_policy_distillation/)
 
 **Source:** [`modal_training_gym/common/eval.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/common/eval.py)

--- a/docs-next/src/content/docs/reference/evaluation/evalrowresult.md
+++ b/docs-next/src/content/docs/reference/evaluation/evalrowresult.md
@@ -31,5 +31,6 @@ EvalRowResult(**data)
 - [Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare](/tutorials/rl/000_rl_basics/)
 - [Code RL with Harbor hello-world and sandboxed verification](/tutorials/rl/001_sandboxes/)
 - [Multi-turn number-guessing RL with custom generate and reward functions](/tutorials/rl/002_multiturn/)
+- [On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student](/tutorials/rl/003_on_policy_distillation/)
 
 **Source:** [`modal_training_gym/common/eval.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/common/eval.py)

--- a/docs-next/src/content/docs/reference/models/qwen3_4b.md
+++ b/docs-next/src/content/docs/reference/models/qwen3_4b.md
@@ -30,5 +30,6 @@ Download or materialize weights into the model volume.
 - [Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare](/tutorials/rl/000_rl_basics/)
 - [Code RL with Harbor hello-world and sandboxed verification](/tutorials/rl/001_sandboxes/)
 - [Multi-turn number-guessing RL with custom generate and reward functions](/tutorials/rl/002_multiturn/)
+- [On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student](/tutorials/rl/003_on_policy_distillation/)
 
 **Source:** [`modal_training_gym/common/models/qwen3_4b.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/common/models/qwen3_4b.py)

--- a/docs-next/src/content/docs/reference/training/slimerecipe.md
+++ b/docs-next/src/content/docs/reference/training/slimerecipe.md
@@ -75,9 +75,10 @@ Recipe dataclass for configuring slime GRPO training on Modal.
 | `megatron_to_hf_mode` | `str` | `"bridge"` |  |
 | `use_fault_tolerance` | `bool` | `True` |  |
 | `rm_type` | `str \| None` | `None` |  |
-| `custom_rm_path` | `str` | `""` |  |
 | `custom_rm_function` | `collections.abc.Callable \| None` | `None` |  |
 | `custom_generate_function` | `collections.abc.Callable \| None` | `None` |  |
+| `rollout_function` | `collections.abc.Callable \| str \| None` | `None` |  |
+| `custom_megatron_before_train_step_hook` | `collections.abc.Callable \| str \| None` | `None` |  |
 | `extra_config` | `dict \| None` | `None` |  |
 | `sglang_config` | `dict \| None` | `None` |  |
 | `apply_chat_template_kwargs` | `str` | `""` |  |
@@ -93,5 +94,6 @@ Recipe dataclass for configuring slime GRPO training on Modal.
 - [Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare](/tutorials/rl/000_rl_basics/)
 - [Code RL with Harbor hello-world and sandboxed verification](/tutorials/rl/001_sandboxes/)
 - [Multi-turn number-guessing RL with custom generate and reward functions](/tutorials/rl/002_multiturn/)
+- [On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student](/tutorials/rl/003_on_policy_distillation/)
 
 **Source:** [`modal_training_gym/train_recipes/slime_recipe/recipe.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/train_recipes/slime_recipe/recipe.py)

--- a/docs-next/src/content/docs/reference/training/trainconfig.md
+++ b/docs-next/src/content/docs/reference/training/trainconfig.md
@@ -29,5 +29,6 @@ Build the app, run training, and return the TrainResult.
 - [Qwen3-4B haiku evaluation with verifiable rewards — serve, evaluate, train, compare](/tutorials/rl/000_rl_basics/)
 - [Code RL with Harbor hello-world and sandboxed verification](/tutorials/rl/001_sandboxes/)
 - [Multi-turn number-guessing RL with custom generate and reward functions](/tutorials/rl/002_multiturn/)
+- [On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student](/tutorials/rl/003_on_policy_distillation/)
 
 **Source:** [`modal_training_gym/common/train.py`](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/common/train.py)

--- a/docs-next/src/content/docs/tutorials/index.md
+++ b/docs-next/src/content/docs/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 title: Tutorials
 description: Runnable Modal training examples across intro, RL, SFT, and infrastructure-focused walkthroughs.
-editUrl: https://github.com/modal-projects/training-gym/edit/joy/add-cli-to-website/tutorials/README.md
+editUrl: https://github.com/modal-projects/training-gym/edit/main/tutorials/README.md
 ---
 
 The catalog of available tutorials — with difficulty, framework, cluster
@@ -19,7 +19,7 @@ content stripped of narration.
 ## Authoring a new tutorial
 
 Tutorials are generated from a Python source file under
-[`tutorial_generator/`](https://github.com/modal-projects/training-gym/tree/joy/add-cli-to-website/tutorials/tutorial_generator). The generator AST-walks each
+[`tutorial_generator/`](https://github.com/modal-projects/training-gym/tree/main/tutorials/tutorial_generator). The generator AST-walks each
 source and emits `tutorials/<bucket>/<name>/<name>.py` + `tutorials/<bucket>/<name>/<name>.ipynb`.
 **Edit the source, not the generated files** — the pre-commit hook
 (`.pre-commit-config.yaml`) regenerates on commit, so hand-edits to the
@@ -74,5 +74,5 @@ are maps, the `.ipynb` is the walkthrough. Aim for roughly:
   cell-by-cell interactive invocation (`@notebook_only`).
 - Optional: a "Serve / evaluate / next step" tail, where relevant.
 
-[`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/joy/add-cli-to-website/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) is the current
+[`000_rl_basics`](https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/000_rl_basics/000_rl_basics.ipynb) is the current
 reference example for tutorial narration depth.

--- a/docs-next/src/content/docs/tutorials/rl/001_sandboxes.md
+++ b/docs-next/src/content/docs/tutorials/rl/001_sandboxes.md
@@ -40,23 +40,31 @@ from modal_training_gym import (
 [Harbor Hub](https://hub.harborframework.com). Each task has:
 - `instruction.md` — the problem statement (prompt)
 - `task.toml` — metadata (difficulty, category)
-- `tests/` — input/output test pairs for verification
+- `tests/` — verification tests (format varies by task)
 
-Setting `test_data_dir="tests"` reads `*.in`/`*.out` file pairs and
-embeds them in each sample's label so the reward function can verify
-solutions without filesystem access.
+The hello-world task uses pytest-based verification rather than
+`*.in`/`*.out` file pairs, so we define stdin/stdout test cases
+inline and pass them directly to the sandbox scorer.
 
 A single dataset instance handles both training and eval —
 `prepare()` writes train and eval splits to the volume,
 while `load()` returns all tasks for offline evaluation.
 
 ```python
+HELLO_WORLD_TESTS = [{"input": "", "expected_output": "Hello, world!\n"}]
+
 dataset = HarborDataset(
     dataset_name="harbor/hello-world",
     label_metadata_path="task.toml",
-    test_data_dir="tests",
     train_repeats=20,
     always_prepare=True, # For the purpose of this tutorial, we want to prepare the dataset every time we run it, in case there is stale data from a previous run.
+    system_prompt=(
+        "You are an expert Python programmer. "
+        "Solve the given problem by writing a complete Python program. "
+        "Your program must print the answer to stdout using print(). "
+        "Do not create or write any files. "
+        "Put your solution in a ```python code fence."
+    ),
 )
 ```
 
@@ -141,16 +149,9 @@ def score_usaco_with_sandbox(
 
 async def usaco_rm(args, sample, **kwargs) -> float:
     import asyncio
-    import json
-
-    raw = getattr(sample, "label", None)
-    label = json.loads(raw) if isinstance(raw, str) else (raw or {})
-    test_cases = label.get("test_cases", [])
-    if not test_cases:
-        return 0.0
 
     reward, meta = await asyncio.to_thread(
-        score_usaco_with_sandbox, sample.response, test_cases=test_cases,
+        score_usaco_with_sandbox, sample.response, test_cases=HELLO_WORLD_TESTS,
     )
     sample.metadata = {**(getattr(sample, "metadata", None) or {}), "usaco": meta}
     return float(reward)
@@ -163,15 +164,22 @@ base_model = Qwen3_4B()
 base_deployment: ModelDeployment = DeploymentConfig(model=base_model).serve()
 print(f"Base model URL: {base_deployment.url}")
 
-def eval_response_fn(example: dict, response: str) -> EvalRowResult:
-    test_cases = example.get("label", {}).get("test_cases", [])
-    score, metadata = score_usaco_with_sandbox(response, test_cases=test_cases)
+def eval_fn(deployment: ModelDeployment, example: dict) -> EvalRowResult:
+    prompt = example.get("instruction", "")
+    response = deployment.generate(
+        prompt,
+        ensure_ready=False,
+        messages=[
+            {"role": "system", "content": dataset.system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+    )
+    score, metadata = score_usaco_with_sandbox(response, test_cases=HELLO_WORLD_TESTS)
     return EvalRowResult(score=score, response=response, metadata=metadata)
 
 eval_config = EvalConfig(
     dataset=dataset,
-    eval_response_fn=eval_response_fn,
-    generate_kwargs={"chat_template_kwargs": {"enable_thinking": False}},
+    eval_fn=eval_fn,
 )
 print("Running base eval...")
 base_eval = eval_config.evaluate(base_deployment, debug=True)
@@ -204,7 +212,6 @@ training_run = TrainConfig(
         n_samples_per_eval_prompt=8,
         max_tokens_per_gpu=4096,
         save_interval=10,
-        apply_chat_template_kwargs='{"enable_thinking": false}',
         image_overlay=lambda image: image.run_commands(
             "uv pip install --system modal>=1.2.0",
         ),

--- a/docs-next/src/content/docs/tutorials/rl/003_on_policy_distillation.md
+++ b/docs-next/src/content/docs/tutorials/rl/003_on_policy_distillation.md
@@ -1,0 +1,346 @@
+---
+title: "On-policy distillation: Teacher model trains a student model"
+description: "On-policy distillation on math — Qwen3-8B teacher, Qwen3-4B student"
+---
+
+In this tutorial, we take two models, Qwen3-8B and Qwen3-4B, and use 
+the larger 8B model to teach the smaller 4B model on its generation logprobs.
+
+Using the Slime framework and Modal Training Gym, we can easily self-host the
+teacher model on a H100 machine, hit the /generate endpoint with "return_logprob=True",
+and penalize the student model's logprobs per token in input sequence using reverse KL divergence.
+
+The tutorial follows these steps:
+
+1. **Deploy the teacher** (Qwen3-8B) on an SGLang server with `DeploymentConfig`.
+2. **Load a math dataset** (`dapo-math-17k`) and define a verifiable eval that checks `Answer: \boxed{N}`.
+3. **Evaluate the base student** (Qwen3-4B) to get a baseline accuracy.
+4. **Define a reward function** that calls the teacher's `/generate` endpoint with `return_logprob=True` and combines the teacher log-probs with a math correctness score.
+5. **Train with GRPO + OPD** using `SlimeRecipe` — slime applies a per-token reverse KL penalty from the teacher log-probs on top of the GRPO advantage.
+6. **Evaluate the trained student** and compare accuracy before vs after.
+
+### How OPD works
+
+During each rollout step:
+1. The student generates a response (math reasoning).
+2. The student's token IDs are sent to the teacher's SGLang server.
+3. The teacher returns per-token log-probabilities.
+4. Slime modifies the advantage at each token:
+
+$$A_t = A_t^{\text{GRPO}} - \lambda_{\text{opd}} \cdot (\log \pi_{\text{student}} - \log \pi_{\text{teacher}})$$
+
+The first term pushes toward correct math answers (sparse reward).
+The second term pushes toward the teacher's token-level distribution
+(dense signal at every position). Together they teach the student
+*what* to say (correct answer) and *how* to say it (teacher-like
+reasoning).
+
+### Dataset
+
+We use [`zhuzilin/dapo-math-17k`](https://huggingface.co/datasets/zhuzilin/dapo-math-17k),
+the same math dataset used by slime's own OPD examples. Each row is a math
+problem with a ground-truth integer answer. The model is prompted to
+respond with `Answer: \boxed{N}` — evaluation just checks whether the
+number matches.
+
+```python
+import re
+
+from modal_training_gym import (
+    DeploymentConfig,
+    EvalConfig,
+    EvalRowResult,
+    HuggingFaceDataset,
+    ModelDeployment,
+    Qwen3_4B,
+    Qwen3_8B,
+    SlimeRecipe,
+    TrainConfig,
+    list_checkpoints,
+)
+from modal_training_gym.deploy_recipes.sglang_recipe import SglangRecipe
+```
+
+## Deploy the teacher model
+
+We borrow a recipe from Modal's Training Gym repo to deploy our teacher model on an SGLang server.
+
+```python
+teacher_model = Qwen3_8B()
+teacher_deployment = DeploymentConfig(
+    model=teacher_model,
+    recipe=SglangRecipe(gpu="H100"),
+    app_name="opd-teacher-qwen3-8b",
+    served_model_name="qwen3-8b-teacher",
+).serve()
+print(f"Teacher URL: {teacher_deployment.url}")
+
+TEACHER_GENERATE_URL = f"{teacher_deployment.url}/generate"
+```
+
+## Dataset
+
+We use a simple math dataset containing competition problems that the LLM is tasked
+with answering via a `Answer: \boxed{N}` response. This simple format allows
+for deterministic evaluation!
+
+[Here's the link to `zhuzilin/dapo-math-17k`](https://huggingface.co/datasets/zhuzilin/dapo-math-17k)
+
+Each row contains a `prompt` field with the original chat message and a `label` containing an integer answer.
+
+[Thinking Machines](https://thinkingmachines.ai/blog/on-policy-distillation/) demonstrates that 
+using a small number of samples with a larger number of rollouts can be sufficient for OPD.
+For this tutorial, we take 100 training samples and hold out 20 for evaluation.
+
+```python
+class MathDataset(HuggingFaceDataset):
+    hf_repo = "zhuzilin/dapo-math-17k"
+    input_column = "prompt"
+    output_column = "label"
+    output_format = "jsonl"
+    apply_chat_template = False
+
+train_dataset = MathDataset(n_rows=100)
+eval_dataset = MathDataset(n_rows=20)
+```
+
+```python
+def _normalize_answer(answer: str) -> str:
+    answer = str(answer).strip()
+    answer = answer.split("=")[-1]
+    for old, new in [("$", ""), ("\\$", ""), (",", ""), (" ", ""),
+                      ("\\text{", ""), ("}", ""), ("\\boxed{", "")]:
+        answer = answer.replace(old, new)
+    return answer.strip()
+
+def _extract_answer(response: str) -> str:
+    match = re.findall(r"(?i)Answer\s*:\s*([^\n]+)", response)
+    return match[-1].strip() if match else "[INVALID]"
+
+def _check_math(response: str, label: str) -> bool:
+    pred = _normalize_answer(_extract_answer(response))
+    gt = _normalize_answer(label)
+    try:
+        gt = str(int(float(gt)))
+    except (ValueError, OverflowError):
+        pass
+    return pred == gt
+
+def math_eval_fn(deployment: ModelDeployment, example: dict) -> EvalRowResult:
+    prompt = example.get("prompt", "")
+    if isinstance(prompt, list):
+        prompt = prompt[0]["content"] if prompt else ""
+    label = example.get("label", "")
+
+    response = deployment.generate(
+        prompt,
+        ensure_ready=False,
+        chat_template_kwargs={"enable_thinking": True},
+    )
+
+    correct = _check_math(response, label)
+    pred = _normalize_answer(_extract_answer(response))
+
+    return EvalRowResult(
+        score=1.0 if correct else 0.0,
+        response=response,
+        metadata={"correct": correct, "pred": pred, "label": label},
+    )
+```
+
+## Baseline Eval
+
+Let's run the math eval on our base serving model. Thankfully, our dataset requires
+simple-enough answers that a tiny, 4B model should not cause issues for our deterministic parser.
+In our own experience, requiring a strict JSON output format can cause evaluation issues!
+See [this LoRA adapter for making Qwen3-4B successful at structured output](https://huggingface.co/uchkw/qwen3-4b-structured-output-lora).
+
+```python
+base_model = Qwen3_4B()
+base_deployment = DeploymentConfig(model=base_model).serve()
+print(f"Student URL: {base_deployment.url}")
+
+eval_config = EvalConfig(dataset=eval_dataset, eval_fn=math_eval_fn)
+print("--- Evaluating base student... ---")
+base_eval = eval_config.evaluate(base_deployment, debug=True)
+n_correct = sum(1 for r in base_eval.rows if r.metadata.get("correct"))
+print(f"Base accuracy: {n_correct}/{len(base_eval.rows)} "
+      f"({base_eval.mean:.1%})")
+```
+
+## Reward function
+
+OPD uses "reverse" KL divergence to grade the student model's output. Remember,
+KL divergence D_kl(P || Q) is Sigma_x P(x) * log(P(x) / Q(x)), where P is the behavior distribution
+and Q is the target distribution. Forward KL treats the teacher model as P and the student model as Q.
+However, the log(P(x) / Q(x)) term would then be weighted by the teacher model's probability distribution P,
+making the result being high surprisal on modes unfamiliar to the student model.
+
+Instead, we want to use the reverse KL divergence D_kl(Student || Teacher), where our student model
+is treated as the behavior distribution and the teacher model is our target distribution. When the teacher has high surprisal on a 
+student mode, the term log(P(x)) - log(Q(x)) will yield a high positive KL divergence to penalize the student model. 
+Now, the student model only gets penalized on modes relevant to itself.
+
+```python
+async def math_opd_rm(args, sample, **kwargs):
+    """Collect teacher log-probs AND compute math correctness reward.
+
+    The teacher log-prob collection is handled by slime's built-in OPD
+    reward function. We call it, then add our scalar math reward.
+    """
+    from slime.rollout.on_policy_distillation import reward_func as _opd_reward
+
+    teacher_response = await _opd_reward(args, sample, **kwargs)
+
+    label = getattr(sample, "label", "") or ""
+    correct = _check_math(sample.response, label)
+    sample.math_correct = correct
+
+    return teacher_response
+
+def math_opd_post_process(args, samples, **kwargs):
+    """Post-process: store teacher log-probs and return math rewards.
+
+    Delegates to slime's built-in post_process_rewards for the teacher
+    log-prob alignment, then overrides the scalar rewards with math
+    correctness scores.
+    """
+    from slime.rollout.on_policy_distillation import post_process_rewards as _opd_post
+
+    _, _ = _opd_post(args, samples, **kwargs)
+
+    math_rewards = []
+    for sample in samples:
+        correct = getattr(sample, "math_correct", False)
+        math_rewards.append(1.0 if correct else -1.0)
+
+    return math_rewards, math_rewards
+```
+
+## Training
+
+The training recipe uses 1 H100 GPU per actor and rollout engine. The actor engine
+runs the training and the rollout engine runs the model for inference/forward passes.
+You may want to tune the batch size for fitting the memory requirements of your GPU
+and increase the samples per prompt parameter for generating more variants per group.
+The total_rollouts_per_step is the rollout_batch_size * n_samples_per_prompt, and
+the total # of rollouts that occur over a training run is the total_rollouts_per_step * num_rollout.
+
+```python
+training_run = TrainConfig(
+    model=base_model,
+    dataset=train_dataset,
+    recipe=SlimeRecipe(
+        custom_rm_function=math_opd_rm,
+
+        gpu_type="H100",
+        colocate=True,
+        actor_num_gpus_per_node=1,
+        rollout_num_gpus=1,
+        tensor_model_parallel_size=1,
+        sequence_parallel=False,
+        rollout_num_gpus_per_engine=1,
+
+        num_rollout=10,
+        rollout_batch_size=16,
+        n_samples_per_prompt=4,
+        rollout_max_response_len=2048,
+        rollout_temperature=1.0,
+
+        global_batch_size=16,
+        lr=1e-6,
+        save_interval=5,
+        apply_chat_template_kwargs='{"enable_thinking": true}',
+
+        environment={
+            "PYTHONPATH": "/root/Megatron-LM/:/root",
+            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+            "NCCL_NVLS_ENABLE": "1",
+        },
+
+        extra_config={
+            "use_opd": True,
+            "opd_type": "sglang",
+            "opd_kl_coef": 1.0,
+            "custom_reward_post_process_path": (
+                "003_on_policy_distillation.math_opd_post_process"
+            ),
+            "rm_url": TEACHER_GENERATE_URL,
+        },
+    ),
+)
+
+print("--- Starting OPD training... ---")
+print(f"  Teacher: {teacher_deployment.url}")
+print(f"  Student: Qwen3-4B")
+print(f"  Dataset: dapo-math-17k (100 problems)")
+train_result = training_run.train()
+print(f"Training run id: {train_result.training_run_id}")
+print("--- Training complete ---")
+```
+
+## Evaluate the trained student
+
+Let's run the evaluation on our trained model and compare it
+to the baseline evaluation from earlier.
+
+```python
+checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+print(f"Checkpoint: {checkpoint.path}")
+
+trained_deployment = DeploymentConfig(
+    model=Qwen3_4B(),
+    checkpoint=checkpoint,
+    app_name="qwen3-4b-opd-trained-serve",
+    served_model_name="qwen3-4b-opd",
+).serve()
+print(f"Trained student URL: {trained_deployment.url}")
+
+print("--- Evaluating trained student... ---")
+trained_eval = eval_config.evaluate(trained_deployment, debug=True)
+n_correct = sum(1 for r in trained_eval.rows if r.metadata.get("correct"))
+print(f"Trained accuracy: {n_correct}/{len(trained_eval.rows)} "
+      f"({trained_eval.mean:.1%})")
+```
+
+## Results
+
+Let's hope you see a positive delta on your eval performance!
+
+```python
+base_correct = sum(1 for r in base_eval.rows if r.metadata.get("correct"))
+trained_correct = sum(1 for r in trained_eval.rows if r.metadata.get("correct"))
+total = len(base_eval.rows)
+print(f"Base student:    {base_correct}/{total} ({base_eval.mean:.1%})")
+print(f"Trained student: {trained_correct}/{total} ({trained_eval.mean:.1%})")
+print(f"Delta:           {trained_eval.mean - base_eval.mean:+.1%}")
+```
+
+## Next steps
+
+Some cool ways to extend and improve this example:
+1. Use a bigger teacher: Qwen3 offers models in the 32B parameter range. 
+This model will fit on a 4xH100 GPU setup and can show measurable improvements
+on the student model evaluation delta.
+2. Tweak the composite reward signal: Try applying a coefficient like *2* to the
+binary integer reward signal used in the custom reward function to value correct answers
+over student-teacher alignment.
+3. Try cross-family distillation: Use a teacher from a different model family (e.g. Kimi K2)
+to train our Qwen3-4B student model. You may run into cross-tokenizer differences, so
+be careful to only grade logprobs on tokens that exist in both models' vocabularies and
+align 1:1 on a per-character basis.
+
+---
+
+## Related API Reference
+
+- [`Qwen3_4B`](/reference/models/qwen3_4b/)
+- [`Qwen3_8B`](/reference/models/qwen3_8b/)
+- [`DeploymentConfig`](/reference/deployment/deploymentconfig/)
+- [`EvalConfig`](/reference/evaluation/evalconfig/)
+- [`EvalRowResult`](/reference/evaluation/evalrowresult/)
+- [`SlimeRecipe`](/reference/training/slimerecipe/)
+- [`TrainConfig`](/reference/training/trainconfig/)
+
+**Source:** [`tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.py`](https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.py)
+ | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.ipynb" target="_blank" rel="noopener noreferrer">Open in Modal Notebook</a>


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
