### PR TITLE
Add small aesthetic changes to top bar

### DIFF
--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -714,36 +714,41 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    padding: 8px 24px 12px;
+    min-height: 53px;
+    padding: 0 1rem;
   }
 
   .top-brand {
     display: inline-flex;
     align-items: center;
-    gap: 0.62rem;
+    gap: 0.55rem;
+    flex: 0 0 auto;
     min-width: 0;
   }
 
   .top-brand-logo {
-    width: 1.7rem;
-    height: 1.7rem;
+    height: 17.5px;
+    width: auto;
     flex: 0 0 auto;
   }
 
   .top-brand-title {
     display: inline-flex;
     align-items: center;
-    gap: 0.38rem;
-    font-size: 1.85rem;
+    gap: 0.18rem;
+    font-family: var(--font-display);
+    font-feature-settings: "ss01" on;
+    font-size: 17.6px;
     line-height: 1;
     padding-block: 0.08rem;
-    font-weight: 700;
-    letter-spacing: -0.025em;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    transform: translateY(1px);
     white-space: nowrap;
   }
 
   .top-brand-modal {
-    color: var(--text-bright);
+    color: #ddffdc;
   }
 
   .top-brand-gym {
@@ -783,16 +788,8 @@
 
   @media (max-width: 900px) {
     .top-navbar {
-      padding: 14px 0.95rem;
-    }
-
-    .top-brand-logo {
-      width: 1.35rem;
-      height: 1.35rem;
-    }
-
-    .top-brand-title {
-      font-size: 1.35rem;
+      min-height: 53px;
+      padding: 0 1rem;
     }
 
     .shell {
@@ -801,6 +798,12 @@
 
     .workspace {
       padding: 24px;
+    }
+  }
+
+  @media (max-width: 520px) {
+    .docs-button {
+      display: none;
     }
   }
 </style>

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -19,6 +19,13 @@
   font-style: italic;
 }
 
+@font-face {
+  font-family: "Goga";
+  src: url("https://modal-cdn.com/fonts/Goga-VariableVF.woff2") format("woff2");
+  font-weight: 100 900;
+  font-style: normal;
+}
+
 :root {
   --color-ground: #181818;
   --color-dark-gray: #212525;
@@ -213,6 +220,9 @@
   --font-sans:
     "Inter Variable", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
     "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-display:
+    "Goga", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-mono:
     "Fira Mono", ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas,
     monospace;
@@ -234,4 +244,14 @@ body {
   text-rendering: optimizeLegibility;
   color-scheme: dark;
   font-feature-settings: "cv11" on;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-display);
+  font-feature-settings: "ss01" on;
 }

--- a/docs-next/src/components/Header.astro
+++ b/docs-next/src/components/Header.astro
@@ -19,11 +19,11 @@ const isActive = (href: string) =>
 
 <div class="tg-header">
   <div class="tg-header__left">
-    <a href="/" class="title-wrapper sl-flex" style="text-decoration: none; align-items: center; gap: 0.6rem;">
-      <img src="/modal-logo.svg" alt="Modal" style="height: 1.25rem; width: auto;" />
-      <span class="site-title">Training Gym</span>
+    <a href="/" class="title-wrapper sl-flex" style="text-decoration: none; align-items: center; gap: 0.55rem;">
+      <img src="/modal-logo.svg" alt="Modal" style="height: 17.5px; width: auto;" />
+      <span class="site-title"><span class="site-title__modal">Modal</span><span class="site-title__gym">Training Gym</span></span>
     </a>
-    <nav class="tg-header__nav sl-hidden lg:sl-flex" aria-label="Primary">
+    <nav class="tg-header__nav" aria-label="Primary">
       {navItems.map((item) => (
         <a
           href={item.href}
@@ -36,12 +36,29 @@ const isActive = (href: string) =>
   </div>
   <div class="tg-header__right print:hidden">
     {shouldRenderSearch && (
-      <div class="tg-header__search sl-hidden md:sl-flex">
+      <div class="tg-header__search">
         <Search class="tg-header__search" />
       </div>
     )}
     <a class="tg-header__repo" href="https://github.com/modal-projects/training-gym">
       GitHub
     </a>
+    <details class="tg-header__menu">
+      <summary aria-label="Open navigation">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <nav class="tg-header__menu-panel" aria-label="Primary">
+        {navItems.map((item) => (
+          <a
+            href={item.href}
+            class:list={['tg-header__menu-link', { 'is-active': isActive(item.href) }]}
+          >
+            {item.label}
+          </a>
+        ))}
+      </nav>
+    </details>
   </div>
 </div>

--- a/docs-next/src/components/Header.astro
+++ b/docs-next/src/components/Header.astro
@@ -19,8 +19,8 @@ const isActive = (href: string) =>
 
 <div class="tg-header">
   <div class="tg-header__left">
-    <a href="/" class="title-wrapper sl-flex" style="text-decoration: none; align-items: center; gap: 0.55rem;">
-      <img src="/modal-logo.svg" alt="Modal" style="height: 17.5px; width: auto;" />
+    <a href="/" class="title-wrapper sl-flex">
+      <img src="/modal-logo.svg" alt="Modal" />
       <span class="site-title"><span class="site-title__modal">Modal</span><span class="site-title__gym">Training Gym</span></span>
     </a>
     <nav class="tg-header__nav" aria-label="Primary">

--- a/docs-next/src/components/PageSidebar.astro
+++ b/docs-next/src/components/PageSidebar.astro
@@ -10,7 +10,7 @@ const primaryLabel = currentPath.startsWith('/tutorials/') ? 'Read overview' : '
 {
   Astro.locals.starlightRoute.toc && (
     <>
-      <div class="lg:sl-hidden">
+      <div class="tg-mobile-toc lg:sl-hidden">
         <MobileTableOfContents />
       </div>
       <div class="right-sidebar-panel sl-hidden lg:sl-block">

--- a/docs-next/src/styles/custom.css
+++ b/docs-next/src/styles/custom.css
@@ -1,5 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500&family=Inter:wght@400;500;600;700&display=swap');
 
+@font-face {
+  font-family: 'Goga';
+  src: url('https://modal-cdn.com/fonts/Goga-VariableVF.woff2') format('woff2');
+  font-weight: 100 900;
+  font-style: normal;
+}
+
 :root {
   --sl-font:
     'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
@@ -7,6 +14,8 @@
   --sl-font-mono:
     'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     monospace;
+  --sl-nav-pad-x: 1.25rem;
+  --sl-nav-height: 53px;
   --sl-content-width: 56rem;
   --sl-sidebar-width: 18.75rem;
   --sl-text-h1: clamp(2.35rem, 4vw, 3.25rem);
@@ -28,7 +37,7 @@
   --sl-color-gray-6: #2f2f2f;
   --sl-color-black: #181818;
   --sl-color-bg: #181818;
-  --sl-color-bg-nav: #1c1c1c;
+  --sl-color-bg-nav: #181818;
   --sl-color-bg-sidebar: #1c1c1c;
   --sl-color-bg-inline-code: #242424;
   --sl-color-hairline: rgba(255, 255, 255, 0.1);
@@ -42,7 +51,7 @@
   --tg-surface: #2f2f2f;
   --tg-border: rgba(255, 255, 255, 0.1);
   --tg-border-strong: rgba(255, 255, 255, 0.2);
-  --tg-header-shadow: 0 14px 42px rgba(0, 0, 0, 0.28);
+  --tg-header-shadow: none;
   --tg-caution-glow: rgba(249, 180, 79, 0.2);
   --tg-caution-border: rgba(249, 180, 79, 0.42);
   --tg-caution-text: #ffd897;
@@ -74,9 +83,13 @@ body::before {
 .header {
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  border-bottom: 1px solid var(--tg-border);
+  border-bottom: 1px solid #2f2f2f;
   box-shadow: var(--tg-header-shadow);
   background: var(--sl-color-bg-nav);
+}
+
+.header > .sl-container {
+  padding-block: 0.75rem;
 }
 
 .main-frame,
@@ -105,16 +118,22 @@ body::before {
 }
 
 .site-title {
-  color: var(--sl-color-white);
-  font-size: 1rem;
+  color: var(--sl-color-accent);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.18rem;
+  font-family: 'Goga', var(--sl-font);
+  font-feature-settings: 'ss01' on;
+  font-size: 17.6px;
   font-weight: 600;
   letter-spacing: -0.02em;
+  line-height: 1;
+  transform: translateY(1px);
+  white-space: nowrap;
 }
 
-.site-title span {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.7rem;
+.site-title__modal {
+  color: #ddffdc;
 }
 
 .sidebar-pane {
@@ -165,7 +184,7 @@ body::before {
   display: block;
   border-inline-start: 1px solid transparent;
   padding: 0.5rem 0.5rem;
-  font-size: 0.875rem;
+  font-size: 14px;
   line-height: 1.25;
   text-decoration: none;
 }
@@ -274,6 +293,40 @@ body::before {
   border-inline-start: 1px solid var(--tg-border);
 }
 
+.tg-mobile-toc {
+  width: 100%;
+}
+
+@media (max-width: 71.999rem) {
+  .right-sidebar-container {
+    grid-column: 1 / -1;
+    width: 100%;
+    max-width: none;
+    margin-inline: 0;
+  }
+
+  .right-sidebar:has(.tg-mobile-toc) {
+    width: 100%;
+    max-width: none;
+    border-inline-start: 0;
+  }
+
+  .right-sidebar:has(.tg-mobile-toc) .tg-mobile-toc,
+  .right-sidebar:has(.tg-mobile-toc) .tg-mobile-toc nav,
+  .right-sidebar:has(.tg-mobile-toc) .tg-mobile-toc details,
+  .right-sidebar:has(.tg-mobile-toc) .tg-mobile-toc summary {
+    width: 100%;
+    max-width: none;
+  }
+}
+
+@media (min-width: 50rem) and (max-width: 71.999rem) {
+  .right-sidebar-container {
+    width: calc(100% + var(--sl-sidebar-width));
+    margin-inline-start: calc(-1 * var(--sl-sidebar-width));
+  }
+}
+
 .right-sidebar-panel {
   padding: 1.25rem var(--sl-sidebar-pad-x);
 }
@@ -378,7 +431,7 @@ a.sl-link-button,
   gap: 0.45rem;
   min-height: 2.25rem;
   border: 1px solid rgba(255, 255, 255, 0.2) !important;
-  border-radius: 0.375rem !important;
+  border-radius: 9999px !important;
   background: transparent;
   color: var(--sl-color-gray-2);
   font-size: 0.875rem;
@@ -427,45 +480,52 @@ a.sl-link-button.secondary {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 1.75rem;
   height: 100%;
+  min-width: 0;
 }
 
 .tg-header__left {
   display: flex;
   align-items: center;
-  gap: 1.75rem;
+  gap: 3.5rem;
   min-width: 0;
+}
+
+.title-wrapper {
+  flex: 0 0 auto;
+  min-width: max-content;
 }
 
 .tg-header__nav {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: 1.75rem;
 }
 
 .tg-header__nav-link {
   position: relative;
-  color: var(--sl-color-gray-3);
+  color: var(--sl-color-gray-2);
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 400;
   padding: 0.2rem 0;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .tg-header__nav-link:hover {
-  color: var(--sl-color-white);
+  color: var(--sl-color-accent);
 }
 
 .tg-header__nav-link.is-active {
-  color: var(--sl-color-white);
+  color: var(--sl-color-accent);
 }
 
 .tg-header__nav-link.is-active::after {
   content: '';
   position: absolute;
   inset-inline: 0;
-  bottom: -1.05rem;
+  bottom: -12px;
   height: 2px;
   background: var(--sl-color-accent);
   border-radius: 999px;
@@ -476,29 +536,127 @@ a.sl-link-button.secondary {
   align-items: center;
   gap: 0.75rem;
   margin-left: auto;
+  min-width: 0;
 }
 
 .tg-header__search {
-  min-width: min(19rem, 32vw);
+  min-width: min(14rem, 24vw);
 }
 
 button[data-open-modal] {
-  border: 1px solid var(--tg-border-strong) !important;
-  border-radius: 0.5rem !important;
-  background: var(--tg-panel-alt) !important;
-  color: var(--sl-color-gray-2) !important;
+  border: 1px solid transparent !important;
+  border-radius: 9999px !important;
+  background: #212525 !important;
+  color: color-mix(in srgb, var(--sl-color-gray-2) 62%, transparent) !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 0.5rem !important;
+  font-family: var(--sl-font) !important;
+  font-size: 16px !important;
+  font-weight: 400 !important;
+  line-height: 1.25rem !important;
   box-shadow: none !important;
+  height: 1.75rem !important;
+  min-height: 28px !important;
+  width: 222px !important;
+  padding-block: 4px !important;
+  padding-inline: 12px !important;
+  transform: translateY(2.5px) !important;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    color 150ms ease !important;
 }
 
 button[data-open-modal]:hover {
-  border-color: color-mix(in srgb, var(--tg-border-strong) 72%, white) !important;
-  background: var(--tg-surface) !important;
+  border-color: transparent !important;
+  box-shadow: 0 0 0 1px var(--sl-color-accent) !important;
   color: var(--sl-color-white) !important;
 }
 
 button[data-open-modal] > kbd {
-  background: var(--tg-surface);
-  color: var(--sl-color-gray-3);
+  background: none;
+  color: color-mix(in srgb, var(--sl-color-gray-2) 60%, transparent);
+  font-family: var(--sl-font);
+  font-size: 14px;
+  font-weight: 400;
+  padding: 0;
+}
+
+button[data-open-modal] > span {
+  display: block !important;
+}
+
+button[data-open-modal] :is(svg, .icon) {
+  width: 1.25rem !important;
+  height: 1.25rem !important;
+  color: var(--sl-color-gray-4) !important;
+  stroke-width: 2 !important;
+}
+
+.tg-header__menu {
+  display: none;
+  position: relative;
+}
+
+.tg-header__menu summary {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 26px;
+  height: 2rem;
+  color: var(--sl-color-gray-2);
+  cursor: pointer;
+  list-style: none;
+  transform: translateY(-4px);
+}
+
+.tg-header__menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.tg-header__menu summary span {
+  display: block;
+  width: 24px;
+  height: 1.5px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.tg-header__menu-panel {
+  position: absolute;
+  top: calc(100% + 0.9rem);
+  right: 0;
+  z-index: 50;
+  display: flex;
+  min-width: 13rem;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--tg-border);
+  border-radius: 0.5rem;
+  background: var(--sl-color-bg-nav);
+  padding: 0.5rem;
+  box-shadow: var(--tg-header-shadow);
+}
+
+.tg-header__menu-link {
+  border-radius: 0.375rem;
+  color: var(--sl-color-gray-2);
+  font-size: 15px;
+  font-weight: 500;
+  padding: 0.65rem 0.75rem;
+  text-decoration: none;
+}
+
+.tg-header__menu-link:hover,
+.tg-header__menu-link.is-active {
+  background: color-mix(in srgb, var(--sl-color-accent) 8%, transparent);
+  color: var(--sl-color-accent);
+}
+
+button[aria-label='Menu'][class*='md:sl-hidden'] {
+  display: none !important;
 }
 
 .tg-page-head {
@@ -515,9 +673,9 @@ button[data-open-modal] > kbd {
 }
 
 .tg-page-head h1,
-.sl-markdown-content h1,
-.sl-markdown-content h2,
-.sl-markdown-content h3 {
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) {
+  font-family: 'Goga', var(--sl-font);
+  font-feature-settings: 'ss01' on;
   letter-spacing: -0.025em;
 }
 
@@ -534,14 +692,14 @@ button[data-open-modal] > kbd {
   margin: 0;
   max-width: 46rem;
   color: var(--sl-color-gray-2);
-  font-size: 1.05rem;
-  line-height: 1.7;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 .sl-markdown-content {
   color: var(--sl-color-gray-2);
-  font-size: 1rem;
-  line-height: 1.72;
+  font-size: 0.9375rem;
+  line-height: 1.6;
 }
 
 .sl-markdown-content > :first-child {
@@ -787,6 +945,92 @@ dialog {
 
   .tg-page-head__actions {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 72rem) {
+  .tg-header__repo {
+    display: none;
+  }
+}
+
+@media (max-width: 76rem) {
+  .tg-header__repo {
+    display: none;
+  }
+
+  .tg-header__search {
+    min-width: 104px;
+  }
+
+  .tg-header__left {
+    gap: 0;
+  }
+
+  .tg-header__nav {
+    display: none;
+  }
+
+  .tg-header__menu {
+    display: block;
+  }
+
+  .site-title {
+    font-size: 17.6px;
+  }
+
+  .title-wrapper img {
+    height: 17.5px !important;
+  }
+
+  button[data-open-modal] > kbd {
+    display: none;
+  }
+
+  button[data-open-modal] {
+    width: 104px !important;
+  }
+}
+
+@media (max-width: 48rem) {
+  .tg-header {
+    gap: 1rem;
+  }
+
+  button[data-open-modal] {
+    min-height: 1.75rem !important;
+    font-size: 16px !important;
+    width: 104px !important;
+    padding-inline: 12px !important;
+  }
+
+  button[data-open-modal] :is(svg, .icon) {
+    width: 1.25rem !important;
+    height: 1.25rem !important;
+  }
+}
+
+@media (max-width: 42rem) {
+  .tg-header__search {
+    min-width: 9.5rem;
+  }
+
+  button[data-open-modal] {
+    padding-inline: 0.8rem !important;
+  }
+}
+
+@media (max-width: 35rem) {
+  .site-title {
+    font-size: 16.8px;
+  }
+
+  .title-wrapper img {
+    height: 17px !important;
+  }
+
+  .tg-header__search {
+    min-width: 7.5rem;
   }
 }
 

--- a/docs-next/src/styles/custom.css
+++ b/docs-next/src/styles/custom.css
@@ -147,11 +147,13 @@ body::before {
 }
 
 .sidebar:has(.tg-sidebar-empty) {
-  display: none !important;
+  display: none;
 }
 
-.sidebar:has(.tg-sidebar-empty) + .main-frame {
-  padding-inline-start: 0 !important;
+@media (min-width: 50em) {
+  html:has(.tg-sidebar-empty) {
+    --sl-content-inline-start: 0;
+  }
 }
 
 .sidebar-content {
@@ -422,16 +424,14 @@ body::before {
   margin-top: 0.95rem;
 }
 
-.tg-action-button,
-a.sl-link-button,
-.tg-header__repo {
+:is(.tg-action-button, .sl-markdown-content a.sl-link-button, .tg-header .tg-header__repo) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.45rem;
   min-height: 2.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.2) !important;
-  border-radius: 9999px !important;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
   background: transparent;
   color: var(--sl-color-gray-2);
   font-size: 0.875rem;
@@ -445,29 +445,27 @@ a.sl-link-button,
     color 0.15s ease;
 }
 
-.tg-action-button:hover,
-a.sl-link-button:hover,
-.tg-header__repo:hover {
+:is(.tg-action-button, .sl-markdown-content a.sl-link-button, .tg-header .tg-header__repo):hover {
   border-color: color-mix(in srgb, var(--tg-border-strong) 72%, white);
   background: rgba(255, 255, 255, 0.05);
   color: var(--sl-color-white);
 }
 
 .tg-action-button--primary,
-a.sl-link-button.primary {
+.sl-markdown-content a.sl-link-button.primary {
   background: color-mix(in srgb, var(--sl-color-accent) 5%, transparent);
   border-color: color-mix(in srgb, var(--sl-color-accent) 40%, transparent);
   color: var(--sl-color-accent);
 }
 
 .tg-action-button--primary:hover,
-a.sl-link-button.primary:hover {
+.sl-markdown-content a.sl-link-button.primary:hover {
   background: color-mix(in srgb, var(--sl-color-accent) 10%, transparent);
   color: var(--sl-color-accent);
 }
 
 .tg-action-button--ghost,
-a.sl-link-button.secondary {
+.sl-markdown-content a.sl-link-button.secondary {
   background: transparent;
 }
 
@@ -495,6 +493,14 @@ a.sl-link-button.secondary {
 .title-wrapper {
   flex: 0 0 auto;
   min-width: max-content;
+  align-items: center;
+  gap: 0.55rem;
+  text-decoration: none;
+}
+
+.title-wrapper img {
+  height: 17.5px;
+  width: auto;
 }
 
 .tg-header__nav {
@@ -543,38 +549,38 @@ a.sl-link-button.secondary {
   min-width: min(14rem, 24vw);
 }
 
-button[data-open-modal] {
-  border: 1px solid transparent !important;
-  border-radius: 9999px !important;
-  background: #212525 !important;
-  color: color-mix(in srgb, var(--sl-color-gray-2) 62%, transparent) !important;
-  display: inline-flex !important;
-  align-items: center !important;
-  gap: 0.5rem !important;
-  font-family: var(--sl-font) !important;
-  font-size: 16px !important;
-  font-weight: 400 !important;
-  line-height: 1.25rem !important;
-  box-shadow: none !important;
-  height: 1.75rem !important;
-  min-height: 28px !important;
-  width: 222px !important;
-  padding-block: 4px !important;
-  padding-inline: 12px !important;
-  transform: translateY(2.5px) !important;
+.tg-header site-search.tg-header__search button[data-open-modal] {
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  background: #212525;
+  color: color-mix(in srgb, var(--sl-color-gray-2) 62%, transparent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--sl-font);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.25rem;
+  box-shadow: none;
+  height: 1.75rem;
+  min-height: 28px;
+  width: 222px;
+  padding-block: 4px;
+  padding-inline: 12px;
+  transform: translateY(2.5px);
   transition:
     border-color 150ms ease,
     box-shadow 150ms ease,
-    color 150ms ease !important;
+    color 150ms ease;
 }
 
-button[data-open-modal]:hover {
-  border-color: transparent !important;
-  box-shadow: 0 0 0 1px var(--sl-color-accent) !important;
-  color: var(--sl-color-white) !important;
+.tg-header site-search.tg-header__search button[data-open-modal]:hover {
+  border-color: transparent;
+  box-shadow: 0 0 0 1px var(--sl-color-accent);
+  color: var(--sl-color-white);
 }
 
-button[data-open-modal] > kbd {
+.tg-header site-search.tg-header__search button[data-open-modal] > kbd {
   background: none;
   color: color-mix(in srgb, var(--sl-color-gray-2) 60%, transparent);
   font-family: var(--sl-font);
@@ -583,15 +589,15 @@ button[data-open-modal] > kbd {
   padding: 0;
 }
 
-button[data-open-modal] > span {
-  display: block !important;
+.tg-header site-search.tg-header__search button[data-open-modal] > span {
+  display: block;
 }
 
-button[data-open-modal] :is(svg, .icon) {
-  width: 1.25rem !important;
-  height: 1.25rem !important;
-  color: var(--sl-color-gray-4) !important;
-  stroke-width: 2 !important;
+.tg-header site-search.tg-header__search button[data-open-modal] :is(svg, .icon) {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--sl-color-gray-4);
+  stroke-width: 2;
 }
 
 .tg-header__menu {
@@ -655,8 +661,8 @@ button[data-open-modal] :is(svg, .icon) {
   color: var(--sl-color-accent);
 }
 
-button[aria-label='Menu'][class*='md:sl-hidden'] {
-  display: none !important;
+.page nav.sidebar starlight-menu-button {
+  display: none;
 }
 
 .tg-page-head {
@@ -979,16 +985,12 @@ dialog {
     font-size: 17.6px;
   }
 
-  .title-wrapper img {
-    height: 17.5px !important;
-  }
-
-  button[data-open-modal] > kbd {
+  .tg-header site-search.tg-header__search button[data-open-modal] > kbd {
     display: none;
   }
 
-  button[data-open-modal] {
-    width: 104px !important;
+  .tg-header site-search.tg-header__search button[data-open-modal] {
+    width: 104px;
   }
 }
 
@@ -997,16 +999,11 @@ dialog {
     gap: 1rem;
   }
 
-  button[data-open-modal] {
-    min-height: 1.75rem !important;
-    font-size: 16px !important;
-    width: 104px !important;
-    padding-inline: 12px !important;
-  }
-
-  button[data-open-modal] :is(svg, .icon) {
-    width: 1.25rem !important;
-    height: 1.25rem !important;
+  .tg-header site-search.tg-header__search button[data-open-modal] {
+    min-height: 1.75rem;
+    font-size: 16px;
+    width: 104px;
+    padding-inline: 12px;
   }
 }
 
@@ -1015,8 +1012,8 @@ dialog {
     min-width: 9.5rem;
   }
 
-  button[data-open-modal] {
-    padding-inline: 0.8rem !important;
+  .tg-header site-search.tg-header__search button[data-open-modal] {
+    padding-inline: 0.8rem;
   }
 }
 
@@ -1026,7 +1023,7 @@ dialog {
   }
 
   .title-wrapper img {
-    height: 17px !important;
+    height: 17px;
   }
 
   .tg-header__search {


### PR DESCRIPTION
Change top bar for internal dashboard + training gym to match existing Modal pages.

- change logo font to Goga instead of Inter
- adjust logo/text size 
- add hamburger for collapsed pages
- (not top bar) changed header fonts for pages to be Goga instead of Inter
 

New:
<img width="1344" height="82" alt="Screenshot 2026-06-02 at 4 43 00 PM" src="https://github.com/user-attachments/assets/ae985ab5-86fa-4508-81ef-2f76920c671c" />

<img width="778" height="177" alt="Screenshot 2026-06-02 at 4 44 15 PM" src="https://github.com/user-attachments/assets/d0a4fee8-b206-4604-b83a-37af9a7ed0f7" />


Old:
<img width="1354" height="95" alt="Screenshot 2026-06-02 at 4 43 15 PM" src="https://github.com/user-attachments/assets/a58601e0-230d-4b52-a2c5-791ea5dd0032" />

<img width="816" height="170" alt="Screenshot 2026-06-02 at 4 44 05 PM" src="https://github.com/user-attachments/assets/bf18d807-436c-4615-b006-c6c521ed55f2" />

 