### PR TITLE
Pin SGLang image to stable v0.5.12-cu130 release

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -301,9 +301,7 @@ def fastapi_app():
     @web.get("/api/evals/{eval_id}")
     async def eval_detail(eval_id: str):
         try:
-            data = await run_in_threadpool(
-                vol_get, MetadataStore.EVAL_RESULTS, eval_id
-            )
+            data = await run_in_threadpool(vol_get, MetadataStore.EVAL_RESULTS, eval_id)
             return JSONResponse(data)
         except KeyError:
             raise HTTPException(

--- a/modal_training_gym/deploy_recipes/sglang_recipe/recipe.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/recipe.py
@@ -48,7 +48,7 @@ class SglangRecipe(BaseDeployRecipe):
     mem_fraction_static: float | None = None
     chunked_prefill_size: int | None = None
     max_running_requests: int | None = None
-    sglang_image: str = "lmsysorg/sglang:nightly-dev-cu13-20260508-2cf1a4ab"
+    sglang_image: str = "lmsysorg/sglang:v0.5.12-cu130"
     extra_server_args: dict[str, str] | None = None
     environment_name: str | None = None
     deploy_strategy: str = "rolling"


### PR DESCRIPTION
The previous nightly image (`nightly-dev-cu13-20260508-2cf1a4ab`) was deleted from Docker Hub, causing image build failures. Pin to stable release `v0.5.12-cu130` which is immutable and published May 16, 2026.

Also fixes a pre-existing ruff formatting issue in _dashboard.py.