### PR TITLE
Add `modal >= 1.4.0` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Reusable building blocks for Modal multi-node training examples"
 requires-python = ">=3.12"
 dependencies = [
-    "modal",
+    "modal>=1.4.0",
     "cloudpickle",
     "datasets",
     "msgspec",


### PR DESCRIPTION
This package needs `modal>=1.4.0` as it uses `app.deploy` with strategy (which is not supported in versions below 1.4). 

The uv lock uses 1.4.1, so it won't need to change.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
