### PR TITLE
Show full Slime params in dashboard

### DIFF
--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -37,12 +37,20 @@
     () => allRuns.find((run) => run.run_id === selectedRunId) || null,
   );
 
+  let selectedRecipe = $derived.by(() => {
+    if (!selectedRun) return {};
+    return selectedRun.config?.recipe || selectedRun.config?.preset || {};
+  });
+
   let selectedRecipeEntries = $derived.by(() => {
-    if (!selectedRun) return [];
-    const recipe = selectedRun.config?.recipe || selectedRun.config?.preset || {};
-    return Object.entries(recipe).filter(
+    return Object.entries(selectedRecipe).filter(
       ([, value]) => value !== undefined && value !== null && String(value) !== "",
     );
+  });
+
+  let selectedRecipeJson = $derived.by(() => {
+    if (!Object.keys(selectedRecipe).length) return "";
+    return JSON.stringify(selectedRecipe, null, 2);
   });
 
   function selectRun(runId) {
@@ -63,6 +71,10 @@
     }
     if (typeof value === "object") return JSON.stringify(value);
     return String(value);
+  }
+
+  function isSlimeRun(run) {
+    return String(run?.framework || "").toLowerCase() === "slime";
   }
 
   function runDuration(run) {
@@ -273,6 +285,13 @@
           </span>
         </div>
       </section>
+
+      {#if isSlimeRun(selectedRun) && selectedRecipeJson}
+        <section class="drawer-section">
+          <h3 class="drawer-section-title">Full Slime parameters</h3>
+          <pre class="drawer-json">{selectedRecipeJson}</pre>
+        </section>
+      {/if}
 
       <section class="drawer-section">
         <h3 class="drawer-section-title">Training recipe</h3>
@@ -574,6 +593,21 @@
     color: var(--muted);
     font-size: 12px;
     line-height: 16px;
+  }
+
+  .drawer-json {
+    border: 1px solid var(--color-c-gray-10, #2f2f2f);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--panel-alt) 74%, black);
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 16px;
+    margin: 0;
+    max-height: 360px;
+    overflow: auto;
+    padding: 10px;
+    white-space: pre;
   }
 
   .empty {

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -152,6 +152,43 @@ def _serialize_recipe_value(value: Any) -> Any:
     return repr(value)
 
 
+def _is_sensitive_recipe_field(name: str) -> bool:
+    normalized = name.lower()
+    if normalized.endswith("token_id") or normalized.endswith("token_ids"):
+        return False
+    return (
+        any(
+            marker in normalized
+            for marker in ("api_key", "access_key", "secret", "password", "token")
+        )
+        or normalized == "wandb_key"
+    )
+
+
+def _serialize_slime_param_value(name: str, value: Any) -> Any:
+    if _is_sensitive_recipe_field(name):
+        return "[redacted]" if value not in (None, "", False) else value
+    if isinstance(value, dict):
+        return {
+            str(k): _serialize_slime_param_value(str(k), v) for k, v in value.items()
+        }
+    if isinstance(value, list | tuple | set):
+        return [_serialize_slime_param_value(name, v) for v in value]
+    return _serialize_recipe_value(value)
+
+
+def _serialize_slime_params(
+    recipe: SlimeRecipe,
+    *,
+    dataset: DatasetConfig | None = None,
+    model: ModelConfig | None = None,
+) -> dict[str, Any]:
+    return {
+        key: _serialize_slime_param_value(key, value)
+        for key, value in recipe._fields(dataset=dataset, model=model).items()
+    }
+
+
 def _serialize_recipe_fields(recipe: SlimeRecipe) -> dict[str, Any]:
     return {
         field.name: _serialize_recipe_value(getattr(recipe, field.name))
@@ -689,11 +726,7 @@ def build_slime_app(
         print(f"Training run id: {training_run_id}")
         config_summary: dict = {
             "model": {"model_name": model.model_name} if model else {},
-            "recipe": {
-                "gpu_type": slime.gpu_type,
-                "actor_num_nodes": slime.actor_num_nodes,
-                "actor_num_gpus_per_node": slime.actor_num_gpus_per_node,
-            },
+            "recipe": _serialize_slime_params(slime, dataset=dataset, model=model),
             "wandb": (
                 {"project": slime.wandb.project, "group": slime.wandb.group}
                 if slime.wandb

--- a/tests/test_recipe_param_summary.py
+++ b/tests/test_recipe_param_summary.py
@@ -196,6 +196,31 @@ def test_serialized_recipe_fields():
     json.dumps(fields)
 
 
+def test_serialized_slime_params_include_full_debug_fields():
+    """Dashboard debug payload includes full Slime CLI params, not just a summary."""
+    from modal_training_gym.frameworks.slime.launcher import _serialize_slime_params
+
+    recipe = Qwen3_4b_Recipe(
+        rollout_stop_token_ids=[151643, 151645],
+        train_env_vars={"WANDB_API_KEY": "secret-value", "SAFE_FLAG": "1"},
+    )
+    fields = _serialize_slime_params(
+        recipe, dataset=_make_dataset(), model=_make_model()
+    )
+
+    assert fields["gpu_type"] == "H100"
+    assert fields["n_samples_per_prompt"] == 8
+    assert fields["train_env_vars"]["WANDB_API_KEY"] == "[redacted]"
+    assert fields["train_env_vars"]["SAFE_FLAG"] == "1"
+    assert fields["rollout_stop_token_ids"] == [151643, 151645]
+    assert fields["prompt_data"] == "/data/some_dataset/train.parquet"
+    assert fields["num_layers"] == 36
+
+    import json
+
+    json.dumps(fields)
+
+
 def test_param_summary_values_are_json_serializable():
     """All values in the param summary must be JSON-serializable."""
     import json


### PR DESCRIPTION
Expose the complete effective Slime CLI parameter payload in training run metadata and surface it in the dashboard drawer for Slime runs. The serialized payload includes dataset/model-derived Slime fields for debugging, while redacting sensitive values such as API keys, tokens, secrets, and passwords.

## Validation

- `uv run pytest tests/test_recipe_param_summary.py`
- `uvx ruff check modal_training_gym/ tests/test_recipe_param_summary.py`
- `uvx ruff format --check modal_training_gym/ tests/test_recipe_param_summary.py`
- `uv run python -m compileall modal_training_gym/`
- `(cd dashboards/frontend && npm run build)`

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style. (N/A: no example changes)
- [ ] Example does _not_ require third-party dependencies to be installed locally (N/A: no example changes)
- [ ] Example pins its dependencies (N/A: no example changes)
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

Link to Devin session: https://modal.devinenterprise.com/sessions/5c0b579fb96745a1a5d854f166581587
Requested by: @joyliu-q