### PR TITLE
Bump SGLang Image Version

### DIFF
--- a/modal_training_gym/deploy_recipes/sglang_recipe/recipe.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/recipe.py
@@ -48,7 +48,7 @@ class SglangRecipe(BaseDeployRecipe):
     mem_fraction_static: float | None = None
     chunked_prefill_size: int | None = None
     max_running_requests: int | None = None
-    sglang_image: str = "lmsysorg/sglang:v0.5.12-cu130"
+    sglang_image: str = "lmsysorg/sglang:v0.5.12"
     extra_server_args: dict[str, str] | None = None
     environment_name: str | None = None
     deploy_strategy: str = "rolling"


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Fixes error with image build using old slang image `v0.5.12-cu130`.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
