### PR TITLE
Add PyPI publish workflow and package metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run tests
         run: uv run pytest tests/ -v
+
+      - name: Verify package builds
+        run: uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,14 @@
 name = "modal-training-gym"
 version = "0.1.0"
 description = "Reusable building blocks for Modal multi-node training examples"
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [{name = "Modal Labs"}]
 requires-python = ">=3.12"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+]
 dependencies = [
     "modal",
     "cloudpickle",
@@ -22,6 +29,10 @@ packages = ["modal_training_gym"]
 
 [project.scripts]
 training-gym = "modal_training_gym.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/modal-projects/training-gym"
+Documentation = "https://gym.modal.dev"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Adds CI to publish `modal-training-gym` to PyPI when a GitHub release is created, and fills in the project metadata needed for a proper PyPI listing.

### Changes

**`pyproject.toml`** — added `readme`, `license`, `authors`, `classifiers`, and `project.urls` so PyPI renders a complete project page.

**`.github/workflows/publish.yml`** — new workflow triggered on `release: published`. Builds with `uv build` and publishes via [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC `id-token: write`, no API token secrets needed).

**`.github/workflows/test.yml`** — added a `uv build` step so packaging issues are caught on every PR.

### One-time setup required

Before the first release, configure trusted publishing on pypi.org → project settings → "Add a new publisher":
- Owner: `modal-projects`, Repo: `training-gym`, Workflow: `publish.yml`, Environment: *(leave blank)*

Then create a GitHub release (e.g. `v0.1.0`) to trigger the publish.

## Checklist

N/A — this PR adds CI infrastructure, not an example.

Link to Devin session: https://modal.devinenterprise.com/sessions/a937f9ac49024a7cb28d60ed0d6fa516
Requested by: @joyliu-q