### PR TITLE
patch compute_advantages_and_returns for custom generate functions

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -74,13 +74,17 @@ _PATCH_VALIDATION_B64 = encode_patch("patch_validation")
 _PATCH_TORCH_LOAD_B64 = encode_patch("patch_torch_load")
 _PATCH_GLOBAL_PLAN_B64 = encode_patch("patch_global_plan")
 _PATCH_CHECKPOINT_SAVE_B64 = encode_patch("patch_checkpoint_save")
+_PATCH_ADVANTAGES_B64 = encode_patch("patch_advantages")
 
 
 def _build_slime_base_image() -> "Image":
     return (
         Image.from_registry(SLIME_IMAGE)
         .entrypoint([])
-        .run_commands("rm -rf /root/.cache/huggingface")
+        .run_commands(
+            "rm -rf /root/.cache/huggingface",
+            f"echo {_PATCH_ADVANTAGES_B64} | base64 -d | python3",
+        )
     )
 
 

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_advantages.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_advantages.py
@@ -1,0 +1,36 @@
+"""Patch compute_advantages_and_returns to handle missing tensor references.
+
+When a custom generate function is used with kl_coef=0 and no critic,
+the ``can_reuse_log_probs_in_loss`` optimisation in ``train_actor``
+skips computing log_probs before advantage calculation.  Standard
+rollouts still provide ``rollout_log_probs`` as a fallback, but custom
+generate functions do not collect them.  This leaves all three tensor
+references (log_probs, rollout_log_probs, values) as None, crashing the
+``[torch.zeros_like(x, ...) for x in xs]`` list comprehension with
+``TypeError: 'NoneType' object is not iterable``.
+
+This patch makes the None-xs path fall back to creating zero-KL tensors
+from ``loss_masks`` shapes.
+
+Executed at image-build time via ``python3 <this file>``.
+"""
+
+import pathlib
+
+p = pathlib.Path("/root/slime/slime/backends/megatron_utils/loss.py")
+src = p.read_text()
+
+old = """\
+        xs = log_probs or rollout_log_probs or values
+        kl = [torch.zeros_like(x, dtype=torch.float32, device=x.device) for x in xs]"""
+
+new = """\
+        xs = log_probs or rollout_log_probs or values
+        if xs is not None:
+            kl = [torch.zeros_like(x, dtype=torch.float32, device=x.device) for x in xs]
+        else:
+            _dev = loss_masks[0].device if loss_masks else torch.cuda.current_device()
+            kl = [torch.zeros(rl, dtype=torch.float32, device=_dev) for rl in response_lengths]"""
+
+if old in src:
+    p.write_text(src.replace(old, new, 1))


### PR DESCRIPTION
The Slime image bump to `nightly-dev-20260526a` (PR #68) introduced a `can_reuse_log_probs_in_loss` optimisation in `train_actor` that skips computing `log_probs` before `compute_advantages_and_returns` when `kl_coef=0`, no critic, and a single microbatch step.

With standard rollouts, `rollout_log_probs` are collected during generation and available as a fallback tensor reference. But **custom generate functions** (like `number_guess_generate` in tutorial 002) don't collect `rollout_log_probs`, leaving all three tensor references (`log_probs`, `rollout_log_probs`, `values`) as `None`. This causes:

```
TypeError: 'NoneType' object is not iterable
```

at `kl = [torch.zeros_like(x, ...) for x in xs]` in `compute_advantages_and_returns`.

### Fix

Adds `patch_advantages.py` — applied unconditionally in `_build_slime_base_image()` — that makes the None-xs path fall back to creating zero-KL tensors from `loss_masks` shape/device:

```python
if xs is not None:
    kl = [torch.zeros_like(x, ...) for x in xs]
else:
    _dev = loss_masks[0].device if loss_masks else torch.cuda.current_device()
    kl = [torch.zeros(rl, ..., device=_dev) for rl in response_lengths]
```

This is safe because when `xs` is `None`, we're always in the `kl_coef == 0` branch where KL is zero anyway — GRPO only uses `kl` as a template for tensor shape/device.
