### PR TITLE
Auto-resume Slime training from checkpoint on preemption retry

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -592,11 +592,19 @@ def build_slime_app(
             os.makedirs(save_root, exist_ok=True)
 
             original_save = slime.save
+            original_load = slime.load
             object.__setattr__(slime, "save", save_root)
+            if _has_torch_dist_checkpoint(save_root):
+                print(
+                    f"Detected existing checkpoint in {save_root}; "
+                    "will resume training from last saved iteration."
+                )
+                object.__setattr__(slime, "load", save_root)
             try:
                 cmd = build_train_cmd(slime, SLIME_ROOT, model=model, dataset=dataset)
             finally:
                 object.__setattr__(slime, "save", original_save)
+                object.__setattr__(slime, "load", original_load)
             runtime_env = {
                 "env_vars": {
                     "no_proxy": f"127.0.0.1,{cluster.head_addr}",

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -137,6 +137,7 @@ class SlimeRecipe(BaseTrainRecipe):
 
     # ── Checkpointing (optional) ───────────────────────────────────────────
     save: str = "/checkpoints"
+    load: str = ""
     megatron_to_hf_mode: str = "bridge"
     use_fault_tolerance: bool = True
 


### PR DESCRIPTION
When a training run is preempted and auto-retried by Modal, the save directory (keyed by `training_run_id` in the closure) already contains checkpoints from the previous attempt. Previously these were ignored because no `--load` flag was passed to Slime/Megatron, so training restarted from scratch.

Now the `train()` function checks the save directory for an existing torch_dist checkpoint (via the existing `_has_torch_dist_checkpoint` helper) and, if found, sets `--load` to that directory so Megatron resumes from the last saved iteration.

### Changes

- **`SlimeRecipe`**: Add `load: str = ""` field in the checkpointing section. Defaults to empty string, which is filtered out by `cli_args()` so it has no effect unless explicitly set.
- **`launcher.py` `train()`**: After computing `save_root`, check if it already contains a checkpoint. If so, temporarily set `slime.load = save_root` before building the training command, which results in `--load <save_root>` being passed to Slime.

### How it works

1. On first run: `save_root` is empty → no `--load` → training starts fresh
2. On preemption retry: `save_root` has checkpoints from previous attempt → `_has_torch_dist_checkpoint(save_root)` returns `True` → `--load <save_root>` is passed → Megatron reads `latest_checkpointed_iteration.txt` and resumes

## Checklist

- [x] N/A — this is an internal infrastructure change, not a tutorial/example


Link to Devin session: https://modal.devinenterprise.com/sessions/13542ed69d1b468a8bf2785b4cdbc520
Requested by: @joyliu-q