### PR TITLE
Refactor slime launcher similar to multinode-training-guide

### DIFF
--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -43,8 +43,6 @@ def list_checkpoints(training_run_id: str) -> list[Checkpoint]:
     result = TrainResult.from_training_run_id(training_run_id)
     if result.framework in {Framework.SLIME, Framework.SLIME.value}:
         return _list_checkpoints_for_slime(result)
-    if result.framework in {Framework.MILES, Framework.MILES.value}:
-        return _list_checkpoints_for_slime(result)
     raise ValueError(f"Unsupported framework: {result.framework}")
 
 

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -43,6 +43,8 @@ def list_checkpoints(training_run_id: str) -> list[Checkpoint]:
     result = TrainResult.from_training_run_id(training_run_id)
     if result.framework in {Framework.SLIME, Framework.SLIME.value}:
         return _list_checkpoints_for_slime(result)
+    if result.framework in {Framework.MILES, Framework.MILES.value}:
+        return _list_checkpoints_for_slime(result)
     raise ValueError(f"Unsupported framework: {result.framework}")
 
 

--- a/modal_training_gym/common/models/README.md
+++ b/modal_training_gym/common/models/README.md
@@ -1,6 +1,6 @@
 # Models
 
-Built-in `ModelConfig` presets shipped with Training Gym (Qwen3 family, etc.).
+Built-in `ModelConfig` presets shipped with Training Gym (Qwen3 family, Kimi, etc.).
 Each preset declares its HuggingFace repo, tokenizer config, and framework-
 specific training presets (e.g. `SlimePreset`) with tuned parallelism and GPU
 defaults that framework configs apply during `__post_init__`.

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -57,6 +57,7 @@ from .modal_helpers.utils import (
     get_checkpoint_conversion_policy,
     get_modal_cluster_context,
     prepare_slime_config,
+    resolve_checkpoint_ref,
 )
 from .modal_helpers.patches import encode_patch
 from modal_training_gym.common.checkpoint import (
@@ -66,11 +67,12 @@ from modal_training_gym.common.checkpoint import (
 from modal_training_gym.common.framework import Framework
 
 SLIME_ROOT = "/root/slime"
-# Pin by digest to prevent mutable-tag drift.  Tag: nightly-dev-20260526a
-SLIME_IMAGE = "slimerl/slime@sha256:2568a8283b913eeea86b68397288f9ebdb59ebad4eab11c64ee3ce0c49819c3a"
+# Pin by digest to prevent mutable-tag drift.  Tag: nightly-dev-20260529a
+SLIME_IMAGE = "slimerl/slime@sha256:087a57732cf4fb271729df47530b01a9530144f4339247efc422f03e2b6988e1"
 HARBOR_PKG_VERSION = "0.6.6"
 
 _PATCH_VALIDATION_B64 = encode_patch("patch_validation")
+_PATCH_MEGATRON_BRIDGE_B64 = encode_patch("patch_megatron_bridge")
 _PATCH_TORCH_LOAD_B64 = encode_patch("patch_torch_load")
 _PATCH_GLOBAL_PLAN_B64 = encode_patch("patch_global_plan")
 _PATCH_CHECKPOINT_SAVE_B64 = encode_patch("patch_checkpoint_save")
@@ -83,6 +85,7 @@ def _build_slime_base_image() -> "Image":
         .entrypoint([])
         .run_commands(
             "rm -rf /root/.cache/huggingface",
+            f"echo {_PATCH_MEGATRON_BRIDGE_B64} | base64 -d | python3",
             f"echo {_PATCH_ADVANTAGES_B64} | base64 -d | python3",
         )
     )
@@ -167,6 +170,13 @@ def build_slime_app(
         image = slime.image_overlay(image)
         object.__setattr__(slime, "image_overlay", None)
 
+    for patch in slime.patch_files:
+        image = image.add_local_file(
+            patch,
+            remote_path=f"/tmp/{os.path.basename(patch)}",
+            copy=True,
+        )
+
     if isinstance(dataset, HarborDataset):
         image = image.uv_pip_install(f"harbor=={HARBOR_PKG_VERSION}")
 
@@ -177,6 +187,11 @@ def build_slime_app(
             copy=True,
             ignore=["**/__pycache__", "**/*.pyc", "**/.git", "**/.venv"],
         )
+
+    if slime.image_run_commands:
+        image = image.run_commands(*slime.image_run_commands)
+    if slime.image_env:
+        image = image.env(slime.image_env)
 
     image = image.add_local_python_source("modal_training_gym", copy=True)
     image = mount_tools_dir(image)
@@ -416,7 +431,9 @@ def build_slime_app(
         hf_cache_volume.reload()
         checkpoints_volume.reload()
 
-        if model.model_path:
+        if slime.megatron_conversion_hf_checkpoint:
+            hf_path = resolve_checkpoint_ref(slime.megatron_conversion_hf_checkpoint)
+        elif model.model_path:
             hf_path = str(model.model_path)
         else:
             hf_path = snapshot_download(model.model_name, local_files_only=True)
@@ -460,8 +477,12 @@ def build_slime_app(
                 )
         else:
             convert_script = f"{SLIME_ROOT}/tools/convert_hf_to_torch_dist.py"
-        if mmt:
-            model_script = f"{SLIME_ROOT}/scripts/models/{mmt}.sh"
+        if mmt or slime.slime_model_script:
+            model_script = (
+                f"{SLIME_ROOT}/{slime.slime_model_script}"
+                if slime.slime_model_script
+                else f"{SLIME_ROOT}/scripts/models/{mmt}.sh"
+            )
             if needs_preconv:
                 # Strip parallelism flags from MODEL_ARGS so the only
                 # source of TP/PP/EP is our extra_args.  The bridge
@@ -569,19 +590,36 @@ def build_slime_app(
 
     _multi_node = slime.total_nodes > 1
 
+    train_secrets: list[Secret] = []
+    if slime.wandb is not None:
+        train_secrets.append(Secret.from_name(slime.wandb.modal_wandb_secret_name))
+    train_experimental_options: dict[str, Any] = {}
+    if _multi_node:
+        train_experimental_options["efa_enabled"] = True
+
+    train_function_kwargs = dict(slime.train_function_kwargs or {})
+    user_secrets = train_function_kwargs.pop("secrets", None)
+    if user_secrets is not None:
+        if not isinstance(user_secrets, (list, tuple)):
+            user_secrets = [user_secrets]
+        train_secrets.extend(user_secrets)
+    user_experimental_options = train_function_kwargs.pop("experimental_options", None)
+    if user_experimental_options is not None:
+        train_experimental_options.update(user_experimental_options)
+    if train_function_kwargs:
+        unsupported = ", ".join(sorted(train_function_kwargs))
+        raise TypeError(f"Unsupported slime.train_function_kwargs keys: {unsupported}")
+
     @app.function(
         image=train_image,
         gpu=gpu_spec,
+        memory=slime.memory,
+        cloud=slime.cloud,
+        region=slime.region,
         volumes=all_volumes,
-        secrets=[
-            *(
-                []
-                if slime.wandb is None
-                else [Secret.from_name(slime.wandb.modal_wandb_secret_name)]
-            ),
-        ],
+        secrets=train_secrets or None,
         timeout=24 * 60 * 60,
-        experimental_options={"efa_enabled": True} if _multi_node else {},
+        experimental_options=train_experimental_options or None,
         serialized=True,
         name="train",
     )

--- a/modal_training_gym/frameworks/slime/modal_helpers/utils.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/utils.py
@@ -2,6 +2,7 @@
 
 import os
 import shlex
+from os import PathLike
 
 # (attr_name_on_slime_cfg, cli_flag) — optional per-rank conversion args
 _CONVERSION_EXTRA_ARGS = [
@@ -10,6 +11,26 @@ _CONVERSION_EXTRA_ARGS = [
     ("mtp_num_layers", "mtp-num-layers"),
     ("make_vocab_size_divisible_by", "make-vocab-size-divisible-by"),
 ]
+
+
+def is_local_checkpoint_ref(ref: str | PathLike) -> bool:
+    """Return True when a checkpoint ref is already a mounted local path."""
+    return str(ref).startswith("/")
+
+
+def resolve_checkpoint_ref(
+    ref: str | PathLike,
+    *,
+    local_files_only: bool = True,
+) -> str:
+    """Resolve an absolute path or Hugging Face repo ID to a local path."""
+    ref_str = str(ref)
+    if is_local_checkpoint_ref(ref_str):
+        return ref_str
+
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(ref_str, local_files_only=local_files_only)
 
 
 def get_checkpoint_conversion_policy(
@@ -171,7 +192,6 @@ def get_modal_cluster_context(n_nodes: int) -> tuple[int, str, str, int]:
 
 def prepare_slime_config(slime_cfg, model, tmpdir: str) -> None:
     """Resolve HF repo IDs to local paths and materialize inline YAML configs."""
-    from huggingface_hub import snapshot_download
     import yaml
 
     from modal_training_gym.train_recipes.slime_recipe.recipe import YAML_CONFIG_FIELDS
@@ -182,13 +202,11 @@ def prepare_slime_config(slime_cfg, model, tmpdir: str) -> None:
         and model.model_name
         and not str(model.model_name).startswith("/")
     ):
-        model.model_path = snapshot_download(model.model_name, local_files_only=True)
+        model.model_path = resolve_checkpoint_ref(model.model_name)
 
-    for attr in ("ref_load", "critic_load"):
+    for attr in ("load", "ref_load", "critic_load"):
         if (val := getattr(slime_cfg, attr, None)) and not str(val).startswith("/"):
-            object.__setattr__(
-                slime_cfg, attr, snapshot_download(val, local_files_only=True)
-            )
+            object.__setattr__(slime_cfg, attr, resolve_checkpoint_ref(val))
 
     for field in YAML_CONFIG_FIELDS:
         if isinstance(val := getattr(slime_cfg, field, None), dict):
@@ -200,8 +218,15 @@ def prepare_slime_config(slime_cfg, model, tmpdir: str) -> None:
 
 
 def build_train_cmd(slime_cfg, slime_root: str, model=None, dataset=None) -> str:
-    """Build the Ray job entrypoint."""
+    """Build the Ray job entrypoint, sourcing model arch args if needed."""
     train_script = (
         f"{slime_root}/{'train_async.py' if slime_cfg.async_mode else 'train.py'}"
     )
-    return f"python3 {train_script} {shlex.join(slime_cfg.cli_args(dataset=dataset, model=model))}"
+    args = shlex.join(slime_cfg.cli_args(dataset=dataset, model=model))
+    if getattr(slime_cfg, "slime_model_script", ""):
+        inner = (
+            f"source {slime_root}/{slime_cfg.slime_model_script} && "
+            f"python3 {train_script} ${{MODEL_ARGS[@]}} {args}"
+        )
+        return f"bash -c {shlex.quote(inner)}"
+    return f"python3 {train_script} {args}"

--- a/modal_training_gym/train_recipes/slime_recipe/blocks.py
+++ b/modal_training_gym/train_recipes/slime_recipe/blocks.py
@@ -31,7 +31,7 @@ class MultiTurn:
         if self.max_turns is not None and self.max_turns < 1:
             raise ValueError("max_turns must be >= 1")
 
-        custom_config = dict(recipe.custom_config_path or {})
+        custom_config = dict(recipe.extra_config or {})
         if self.max_turns is not None:
             custom_config["max_turns"] = int(self.max_turns)
         if self.log_multi_turn is not None:
@@ -40,7 +40,7 @@ class MultiTurn:
 
         overrides: dict[str, Any] = {
             "custom_generate_function": self.generate_function,
-            "custom_config_path": custom_config,
+            "extra_config": custom_config,
         }
         if self.reward_function is not None:
             overrides["custom_rm_function"] = self.reward_function

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -1,3 +1,4 @@
+import json
 import math
 import os
 from collections.abc import Callable
@@ -35,15 +36,26 @@ _SLIME_SKIP = {
     "app_tags",
     "image_overlay",
     "local_slime",
+    "memory",
+    "cloud",
+    "region",
     "checkpoint",
     "custom_rm_function",
     "custom_generate_function",
     "rollout_function",
     "custom_megatron_before_train_step_hook",
     "sglang_request_params",
+    "slime_model_script",
+    "source_hf_checkpoint",
+    "megatron_conversion_hf_checkpoint",
+    "patch_files",
+    "image_run_commands",
+    "image_env",
+    "train_function_kwargs",
 }
 
 YAML_CONFIG_FIELDS = ("eval_config", "extra_config", "sglang_config")
+JSON_CONFIG_FIELDS = ("train_env_vars", "apply_chat_template_kwargs", "multimodal_keys")
 
 
 @dataclass(config=ConfigDict(extra="forbid", arbitrary_types_allowed=True))
@@ -83,6 +95,16 @@ class SlimeRecipe(BaseTrainRecipe):
     wandb: WandbConfig | None = None
     image_overlay: Callable[[modal.Image], modal.Image] | None = None
     local_slime: str | None = None
+    memory: int | tuple[int, int] | None = None
+    cloud: str | None = None
+    region: str | None = None
+    slime_model_script: str = ""
+    source_hf_checkpoint: str | None = None
+    megatron_conversion_hf_checkpoint: str | None = None
+    patch_files: list[str] = field(default_factory=list)
+    image_run_commands: list[str] = field(default_factory=list)
+    image_env: dict[str, str] = field(default_factory=dict)
+    train_function_kwargs: dict[str, Any] = field(default_factory=dict)
 
     # ── Cluster and parallelism (optional) ─────────────────────────────────
     actor_num_nodes: int = 1
@@ -165,7 +187,9 @@ class SlimeRecipe(BaseTrainRecipe):
     extra_config: dict | None = None
     sglang_config: dict | None = None
     sglang_request_params: dict | None = None
-    apply_chat_template_kwargs: str = ""
+    apply_chat_template_kwargs: dict | str = ""
+    train_env_vars: dict | str | None = None
+    multimodal_keys: dict | str | None = None
 
     # ── Validators ───────────────────────────────────────────────────────────
 
@@ -387,6 +411,8 @@ class SlimeRecipe(BaseTrainRecipe):
             flag = f"--{key.replace('_', '-')}"
             if val is True:
                 out.append(flag)
+            elif isinstance(val, dict) and key in JSON_CONFIG_FIELDS:
+                out += [flag, json.dumps(val)]
             elif isinstance(val, list):
                 out += [flag] + [str(v) for v in val]
             else:

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ requires-dist = [
     { name = "cloudpickle" },
     { name = "datasets" },
     { name = "fastapi" },
-    { name = "modal" },
+    { name = "modal", specifier = ">=1.4.0" },
     { name = "msgspec" },
     { name = "openai" },
     { name = "pydantic" },


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
