### PR TITLE
Import randomname at image build time, not top level package

### DIFF
--- a/modal_training_gym/common/ids.py
+++ b/modal_training_gym/common/ids.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import datetime
 import hashlib
 
-import randomname
-
 
 def create_hash(
     model_name: str,
@@ -13,6 +11,8 @@ def create_hash(
     app_name: str,
     model_path: str,
 ) -> str:
+    import randomname
+
     created_at = str(int(datetime.datetime.now(datetime.UTC).timestamp()))
 
     slug = randomname.get_name(sep="-").lower()

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -140,6 +140,7 @@ def build_miles_app(
         image = image.uv_pip_install(f"harbor=={HARBOR_PKG_VERSION}")
 
     image = image.add_local_python_source("modal_training_gym", copy=True)
+    image = image.uv_pip_install("randomname")
     image = mount_tools_dir(image)
 
     if caller_script is not None:

--- a/tests/test_readable_ids.py
+++ b/tests/test_readable_ids.py
@@ -16,7 +16,9 @@ def test_create_hash_has_word_word_hash_shape() -> None:
 
 
 def test_create_hash_suffix_is_stable_for_same_parts(monkeypatch) -> None:
-    monkeypatch.setattr(ids.randomname, "get_name", lambda *, sep: "brisk-river")
+    import randomname
+
+    monkeypatch.setattr(randomname, "get_name", lambda *, sep: "brisk-river")
     first = ids.create_hash("model", "ckpt", "recipe", "app", "path")
     second = ids.create_hash("model", "ckpt", "recipe", "app", "path")
 
@@ -24,7 +26,9 @@ def test_create_hash_suffix_is_stable_for_same_parts(monkeypatch) -> None:
 
 
 def test_create_hash_suffix_differs_for_different_parts(monkeypatch) -> None:
-    monkeypatch.setattr(ids.randomname, "get_name", lambda *, sep: "brisk-river")
+    import randomname
+
+    monkeypatch.setattr(randomname, "get_name", lambda *, sep: "brisk-river")
     first = ids.create_hash("model-a", "ckpt", "recipe", "app", "path")
     second = ids.create_hash("model-b", "ckpt", "recipe", "app", "path")
 


### PR DESCRIPTION
To generate ids in https://github.com/modal-projects/training-gym/pull/90, we imported randomname as a package. However, we did this as a global import instead of relative. As such, training runs that needs this fail because it's not built into the launcher image that is running.

This PR makes a fix to add this, and fix the failing tests from before.