### PR TITLE
Bump minimum modal version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Reusable building blocks for Modal multi-node training examples"
 requires-python = ">=3.12"
 dependencies = [
-    "modal>=1.4.0",
+    "modal>=1.4.3",
     "cloudpickle",
     "datasets",
     "msgspec",


### PR DESCRIPTION
Bumps min modal version to 1.4.3 in pyproject.toml. This version supports beta sandbox features like directory snapshots, which are helpful for reinforcement learning evals.