### PR TITLE
Fix submit_and_tail killing jobs when Ray log stream disconnects early.

### DIFF
--- a/modal_training_gym/common/ray_cluster.py
+++ b/modal_training_gym/common/ray_cluster.py
@@ -250,6 +250,7 @@ class ModalRayCluster:
         entrypoint: str,
         *,
         runtime_env: dict | None = None,
+        max_retries: int = 10,
     ) -> str:
         """Submit a Ray job, stream its logs to stdout, and return the final status."""
         if not self.is_head:
@@ -262,6 +263,7 @@ class ModalRayCluster:
         print(f"Submitted Ray job: {job_id}")
 
         _TERMINAL = {"SUCCEEDED", "FAILED", "STOPPED"}
+        retry_count = 0
 
         while True:
             log_stream = self._client.tail_job_logs(job_id)
@@ -277,9 +279,15 @@ class ModalRayCluster:
             status = self._client.get_job_status(job_id).value
             if status in _TERMINAL:
                 break
+            retry_count += 1
+            if retry_count >= max_retries:
+                raise RuntimeError(
+                    f"Ray job {job_id} log stream disconnected {max_retries} times "
+                    f"without reaching terminal status (current: {status})"
+                )
             print(
                 f"\n[ray] Log stream ended but job {job_id} is still {status}; "
-                "reconnecting in 5s..."
+                f"reconnecting in 5s... (retry {retry_count}/{max_retries})"
             )
             await asyncio.sleep(5)
 

--- a/modal_training_gym/common/ray_cluster.py
+++ b/modal_training_gym/common/ray_cluster.py
@@ -250,7 +250,7 @@ class ModalRayCluster:
         entrypoint: str,
         *,
         runtime_env: dict | None = None,
-        max_retries: int = 10,
+        max_retries: int = 35,
     ) -> str:
         """Submit a Ray job, stream its logs to stdout, and return the final status."""
         if not self.is_head:
@@ -265,7 +265,7 @@ class ModalRayCluster:
         _TERMINAL = {"SUCCEEDED", "FAILED", "STOPPED"}
         retry_count = 0
 
-        while True:
+        while retry_count < max_retries:
             log_stream = self._client.tail_job_logs(job_id)
             if inspect.isawaitable(log_stream):
                 log_stream = await log_stream
@@ -280,16 +280,16 @@ class ModalRayCluster:
             if status in _TERMINAL:
                 break
             retry_count += 1
-            if retry_count >= max_retries:
-                raise RuntimeError(
-                    f"Ray job {job_id} log stream disconnected {max_retries} times "
-                    f"without reaching terminal status (current: {status})"
-                )
             print(
                 f"\n[ray] Log stream ended but job {job_id} is still {status}; "
                 f"reconnecting in 5s... (retry {retry_count}/{max_retries})"
             )
             await asyncio.sleep(5)
+        else:
+            raise RuntimeError(
+                f"Ray job {job_id} log stream disconnected {max_retries} times "
+                f"without reaching terminal status (current: {status})"
+            )
 
         print(f"\nFinal Ray job status: {status}")
         if status != "SUCCEEDED":

--- a/modal_training_gym/common/ray_cluster.py
+++ b/modal_training_gym/common/ray_cluster.py
@@ -282,9 +282,9 @@ class ModalRayCluster:
             retry_count += 1
             print(
                 f"\n[ray] Log stream ended but job {job_id} is still {status}; "
-                f"reconnecting in 5s... (retry {retry_count}/{max_retries})"
+                f"reconnecting in 2s... (retry {retry_count}/{max_retries})"
             )
-            await asyncio.sleep(5)
+            await asyncio.sleep(2)
         else:
             raise RuntimeError(
                 f"Ray job {job_id} log stream disconnected {max_retries} times "

--- a/modal_training_gym/common/ray_cluster.py
+++ b/modal_training_gym/common/ray_cluster.py
@@ -260,18 +260,31 @@ class ModalRayCluster:
             runtime_env=runtime_env or {},
         )
         print(f"Submitted Ray job: {job_id}")
-        log_stream = self._client.tail_job_logs(job_id)
-        if inspect.isawaitable(log_stream):
-            log_stream = await log_stream
-        if hasattr(log_stream, "__aiter__"):
-            async for line in log_stream:
-                print(line, end="", flush=True)
-        else:
-            for line in log_stream:
-                print(line, end="", flush=True)
-        status = self._client.get_job_status(job_id).value
+
+        _TERMINAL = {"SUCCEEDED", "FAILED", "STOPPED"}
+
+        while True:
+            log_stream = self._client.tail_job_logs(job_id)
+            if inspect.isawaitable(log_stream):
+                log_stream = await log_stream
+            if hasattr(log_stream, "__aiter__"):
+                async for line in log_stream:
+                    print(line, end="", flush=True)
+            else:
+                for line in log_stream:
+                    print(line, end="", flush=True)
+
+            status = self._client.get_job_status(job_id).value
+            if status in _TERMINAL:
+                break
+            print(
+                f"\n[ray] Log stream ended but job {job_id} is still {status}; "
+                "reconnecting in 5s..."
+            )
+            await asyncio.sleep(5)
+
         print(f"\nFinal Ray job status: {status}")
-        if status not in ("SUCCEEDED",):
+        if status != "SUCCEEDED":
             raise RuntimeError(f"Ray job {job_id} finished with status: {status}")
         return status
 


### PR DESCRIPTION
Ray's tail_job_logs() can silently drop the gRPC/WebSocket stream while the job is still RUNNING (ray-project/ray#57002, #60665). The old code immediately checked job status after the stream ended and raised if it wasn't SUCCEEDED — killing a healthy training run.

Now submit_and_tail polls until the job reaches a terminal state (SUCCEEDED/FAILED/STOPPED) and reconnects the log stream on each iteration, so transient disconnects no longer abort training.

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
