### PR TITLE
Add environments module for defining reinforcement learning environments with Modal sandboxes and Toolathlon implementation

### DIFF
--- a/modal_training_gym/common/environments/__init__.py
+++ b/modal_training_gym/common/environments/__init__.py
@@ -5,7 +5,6 @@ classes); concrete benchmarks (e.g. ``toolathlon``) build on them.
 """
 
 from modal_training_gym.common.environments.base import (
-    Action,
     DirectorySnapshotLibrary,
     Environment,
     EvalVerdict,
@@ -13,6 +12,7 @@ from modal_training_gym.common.environments.base import (
     SandboxEnvironment,
     SandboxEnvironmentPool,
     StepResult,
+    ToolCall,
 )
 from modal_training_gym.common.environments.toolathlon import (
     DEFAULT_CONFIG,
@@ -33,7 +33,7 @@ from modal_training_gym.common.environments.toolathlon import (
 
 __all__ = [
     # base — shapes
-    "Action",
+    "ToolCall",
     "Observation",
     "StepResult",
     "EvalVerdict",

--- a/modal_training_gym/common/environments/__init__.py
+++ b/modal_training_gym/common/environments/__init__.py
@@ -1,0 +1,62 @@
+"""Live, sandbox-backed RL environments.
+
+``base`` holds the framework-agnostic abstractions (I/O shapes + lifecycle base
+classes); concrete benchmarks (e.g. ``toolathlon``) build on them.
+"""
+
+from modal_training_gym.common.environments.base import (
+    Action,
+    DirectorySnapshotLibrary,
+    Environment,
+    EvalVerdict,
+    Observation,
+    SandboxEnvironment,
+    SandboxEnvironmentPool,
+    StepResult,
+)
+from modal_training_gym.common.environments.toolathlon import (
+    DEFAULT_CONFIG,
+    TIER_A_MCPS,
+    ToolathlonEnvConfig,
+    ToolathlonEnvironment,
+    ToolathlonEnvPool,
+    ToolathlonTrajectoryDataset,
+    build_env_image,
+    build_prefix_messages,
+    build_snapshot_library,
+    default_system_prompt,
+    dispatch_tool,
+    get_env_pool,
+    prune_prefix,
+    render_tool_catalog,
+)
+
+__all__ = [
+    # base — shapes
+    "Action",
+    "Observation",
+    "StepResult",
+    "EvalVerdict",
+    # base — lifecycle
+    "Environment",
+    "SandboxEnvironment",
+    "SandboxEnvironmentPool",
+    "DirectorySnapshotLibrary",
+    # toolathlon — config + env
+    "ToolathlonEnvConfig",
+    "DEFAULT_CONFIG",
+    "TIER_A_MCPS",
+    "ToolathlonEnvironment",
+    "ToolathlonEnvPool",
+    "get_env_pool",
+    "build_env_image",
+    "dispatch_tool",
+    # toolathlon — snapshots
+    "build_snapshot_library",
+    # toolathlon — data + prompts
+    "ToolathlonTrajectoryDataset",
+    "build_prefix_messages",
+    "prune_prefix",
+    "render_tool_catalog",
+    "default_system_prompt",
+]

--- a/modal_training_gym/common/environments/base.py
+++ b/modal_training_gym/common/environments/base.py
@@ -7,7 +7,7 @@ environment and the lifecycle base classes that concrete environments
 
 Three layers, from generic to specific:
 
-1. **I/O shapes** — :class:`Action`, :class:`Observation`, :class:`StepResult`,
+1. **I/O shapes** — :class:`ToolCall`, :class:`Observation`, :class:`StepResult`,
    :class:`EvalVerdict`. Plain dataclasses describing what an agent sends to an
    environment and what it gets back.
 2. **Environment lifecycle** — :class:`Environment` (one live episode: ``step`` /
@@ -28,101 +28,28 @@ can override only what it needs.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from typing import Any
 
-
-# ── I/O shapes ────────────────────────────────────────────────────────────
-
-
-@dataclass
-class Action:
-    """A single action an agent takes against an environment — a tool call.
-
-    ``name`` is the tool/function name and ``arguments`` its keyword arguments.
-    Mirrors the ``ToolCall`` shape in ``common/models/base.py`` so a parsed
-    model response can be fed straight into :meth:`Environment.step`.
-    """
-
-    name: str
-    arguments: dict[str, Any] = field(default_factory=dict)
-
-    @classmethod
-    def parse(cls, text: str) -> "Action | None":
-        """Parse the first action from raw agent output, or ``None`` if there isn't one.
-
-        Default wire format: a single JSON object ``{"name": ..., "arguments": {...}}`` — the inverse
-        of a system prompt that instructs the agent to emit exactly that. A leading ``</think>``
-        reasoning block is stripped (a no-op for non-reasoning models). Objects are scanned
-        left-to-right with a streaming decoder, so a multi-object dump or trailing prose still yields a
-        usable first action instead of failing to decode the whole blob.
-
-        Subclasses override to capture extra fields or a different format; build with ``cls(...)`` so a
-        subclass parser returns its own type.
-        """
-        for obj in cls._iter_json_objects(text):
-            action = cls._from_obj(obj)
-            if action is not None:
-                return action
-        return None
-
-    @classmethod
-    def parse_all(cls, text: str) -> list["Action"]:
-        """Every action in one reply, in order — for turns that batch multiple tool calls."""
-        return [
-            a
-            for obj in cls._iter_json_objects(text)
-            if (a := cls._from_obj(obj)) is not None
-        ]
-
-    @classmethod
-    def _from_obj(cls, obj: Any) -> "Action | None":
-        """Build an action from one decoded JSON value, or ``None`` if it isn't an action."""
-        if isinstance(obj, dict) and "name" in obj:
-            return cls(name=obj["name"], arguments=obj.get("arguments", {}) or {})
-        return None
-
-    @staticmethod
-    def _iter_json_objects(text: str):
-        """Yield top-level JSON values found in ``text``, left to right."""
-        if "</think>" in text:
-            text = text.split("</think>")[-1]
-        text = text.strip()
-        try:  # fast path: the whole reply is exactly one object
-            yield json.loads(text)
-            return
-        except (json.JSONDecodeError, TypeError):
-            pass
-        decoder = json.JSONDecoder()
-        idx = text.find("{")
-        while idx != -1:
-            try:
-                obj, end = decoder.raw_decode(text, idx)
-                yield obj
-                idx = text.find("{", end)
-                continue
-            except json.JSONDecodeError:
-                pass
-            idx = text.find("{", idx + 1)
+from modal_training_gym.common.models.base import ToolCall
 
 
 @dataclass
 class Observation:
-    """The environment's response to an action.
+    """The environment's response to a tool call.
 
     text : str
-        Human/agent-readable result of the action (tool output, error message).
+        Human/agent-readable result of the tool call (tool output, error message).
     is_error : bool
-        Whether the action failed (e.g. a tool raised). Lets a caller bail out
+        Whether the tool call failed (e.g. a tool raised). Lets a caller bail out
         of a flailing episode without parsing ``text``.
-    meta : dict
+    metadata : dict
         Optional structured extras (raw payload, status codes, …).
     """
 
     text: str = ""
     is_error: bool = False
-    meta: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -130,9 +57,9 @@ class StepResult:
     """Result of one :meth:`Environment.step`.
 
     observation : Observation
-        What the environment returned for the action.
+        What the environment returned for the tool call.
     done : bool
-        Whether the episode should end (terminal action, fatal error, …).
+        Whether the episode should end (terminal tool call, fatal error, …).
     info : dict
         Optional per-step diagnostics.
     """
@@ -159,6 +86,8 @@ class EvalVerdict:
     passed: bool
     detail: str = ""
     harness_error: bool = False
+    # For additional metadata like test cases
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 # ── Environment lifecycle ───────────────────────────────────────────────────
@@ -167,13 +96,13 @@ class EvalVerdict:
 class Environment:
     """A single live environment episode.
 
-    Subclasses implement :meth:`step` (apply an action) and, when the task is
+    Subclasses implement :meth:`step` (apply a tool call) and, when the task is
     gradable, :meth:`evaluate` (score the final state). :meth:`close` releases
     any resources. Supports the context-manager protocol so callers can write
     ``with pool.acquire(...) as env:``.
     """
 
-    def step(self, action: Action) -> StepResult:
+    def step(self, action: ToolCall) -> StepResult:
         """Apply ``action`` and return the resulting :class:`StepResult`."""
         raise NotImplementedError(f"{type(self).__name__} has no step()")
 
@@ -343,7 +272,7 @@ class DirectorySnapshotLibrary:
            (and start any helper process needed to advance, e.g. a tool server);
         3. for each step, ``snapshot_directory(root)`` then, unless it's the last
            step, ``advance(sandbox, step)`` to mutate the world from ``step`` to
-           ``step + 1`` (e.g. replay one expert action).
+           ``step + 1`` (e.g. replay one expert tool call).
 
         Returns the number of snapshots written (``n_steps + 1``).
         """

--- a/modal_training_gym/common/environments/base.py
+++ b/modal_training_gym/common/environments/base.py
@@ -1,0 +1,360 @@
+"""Base abstractions for live, sandbox-backed RL environments.
+
+This module is the environment analogue of ``common/models/base.py`` and
+``common/dataset.py``: it defines the *shapes* that flow in and out of an
+environment and the lifecycle base classes that concrete environments
+(e.g. :mod:`modal_training_gym.common.environments.toolathlon`) implement.
+
+Three layers, from generic to specific:
+
+1. **I/O shapes** — :class:`Action`, :class:`Observation`, :class:`StepResult`,
+   :class:`EvalVerdict`. Plain dataclasses describing what an agent sends to an
+   environment and what it gets back.
+2. **Environment lifecycle** — :class:`Environment` (one live episode: ``step`` /
+   ``evaluate`` / ``close``) and :class:`SandboxEnvironment` (an ``Environment``
+   whose state lives in a Modal sandbox).
+3. **Pooling + snapshots** — :class:`SandboxEnvironmentPool` (create/reuse warm
+   sandboxes per acquire) and :class:`DirectorySnapshotLibrary` (capture and
+   restore environment state as Modal directory snapshots keyed by
+   ``(item, step)``).
+
+Nothing here is specific to any benchmark, model, or tutorial. Subclasses
+supply the image, the tool transport, and the grading.
+
+Like ``ModelConfig`` / ``DatasetConfig``, these are plain base classes (not
+``abc.ABC``): unimplemented hooks raise ``NotImplementedError`` so a subclass
+can override only what it needs.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ── I/O shapes ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Action:
+    """A single action an agent takes against an environment — a tool call.
+
+    ``name`` is the tool/function name and ``arguments`` its keyword arguments.
+    Mirrors the ``ToolCall`` shape in ``common/models/base.py`` so a parsed
+    model response can be fed straight into :meth:`Environment.step`.
+    """
+
+    name: str
+    arguments: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def parse(cls, text: str) -> "Action | None":
+        """Parse the first action from raw agent output, or ``None`` if there isn't one.
+
+        Default wire format: a single JSON object ``{"name": ..., "arguments": {...}}`` — the inverse
+        of a system prompt that instructs the agent to emit exactly that. A leading ``</think>``
+        reasoning block is stripped (a no-op for non-reasoning models). Objects are scanned
+        left-to-right with a streaming decoder, so a multi-object dump or trailing prose still yields a
+        usable first action instead of failing to decode the whole blob.
+
+        Subclasses override to capture extra fields or a different format; build with ``cls(...)`` so a
+        subclass parser returns its own type.
+        """
+        for obj in cls._iter_json_objects(text):
+            action = cls._from_obj(obj)
+            if action is not None:
+                return action
+        return None
+
+    @classmethod
+    def parse_all(cls, text: str) -> list["Action"]:
+        """Every action in one reply, in order — for turns that batch multiple tool calls."""
+        return [
+            a
+            for obj in cls._iter_json_objects(text)
+            if (a := cls._from_obj(obj)) is not None
+        ]
+
+    @classmethod
+    def _from_obj(cls, obj: Any) -> "Action | None":
+        """Build an action from one decoded JSON value, or ``None`` if it isn't an action."""
+        if isinstance(obj, dict) and "name" in obj:
+            return cls(name=obj["name"], arguments=obj.get("arguments", {}) or {})
+        return None
+
+    @staticmethod
+    def _iter_json_objects(text: str):
+        """Yield top-level JSON values found in ``text``, left to right."""
+        if "</think>" in text:
+            text = text.split("</think>")[-1]
+        text = text.strip()
+        try:  # fast path: the whole reply is exactly one object
+            yield json.loads(text)
+            return
+        except (json.JSONDecodeError, TypeError):
+            pass
+        decoder = json.JSONDecoder()
+        idx = text.find("{")
+        while idx != -1:
+            try:
+                obj, end = decoder.raw_decode(text, idx)
+                yield obj
+                idx = text.find("{", end)
+                continue
+            except json.JSONDecodeError:
+                pass
+            idx = text.find("{", idx + 1)
+
+
+@dataclass
+class Observation:
+    """The environment's response to an action.
+
+    text : str
+        Human/agent-readable result of the action (tool output, error message).
+    is_error : bool
+        Whether the action failed (e.g. a tool raised). Lets a caller bail out
+        of a flailing episode without parsing ``text``.
+    meta : dict
+        Optional structured extras (raw payload, status codes, …).
+    """
+
+    text: str = ""
+    is_error: bool = False
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StepResult:
+    """Result of one :meth:`Environment.step`.
+
+    observation : Observation
+        What the environment returned for the action.
+    done : bool
+        Whether the episode should end (terminal action, fatal error, …).
+    info : dict
+        Optional per-step diagnostics.
+    """
+
+    observation: Observation
+    done: bool = False
+    info: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EvalVerdict:
+    """Terminal grade of an environment's final state.
+
+    passed : bool
+        Whether the task's own evaluator considers the end state correct.
+    detail : str
+        Human-readable explanation (evaluator output, failure reason).
+    harness_error : bool
+        ``True`` when grading itself crashed (bad config / broken harness)
+        rather than the task legitimately failing — so harness breakage isn't
+        silently scored as a string of task failures.
+    """
+
+    passed: bool
+    detail: str = ""
+    harness_error: bool = False
+
+
+# ── Environment lifecycle ───────────────────────────────────────────────────
+
+
+class Environment:
+    """A single live environment episode.
+
+    Subclasses implement :meth:`step` (apply an action) and, when the task is
+    gradable, :meth:`evaluate` (score the final state). :meth:`close` releases
+    any resources. Supports the context-manager protocol so callers can write
+    ``with pool.acquire(...) as env:``.
+    """
+
+    def step(self, action: Action) -> StepResult:
+        """Apply ``action`` and return the resulting :class:`StepResult`."""
+        raise NotImplementedError(f"{type(self).__name__} has no step()")
+
+    def evaluate(self) -> EvalVerdict:
+        """Grade the environment's current/final state."""
+        raise NotImplementedError(f"{type(self).__name__} has no evaluate()")
+
+    def close(self) -> None:
+        """Release resources held by this episode (idempotent, never raises)."""
+
+    def __enter__(self) -> "Environment":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+class SandboxEnvironment(Environment):
+    """An :class:`Environment` whose mutable state lives inside a Modal sandbox.
+
+    Holds the ``modal.Sandbox`` handle; :meth:`close` terminates it. Subclasses
+    implement :meth:`step` / :meth:`evaluate` by ``exec``-ing inside the sandbox.
+    """
+
+    def __init__(self, sandbox: Any) -> None:
+        self.sandbox = sandbox
+
+    def close(self) -> None:
+        try:
+            self.sandbox.terminate()
+        except Exception:
+            pass
+
+
+# ── Pooling ──────────────────────────────────────────────────────────────
+
+
+class SandboxEnvironmentPool:
+    """Creates sandbox-backed environments on demand, sharing one Modal ``App``.
+
+    Subclasses override :meth:`build_image` (the base sandbox image) and
+    :meth:`acquire` (turn acquire-args into a ready :class:`Environment`), and
+    can use :meth:`create_sandbox` as a helper. The default :meth:`release`
+    closes the env.
+
+    **Cloudpickle safety.** A pool is often instantiated client-side (e.g. a
+    base eval) and then captured when a rollout/reward function is cloudpickled
+    *by value* to remote workers. Live ``modal.App`` handles hold asyncio
+    futures and aren't picklable, so :meth:`__getstate__` drops them; they are
+    re-created lazily via :meth:`app_handle` on the worker.
+    """
+
+    #: Name of the shared ``modal.App`` sandboxes are created under.
+    app_name: str = ""
+
+    def __init__(self) -> None:
+        self._app: Any = None
+
+    def __getstate__(self) -> dict:
+        # Drop the live App handle so cloudpickle can ship the pool by value.
+        state = dict(self.__dict__)
+        state["_app"] = None
+        return state
+
+    def app_handle(self) -> Any:
+        """The shared ``modal.App`` (created/looked up lazily)."""
+        import modal
+
+        if self._app is None:
+            if not self.app_name:
+                raise ValueError(f"{type(self).__name__}.app_name must be set")
+            self._app = modal.App.lookup(self.app_name, create_if_missing=True)
+        return self._app
+
+    def build_image(self) -> Any:
+        """Return the base ``modal.Image`` sandboxes are created from."""
+        raise NotImplementedError(f"{type(self).__name__} has no build_image()")
+
+    def create_sandbox(
+        self,
+        *,
+        image: Any = None,
+        command: tuple[str, ...] = ("sleep", "infinity"),
+        **kwargs: Any,
+    ) -> Any:
+        """Create a long-lived sandbox from ``image`` (defaults to :meth:`build_image`)."""
+        import modal
+
+        return modal.Sandbox.create(
+            *command,
+            image=image if image is not None else self.build_image(),
+            app=self.app_handle(),
+            **kwargs,
+        )
+
+    def acquire(self, *args: Any, **kwargs: Any) -> Environment:
+        """Return a ready :class:`Environment` for the given acquire-args."""
+        raise NotImplementedError(f"{type(self).__name__} has no acquire()")
+
+    def release(self, env: Environment) -> None:
+        """Release an environment acquired from this pool."""
+        env.close()
+
+
+# ── Directory snapshots ─────────────────────────────────────────────────────
+
+
+class DirectorySnapshotLibrary:
+    """Capture/restore environment state as Modal directory snapshots.
+
+    A snapshot library is a ``modal.Dict`` mapping ``"{item}/{step}"`` to a
+    *directory* snapshot ``Image`` of ``root`` at that step. The env pool mounts
+    these by key to restore the world to a given step.
+
+    **The remountable-snapshot rule.** ``mount_image`` of a directory snapshot
+    only works if the snapshotted path was itself a *mounted overlay*. So
+    :meth:`build_item` mounts an empty ``Image.from_scratch()`` at ``root``
+    *before* seeding state, then ``snapshot_directory(root)``. Snapshotting a
+    plain base-image directory yields a snapshot Modal's backend can't remount.
+
+    Handles are looked up lazily so the library can be imported on remote
+    workers without a Modal round-trip at import time.
+    """
+
+    def __init__(self, catalog_name: str, root: str) -> None:
+        self.catalog_name = catalog_name
+        self.root = root
+        self._catalog: Any = None
+
+    def __getstate__(self) -> dict:
+        state = dict(self.__dict__)
+        state["_catalog"] = None
+        return state
+
+    def catalog(self) -> Any:
+        """The backing ``modal.Dict`` (created/looked up lazily)."""
+        import modal
+
+        if self._catalog is None:
+            self._catalog = modal.Dict.from_name(
+                self.catalog_name, create_if_missing=True
+            )
+        return self._catalog
+
+    @staticmethod
+    def key(item: str, step: int) -> str:
+        return f"{item}/{step}"
+
+    def get(self, item: str, step: int) -> Any:
+        """The snapshot ``Image`` for ``(item, step)``."""
+        return self.catalog()[self.key(item, step)]
+
+    def has(self, item: str, step: int) -> bool:
+        return self.key(item, step) in self.catalog()
+
+    def mount(self, sandbox: Any, item: str, step: int) -> None:
+        """Mount the ``(item, step)`` snapshot at ``root`` inside ``sandbox``."""
+        sandbox.mount_image(self.root, self.get(item, step))
+
+    def build_item(self, sandbox: Any, item: str, n_steps: int, seed, advance) -> int:
+        """Snapshot ``root`` at every step ``0..n_steps`` of one item.
+
+        ``sandbox`` is a freshly created sandbox. The sequence is:
+
+        1. mount an empty overlay at ``root`` (so the snapshot is remountable);
+        2. ``seed(sandbox)`` — materialize the step-0 state into the overlay
+           (and start any helper process needed to advance, e.g. a tool server);
+        3. for each step, ``snapshot_directory(root)`` then, unless it's the last
+           step, ``advance(sandbox, step)`` to mutate the world from ``step`` to
+           ``step + 1`` (e.g. replay one expert action).
+
+        Returns the number of snapshots written (``n_steps + 1``).
+        """
+        import modal
+
+        # Empty writable overlay so the directory snapshot is remountable.
+        sandbox.mount_image(self.root, modal.Image.from_scratch())
+        seed(sandbox)
+        catalog = self.catalog()
+        for step in range(n_steps + 1):
+            catalog[self.key(item, step)] = sandbox.snapshot_directory(self.root)
+            if step < n_steps:
+                advance(sandbox, step)
+        return n_steps + 1

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -1,0 +1,918 @@
+"""Live, decoupled Toolathlon environment built on the env base abstractions.
+
+Toolathlon (https://toolathlon.xyz) is a long-horizon, tool-using agent
+benchmark. This module turns it into a reusable RL environment with three
+cooperating pieces, layered on the abstractions in :mod:`.base`:
+
+- **Config** — :class:`ToolathlonEnvConfig` holds every path/port/image name so
+  nothing is hardcoded at module scope.
+- **Environment + pool** — :class:`ToolathlonEnvironment` (one live episode: a
+  Modal sandbox running the MCP tool gateway, graded by Toolathlon's own
+  evaluator) and :class:`ToolathlonEnvPool` (warm sandboxes + the directory
+  snapshot library that restores the world to a given trajectory step).
+- **Trajectory data** — :class:`ToolathlonTrajectoryDataset` loads expert
+  trajectories (remapping the original workspace path onto ours) and the
+  :func:`build_prefix_messages` / :func:`prune_prefix` helpers reconstruct the
+  step-``K`` prompt prefix.
+
+Scope ("Tier A"): process-only MCP servers whose entire state lives in the agent
+workspace (``filesystem``, ``excel``, ``pdf-tools``, ``word``, ``pptx``,
+``memory``, ``howtocook``, ``arxiv_local``, ``terminal``), so it can be captured
+with a single directory snapshot. Tasks backed by external services (k8s,
+WooCommerce/MySQL, Canvas/Postgres, email) are out of scope.
+
+Nothing here is tutorial-specific: a caller supplies the task split, the
+tokenizer/budget for pruning, and (optionally) the system prompt.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from modal_training_gym.common.dataset import DatasetConfig
+from modal_training_gym.common.environments.base import (
+    Action,
+    DirectorySnapshotLibrary,
+    EvalVerdict,
+    Observation,
+    SandboxEnvironment,
+    SandboxEnvironmentPool,
+    StepResult,
+)
+
+# MCP servers whose state is confined to the agent workspace (snapshot-safe "Tier A").
+TIER_A_MCPS = frozenset(
+    {
+        "filesystem",
+        "excel",
+        "pdf-tools",
+        "word",
+        "pptx",
+        "memory",
+        "howtocook",
+        "arxiv_local",
+        "terminal",
+    }
+)
+
+# Terminal "done" action names the agent can emit to end an episode.
+DONE_TOOLS = frozenset({"claim_done", "local-claim_done"})
+
+
+# ── Config ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ToolathlonEnvConfig:
+    """All paths/ports/image names for one decoupled Toolathlon environment.
+
+    The defaults reproduce the reference setup. ``snapshot_root`` is the overlay
+    mount + directory-snapshot root, pinned to a fixed path (via the patched run
+    config's ``direct_to_dumps`` + ``dump_path``) so the workspace path is
+    deterministic across the snapshot build and the rollout/eval pool.
+    """
+
+    image: str = "lockon0927/toolathlon-task-image:1016beta"
+    commit: str = "main"  # pin a SHA for reproducibility in a real run
+    snapshot_root: str = "/task"
+    workspace_subdir: str = "workspace"
+    # The expert trajectories were generated with the agent workspace at this absolute path; our MCP
+    # filesystem server is rooted at ``workspace_path``, so callers remap this prefix across a loaded
+    # trajectory (golden call args, observations, task text) so replay + student calls resolve.
+    orig_workspace: str = "/workspace/dumps/workspace"
+    eval_config: str = (
+        "scripts/formal_run_modal.json"  # patched run config (direct_to_dumps -> root)
+    )
+    venv: str = "/opt/toolathlon/.venv"  # uv-synced venv with Toolathlon's deps
+    gateway_port: int = 8765
+    snapshot_catalog: str = (
+        "toolathlon-tierA-snapshots"  # modal.Dict: (task, K) -> snapshot
+    )
+    sandbox_app: str = "toolathlon-tierA-env"
+
+    @property
+    def workspace_path(self) -> str:
+        """Where the MCP servers + evaluator operate (= ``snapshot_root/workspace``)."""
+        return f"{self.snapshot_root}/{self.workspace_subdir}"
+
+    @property
+    def bundle_path(self) -> str:
+        # Inside the overlay -> travels in the directory snapshot.
+        return f"{self.workspace_path}/.toolathlon_bundle.json"
+
+    @property
+    def traj_log_path(self) -> str:
+        # Synthesized dump_line consumed by container_eval; in the snapshot root so it travels too.
+        return f"{self.snapshot_root}/traj_log.json"
+
+    @property
+    def pybin(self) -> str:
+        return f"{self.venv}/bin/python"
+
+    @property
+    def gateway_sse_url(self) -> str:
+        return f"http://127.0.0.1:{self.gateway_port}/sse"
+
+    @property
+    def gateway_health_url(self) -> str:
+        return f"http://127.0.0.1:{self.gateway_port}/health"
+
+
+DEFAULT_CONFIG = ToolathlonEnvConfig()
+
+
+# ── In-sandbox snippets ─────────────────────────────────────────────────────
+# Run inside the sandbox with the synced venv's interpreter (``config.pybin``).
+
+# Call one tool through the gateway's MCP SSE transport using the official `mcp` client and print a
+# parseable result line. The decoupled gateway is a standard MCP SSE server, so this is the canonical
+# client path — shared by golden replay (snapshot build) and the live env pool.
+_MCP_CALL_SNIPPET = (
+    "import sys, json, asyncio\n"
+    "from mcp.client.sse import sse_client\n"
+    "from mcp import ClientSession\n"
+    "async def _main():\n"
+    "    url, name, args = sys.argv[1], sys.argv[2], json.loads(sys.argv[3])\n"
+    "    async with sse_client(url) as (r, w):\n"
+    "        async with ClientSession(r, w) as s:\n"
+    "            await s.initialize()\n"
+    "            res = await s.call_tool(name, args)\n"
+    "            out = {\n"
+    "                'isError': bool(getattr(res, 'isError', False)),\n"
+    "                'content': [getattr(c, 'text', str(c)) for c in (res.content or [])],\n"
+    "            }\n"
+    "            print('__RESULT__' + json.dumps(out))\n"
+    "asyncio.run(_main())\n"
+)
+
+# Run the `local-python-execute` aux tool. Unlike the MCP server tools, the Toolathlon "local" tools
+# are agent-side FunctionTools (not gateway-exposed), so we run them directly here, mirroring upstream:
+# write the code under {ws}/.python_tmp and `uv run` it in the workspace. argv: ws, filename, b64(code), timeout.
+_LOCAL_PY_SNIPPET = (
+    "import os, sys, json, base64, subprocess\n"
+    "ws, fn, b64, timeout = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])\n"
+    "tmp = os.path.join(ws, '.python_tmp'); os.makedirs(tmp, exist_ok=True)\n"
+    "open(os.path.join(tmp, fn), 'w', encoding='utf-8').write(base64.b64decode(b64).decode())\n"
+    "try:\n"
+    "    r = subprocess.run(f'uv run --directory {ws} ./.python_tmp/{fn}', shell=True, "
+    "capture_output=True, text=True, timeout=timeout)\n"
+    "    parts = []\n"
+    "    if r.stdout: parts += ['=== STDOUT ===', r.stdout.rstrip()]\n"
+    "    if r.stderr: parts += ['=== STDERR ===', r.stderr.rstrip()]\n"
+    "    parts += ['=== EXECUTION INFO ===', f'Return code: {r.returncode}']\n"
+    "    print('__RESULT__' + json.dumps({'isError': False, 'content': ['\\n'.join(parts)]}))\n"
+    "except subprocess.TimeoutExpired:\n"
+    "    print('__RESULT__' + json.dumps({'isError': False, "
+    "'content': [f'=== EXECUTION TIMEOUT === after {timeout}s']}))\n"
+)
+
+
+def _trajlog_snippet(config: ToolathlonEnvConfig) -> str:
+    """Synthesize the dump_line (traj_log.json) that ``container_eval`` consumes.
+
+    We don't run Toolathlon's host agent loop (the agent drives tools directly), so we reconstruct the
+    same TaskConfig preprocess built and write {config, status=SUCCESS}. status=SUCCESS forces the
+    workspace-vs-groundtruth check to run -> that pass/fail IS the terminal verdict. argv: task_dir, out_path.
+    """
+    return (
+        "import sys, json, os\n"
+        "from utils.task_runner.runner import TaskRunner\n"
+        "from utils.data_structures.task_config import TaskConfig\n"
+        "from utils.roles.task_agent import TaskStatus\n"
+        "task_dir, out_path = sys.argv[1], sys.argv[2]\n"
+        f"ec = json.load(open('{config.eval_config}'))\n"
+        "agent_config = TaskRunner.load_configs(ec)[1]\n"
+        "tc = TaskConfig.build(task_dir, agent_config.model.short_name, ec['global_task_config'], "
+        "single_turn_mode=True, cn_mode=False)\n"
+        "tc.log_file = os.path.join(tc.task_root, 'traj_log.json')\n"
+        "tc.agent_workspace = os.path.join(tc.task_root, 'workspace')\n"
+        "json.dump({'config': tc.to_dict(), 'status': TaskStatus.SUCCESS.value}, open(out_path, 'w'))\n"
+        "print('__TRAJLOG_OK__')\n"
+    )
+
+
+def _patch_config_snippet(config: ToolathlonEnvConfig) -> str:
+    # Patch the run config so task_root is exactly snapshot_root (direct_to_dumps + dump_path) — makes
+    # the workspace path deterministic (no model-name/turn components) so builder + pool agree.
+    return (
+        "import json; d=json.load(open('scripts/formal_run_v0.json')); "
+        "g=d.setdefault('global_task_config', {}); "
+        f"g['dump_path']='{config.snapshot_root}'; g['direct_to_dumps']=True; "
+        f"json.dump(d, open('{config.eval_config}','w'), indent=2)"
+    )
+
+
+# ── Tool dispatch ─────────────────────────────────────────────────────────
+
+
+def _absolutize_excel_paths(
+    config: ToolathlonEnvConfig, name: str, arguments: dict
+) -> dict:
+    """Rewrite relative spreadsheet paths to absolute for excel-* tools.
+
+    The excel MCP server runs in stdio mode here, which requires *absolute* file paths; the expert
+    trajectories pass workspace-relative names (the original run used excel in SSE mode).
+    """
+    if not name.startswith("excel-"):
+        return arguments
+    exts = (".xlsx", ".xls", ".xlsm", ".csv")
+
+    def _fix(v):
+        if isinstance(v, str) and not v.startswith("/") and v.lower().endswith(exts):
+            return f"{config.workspace_path}/{v}"
+        return v
+
+    return {k: _fix(v) for k, v in arguments.items()}
+
+
+def dispatch_tool(
+    sandbox: Any, config: ToolathlonEnvConfig, action: Action
+) -> Observation:
+    """Run one tool call inside ``sandbox`` and return an :class:`Observation`.
+
+    ``local-*`` tools are the agent's aux tools (not gateway-exposed): ``claim_done`` is a no-op done
+    signal, ``python-execute`` runs code in the workspace. Everything else goes through the MCP gateway
+    over localhost.
+    """
+    name = action.name
+    arguments = _absolutize_excel_paths(config, name, action.arguments or {})
+    if name == "local-claim_done":
+        return Observation(text="task marked done", is_error=False)
+    if name == "local-python-execute":
+        fn = str(arguments.get("filename") or "snippet.py")
+        if not fn.endswith(".py"):
+            fn += ".py"
+        timeout = min(int(arguments.get("timeout", 30) or 30), 120)
+        b64 = base64.b64encode(str(arguments.get("code", "")).encode()).decode()
+        proc = sandbox.exec(
+            config.pybin,
+            "-c",
+            _LOCAL_PY_SNIPPET,
+            config.workspace_path,
+            fn,
+            b64,
+            str(timeout),
+        )
+    else:
+        proc = sandbox.exec(
+            config.pybin,
+            "-c",
+            _MCP_CALL_SNIPPET,
+            config.gateway_sse_url,
+            name,
+            json.dumps(arguments),
+        )
+    proc.wait()
+    for line in proc.stdout.read().splitlines():
+        if line.startswith("__RESULT__"):
+            out = json.loads(line[len("__RESULT__") :])
+            return Observation(
+                text="\n".join(out.get("content", [])),
+                is_error=bool(out.get("isError")),
+            )
+    return Observation(text=proc.stderr.read()[:500], is_error=True)
+
+
+# ── Gateway lifecycle (inside the sandbox) ──────────────────────────────────
+
+
+def _await_gateway(
+    sandbox: Any, config: ToolathlonEnvConfig, attempts: int = 60
+) -> bool:
+    """Block until the in-sandbox gateway answers /health (servers spawned + ready)."""
+    import time
+
+    for _ in range(attempts):
+        proc = sandbox.exec("curl", "-fsS", config.gateway_health_url)
+        proc.wait()
+        if proc.returncode == 0:
+            return True
+        time.sleep(1)
+    return False
+
+
+def _start_gateway(sandbox: Any, config: ToolathlonEnvConfig) -> None:
+    """Start the MCP gateway process (spawns the stdio MCP servers rooted at the workspace)."""
+    sandbox.exec(
+        config.pybin,
+        "-m",
+        "scripts.decoupled.container_tool_gateway",
+        "--bundle_file",
+        config.bundle_path,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(config.gateway_port),
+    )  # background process inside the sandbox
+
+
+def _seed_workspace(sandbox: Any, config: ToolathlonEnvConfig, task_dir: str) -> None:
+    """Preprocess (seed workspace) + synthesize the eval dump_line + start the gateway.
+
+    The gateway spawns the stdio MCP servers rooted at the workspace, so it must be started *after*
+    the workspace exists. Both gateway and any in-sandbox client talk over localhost.
+    """
+    # Preprocess seeds the workspace and writes the bundle (into the workspace, so it travels in the
+    # directory snapshot). direct_to_dumps in eval_config pins task_root == snapshot_root.
+    proc = sandbox.exec(
+        config.pybin,
+        "-m",
+        "scripts.decoupled.container_preprocess",
+        "--eval_config",
+        config.eval_config,
+        "--task_dir",
+        task_dir,
+        "--bundle_file",
+        config.bundle_path,
+    )
+    proc.wait()
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"preprocess failed for {task_dir}: {proc.stderr.read()[:800]}"
+        )
+    # Synthesize traj_log.json so container_eval can score the workspace (we drive tools ourselves).
+    proc = sandbox.exec(
+        config.pybin, "-c", _trajlog_snippet(config), task_dir, config.traj_log_path
+    )
+    proc.wait()
+    if "__TRAJLOG_OK__" not in proc.stdout.read():
+        raise RuntimeError(
+            f"traj_log synthesis failed for {task_dir}: {proc.stderr.read()[:800]}"
+        )
+    _start_gateway(sandbox, config)
+    if not _await_gateway(sandbox, config):
+        raise RuntimeError("gateway did not become ready")
+
+
+# ── Base image (built lazily, cached per config) ────────────────────────────
+
+_IMAGE_CACHE: dict[ToolathlonEnvConfig, Any] = {}
+
+
+def build_env_image(config: ToolathlonEnvConfig = DEFAULT_CONFIG) -> Any:
+    """The CPU image: Toolathlon task image + decoupled scripts + uv-locked Python deps.
+
+    The base image ships node+npm (MCP servers run via npx) and `uv`, but *no* Python packages — the
+    decoupled gateway/preprocess/eval expect a `uv sync`'d venv. The lockfile has no torch/GPU deps,
+    so this stays lightweight. Cached per config to avoid redundant builds.
+    """
+    import modal
+
+    if config not in _IMAGE_CACHE:
+        _IMAGE_CACHE[config] = (
+            modal.Image.from_registry(config.image)
+            .apt_install("git", "curl")
+            .run_commands(
+                f"git clone --depth 1 -b {config.commit} "
+                "https://github.com/hkust-nlp/Toolathlon /opt/toolathlon",
+                # Materialize Toolathlon's locked deps into the venv (gateway needs aiohttp-sse/pyyaml/
+                # mcp; eval needs openai-agents; MCP servers are pre-fetched).
+                "cd /opt/toolathlon && /root/.local/bin/uv sync --frozen",
+                # Decoupled scripts import configs.global_configs / token_key_session — the repo ships
+                # only *_example.py; copy them (placeholder keys are fine for Tier A, no external APIs).
+                "cp /opt/toolathlon/configs/global_configs_example.py /opt/toolathlon/configs/global_configs.py",
+                "cp /opt/toolathlon/configs/token_key_session_example.py /opt/toolathlon/configs/token_key_session.py",
+                f'cd /opt/toolathlon && {config.pybin} -c "{_patch_config_snippet(config)}"',
+            )
+            # PYTHONPATH so `scripts`/`utils` import; VIRTUAL_ENV pins the venv; PATH puts venv + uv first.
+            .env(
+                {
+                    "PYTHONPATH": "/opt/toolathlon",
+                    "VIRTUAL_ENV": config.venv,
+                    "PATH": f"{config.venv}/bin:/root/.local/bin:/usr/local/sbin:"
+                    "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                }
+            )
+            .workdir("/opt/toolathlon")
+        )
+    return _IMAGE_CACHE[config]
+
+
+# ── Environment + pool ──────────────────────────────────────────────────────
+
+
+class ToolathlonEnvironment(SandboxEnvironment):
+    """One live Toolathlon episode backed by a Modal sandbox running the MCP gateway."""
+
+    def __init__(
+        self, sandbox: Any, config: ToolathlonEnvConfig, task_name: str
+    ) -> None:
+        super().__init__(sandbox)
+        self.config = config
+        self.task_name = task_name
+
+    def step(self, action: Action) -> StepResult:
+        """Execute one tool call against the live MCP server; ``done`` on a terminal action."""
+        obs = dispatch_tool(self.sandbox, self.config, action)
+        return StepResult(observation=obs, done=action.name in DONE_TOOLS)
+
+    def evaluate(self) -> EvalVerdict:
+        """Score the restored workspace via Toolathlon's ``container_eval`` (exit 0 == pass).
+
+        container_eval reads the synthesized traj_log (status=SUCCESS) and runs the task's
+        workspace-vs-groundtruth check. Upstream ends with ``raise SystemExit(0 if pass else 1)``, so
+        the exit code IS the verdict. It prints "Evaluation finished." just before exiting; a non-zero
+        exit WITHOUT that marker means the evaluator itself crashed (bad bundle / harness error), not a
+        legitimate task failure — flagged via ``harness_error`` so it isn't scored as a task failure.
+        """
+        proc = self.sandbox.exec(
+            self.config.pybin,
+            "-m",
+            "scripts.decoupled.container_eval",
+            "--bundle_file",
+            self.config.bundle_path,
+        )
+        proc.wait()
+        passed = proc.returncode == 0
+        out = proc.stdout.read()
+        if passed:
+            return EvalVerdict(passed=True)
+        if "Evaluation finished." not in out:
+            return EvalVerdict(
+                passed=False,
+                harness_error=True,
+                detail=f"container_eval crashed (rc={proc.returncode}): {proc.stderr.read()[:500]}",
+            )
+        detail = " | ".join(
+            ln.strip()
+            for ln in out.splitlines()
+            if ln.startswith(("Details:", "Failure:"))
+        )
+        return EvalVerdict(passed=False, detail=detail[:500])
+
+
+class ToolathlonEnvPool(SandboxEnvironmentPool):
+    """Per-acquire sandbox pool that restores ``(task, K)`` from a directory snapshot.
+
+    Each :meth:`acquire` creates a fresh sandbox from the cached image, mounts the ``(task, K)``
+    snapshot, and starts the gateway. We do *not* reuse sandboxes via ``unmount_image`` — unmounting an
+    in-use snapshot mount fails on Modal's backend with an InternalError (same beta limitation as the
+    mount-of-a-plain-dir bug) — so :meth:`release` terminates the sandbox; creation from the cached
+    image (no rebuild) is cheap.
+    """
+
+    def __init__(self, config: ToolathlonEnvConfig = DEFAULT_CONFIG) -> None:
+        super().__init__()
+        self.config = config
+        self.app_name = config.sandbox_app
+        self.snapshots = DirectorySnapshotLibrary(
+            config.snapshot_catalog, config.snapshot_root
+        )
+
+    def build_image(self) -> Any:
+        return build_env_image(self.config)
+
+    def acquire(self, task_name: str, k: int) -> ToolathlonEnvironment:
+        sandbox = self.create_sandbox(timeout=60 * 30, cpu=2.0, memory=4096)
+        # Mount the (task, K) directory snapshot (workspace + bundle + traj_log) and start the gateway
+        # (a process, not captured by the snapshot).
+        self.snapshots.mount(sandbox, task_name, k)
+        _start_gateway(sandbox, self.config)
+        _await_gateway(sandbox, self.config, attempts=40)
+        return ToolathlonEnvironment(sandbox, self.config, task_name)
+
+
+# Lazily-created module-level pool, shared across rollouts in a worker.
+_ENV_POOL_CACHE: dict[ToolathlonEnvConfig, ToolathlonEnvPool] = {}
+
+
+def get_env_pool(config: ToolathlonEnvConfig = DEFAULT_CONFIG) -> ToolathlonEnvPool:
+    """Process-wide :class:`ToolathlonEnvPool` for ``config`` (created lazily)."""
+    if config not in _ENV_POOL_CACHE:
+        _ENV_POOL_CACHE[config] = ToolathlonEnvPool(config)
+    return _ENV_POOL_CACHE[config]
+
+
+# ── Snapshot library builder (offline, once) ────────────────────────────────
+
+
+def build_task_snapshots(
+    task_name: str,
+    golden_calls: list[dict],
+    config: ToolathlonEnvConfig = DEFAULT_CONFIG,
+) -> int:
+    """Snapshot the workspace at every step K of one task's golden trajectory.
+
+    K=0 is the pristine post-preprocess state; K=n is after the n-th golden call. Replaying a golden
+    call advances env state only — the prompt text still comes from the original trace.
+    """
+    import modal
+
+    app = modal.App.lookup(config.sandbox_app, create_if_missing=True)
+    sandbox = modal.Sandbox.create(
+        "sleep", "infinity", image=build_env_image(config), app=app, timeout=60 * 60
+    )
+    snapshots = DirectorySnapshotLibrary(config.snapshot_catalog, config.snapshot_root)
+
+    def _seed(sb: Any) -> None:
+        _seed_workspace(sb, config, f"finalpool/{task_name}")
+
+    def _advance(sb: Any, step: int) -> None:
+        call = golden_calls[step]
+        obs = dispatch_tool(sb, config, Action(call["name"], call.get("arguments", {})))
+        if (
+            obs.is_error
+        ):  # surface a broken gateway/tool immediately, don't emit identical snapshots
+            raise RuntimeError(
+                f"golden replay '{call['name']}' errored: {obs.text[:500]}"
+            )
+
+    try:
+        return snapshots.build_item(
+            sandbox, task_name, len(golden_calls), _seed, _advance
+        )
+    finally:
+        sandbox.terminate()
+
+
+# Parallel builder: a lightweight CPU Modal Function that builds one task's snapshots (spawning its own
+# env sandbox). Mapping it over the tasks builds them all concurrently.
+def _builder_app():
+    import modal
+
+    return modal.App(f"{DEFAULT_CONFIG.sandbox_app}-builder")
+
+
+def build_snapshot_library(
+    task_to_golden: dict[str, list[dict]], config: ToolathlonEnvConfig = DEFAULT_CONFIG
+) -> None:
+    """Build the ``(task, K)`` snapshot catalog, one Modal container per task, in parallel.
+
+    Resumable: a task is skipped if its final snapshot (K = len(golden)) is already cataloged, so
+    re-runs after a partial build (or a TTL refresh of only some tasks) are cheap.
+    """
+    import modal
+
+    snapshots = DirectorySnapshotLibrary(config.snapshot_catalog, config.snapshot_root)
+    pending = []
+    for task_name, golden_calls in task_to_golden.items():
+        if snapshots.has(task_name, len(golden_calls)):
+            print(
+                f"  {task_name}: already cataloged ({len(golden_calls) + 1}), skipping"
+            )
+        else:
+            pending.append((task_name, golden_calls))
+    if not pending:
+        return
+
+    app = modal.App(f"{config.sandbox_app}-builder")
+
+    @app.function(
+        image=modal.Image.debian_slim(python_version="3.12").pip_install(
+            "modal~=1.4.3"
+        ),
+        timeout=60 * 60,
+        max_containers=16,
+        serialized=True,
+    )
+    def _build_one(item: tuple) -> tuple:
+        task_name, golden_calls = item
+        return task_name, build_task_snapshots(task_name, golden_calls, config)
+
+    print(f"  building {len(pending)} task(s) in parallel...")
+    with app.run():
+        for task_name, n in _build_one.map(pending):
+            print(f"  {task_name}: cataloged {n} (task, K) snapshots")
+
+
+# ── Trajectory dataset ──────────────────────────────────────────────────────
+
+
+class ToolathlonTrajectoryDataset(DatasetConfig):
+    """Expert Toolathlon trajectories as a one-row-per-task training dataset.
+
+    Each row carries the compact golden trajectory in its ``label``; the rollout/eval pick a start step
+    K at call time and rebuild the step-K prefix via :func:`build_prefix_messages` / :func:`prune_prefix`.
+    The original workspace path in the raw trace is remapped onto ``config.workspace_path`` so replay
+    and student tool calls resolve.
+
+    Configure via kwargs: ``hf_repo``, ``source_file`` (the trajectory file in the repo),
+    ``train_tasks`` / ``eval_tasks`` (task-name allowlists per split), ``obs_limit``.
+    """
+
+    input_key = "messages"
+    label_key = "label"
+    output_format = "jsonl"
+    apply_chat_template = True
+
+    hf_repo: str = "hkust-nlp/Toolathlon-Trajectories"
+    source_file: str = "deepseek-v3.2-exp_1.jsonl"
+    train_tasks: tuple[str, ...] = ()
+    eval_tasks: tuple[str, ...] = ()
+    obs_limit: int = 1500  # truncate each observation to N chars in context
+
+    def __init__(
+        self,
+        split: str = "train",
+        config: ToolathlonEnvConfig = DEFAULT_CONFIG,
+        **kwargs: Any,
+    ) -> None:
+        self._split = split
+        self.config = config
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def _tasks_for_split(self) -> set[str]:
+        return set(self.eval_tasks if self._split == "eval" else self.train_tasks)
+
+    def _load_trajectories(self) -> list[dict]:
+        from huggingface_hub import hf_hub_download
+
+        path = hf_hub_download(
+            repo_id=self.hf_repo, filename=self.source_file, repo_type="dataset"
+        )
+        keep = self._tasks_for_split()
+        trajectories = []
+        with open(path) as f:
+            for line in f:
+                traj = json.loads(line)
+                if keep and traj.get("task_name") not in keep:
+                    continue
+                # Remap the original workspace prefix -> our workspace_path on the raw serialized
+                # trajectory (covers golden-call args, observations, and the task text in one pass,
+                # including arguments stored as nested JSON strings).
+                raw_msgs = (traj.get("messages") or "[]").replace(
+                    self.config.orig_workspace, self.config.workspace_path
+                )
+                msgs = json.loads(raw_msgs)
+                if len(msgs) < 3:
+                    continue
+                trajectories.append(
+                    {
+                        "task_name": traj["task_name"],
+                        "messages": msgs,
+                        "tool_calls_meta": json.loads(traj.get("tool_calls", "{}"))
+                        if traj.get("tool_calls")
+                        else {},
+                    }
+                )
+        return trajectories
+
+    def _golden_calls(self, msgs: list[dict]) -> list[dict]:
+        """The ordered list of expert (golden) tool calls in a trajectory."""
+        calls = []
+        for m in msgs:
+            if m.get("role") == "assistant" and m.get("tool_calls"):
+                tc = m["tool_calls"]
+                if tc and isinstance(tc[0], dict) and "function" in tc[0]:
+                    fn = tc[0]["function"]
+                    args = fn.get("arguments", "{}")
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except json.JSONDecodeError:
+                            args = {}
+                    calls.append({"name": fn["name"], "arguments": args})
+        return calls
+
+    def _observations(self, msgs: list[dict]) -> list[str]:
+        """Ordered tool observations (one per executed call), truncated to ``obs_limit``."""
+        return [
+            str(m.get("content", ""))[: self.obs_limit]
+            for m in msgs
+            if m.get("role") == "tool"
+        ]
+
+    def _task_request(self, msgs: list[dict]) -> str:
+        for m in msgs:
+            if m.get("role") == "user" and str(m.get("content", "")).strip():
+                return str(m["content"])
+        return ""
+
+    def _tool_schemas(self, trajectory: dict) -> dict:
+        # The exact tool catalog the expert was given via the OpenAI tools= param (gateway tools/list).
+        # name -> {description, parameters} so the prompt can show which tools exist + their args.
+        schemas = {}
+        for t in trajectory.get("tool_calls_meta", {}).get("tools", []):
+            if isinstance(t, dict) and "function" in t:
+                fn = t["function"]
+                schemas[fn["name"]] = {
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+        return schemas
+
+    def _make_row(self, trajectory: dict) -> dict:
+        msgs = trajectory["messages"]
+        golden = self._golden_calls(msgs)
+        task_user = self._task_request(msgs)
+        label = json.dumps(
+            {
+                "task_name": trajectory["task_name"],
+                "total_steps": len(golden),
+                "task_request": task_user,
+                "golden_calls": golden,
+                "observations": self._observations(msgs),
+                "tool_schemas": self._tool_schemas(trajectory),
+            }
+        )
+        # Minimal messages so the framework can load/tokenize the row; the rollout rebuilds the real
+        # step-K prefix from the label per the curriculum (sample.prompt is not used directly).
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a tool-calling agent. Output a JSON tool call.",
+            },
+            {"role": "user", "content": task_user},
+        ]
+        return {"messages": messages, "label": label}
+
+    def _load_split(self) -> list[dict]:
+        return [
+            self._make_row(t)
+            for t in self._load_trajectories()
+            if self._golden_calls(
+                t["messages"]
+            )  # skip degenerate trajectories with no tool calls
+        ]
+
+    def load(self, split: str = "all") -> list[dict]:
+        if split in ("train", "eval"):
+            self._split = split
+        return self._load_split()
+
+    def golden_by_task(self) -> dict[str, list[dict]]:
+        """Map task_name -> golden tool-call list (drives the snapshot builder)."""
+        return {
+            t["task_name"]: self._golden_calls(t["messages"])
+            for t in self._load_trajectories()
+        }
+
+    def prepare(self, path: str, eval_paths: dict | None = None) -> None:
+        import os
+
+        rows = self._load_split()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.writelines(json.dumps(r) + "\n" for r in rows)
+
+
+# ── Prompt-prefix reconstruction ────────────────────────────────────────────
+
+DEFAULT_SYSTEM_PROMPT_TEMPLATE = (
+    "You are a tool-using agent completing a task against real tools. Work one step at a time. "
+    "First, briefly explain your plan for this step in 1-3 sentences of plain prose. Then end "
+    "your reply with EXACTLY ONE JSON object and nothing after it:\n"
+    '{{"name": "<tool_name>", "arguments": {{<args>}}}}\n'
+    "Rules: keep the plan short (no <think> blocks, no step-by-step essays); use only the tools "
+    "listed below (a `*` marks a required argument); use the exact tool names; pass file paths "
+    "as given in the task; do NOT wrap the JSON in markdown or add text after it; call "
+    "`local-claim_done` when the task is complete.\n\n"
+    "## Available tools\n{catalog}"
+)
+
+
+def render_tool_catalog(tool_schemas: dict, desc_chars: int = 160) -> str:
+    """Render the available-tools catalog the agent must choose from.
+
+    The agent can't query the MCP servers itself (that's the host loop's job via tools/list + the
+    OpenAI tools= param), so we surface the exact catalog the expert saw. Compact: one line per tool —
+    ``name(arg, required*)`` + a short description.
+    """
+    lines = []
+    for name in sorted(tool_schemas or {}):
+        spec = tool_schemas[name]
+        # tolerate both {description, parameters} and bare parameters (older cached rows)
+        if isinstance(spec, dict) and ("parameters" in spec or "description" in spec):
+            desc, params = spec.get("description", ""), spec.get("parameters", {})
+        else:
+            desc, params = "", spec
+        props = (params or {}).get("properties", {}) if isinstance(params, dict) else {}
+        required = (
+            set((params or {}).get("required", []) or [])
+            if isinstance(params, dict)
+            else set()
+        )
+        sig = ", ".join(f"{k}*" if k in required else k for k in props)
+        desc = " ".join(str(desc).split())[:desc_chars]
+        lines.append(f"- {name}({sig})" + (f": {desc}" if desc else ""))
+    return "\n".join(lines)
+
+
+def default_system_prompt(tool_schemas: dict) -> str:
+    return DEFAULT_SYSTEM_PROMPT_TEMPLATE.format(
+        catalog=render_tool_catalog(tool_schemas)
+    )
+
+
+def build_prefix_messages(
+    label: dict,
+    k: int,
+    *,
+    obs_limit: int = 1500,
+    system_prompt: Callable[[dict], str] = default_system_prompt,
+) -> list[dict]:
+    """Rebuild the step-K prompt prefix from the compact trajectory in the dataset ``label``.
+
+    system (with the tool catalog) + task request + interleaved [assistant(golden call_i),
+    user(<observation>obs_i)] for i in 0..k-1. We keep only the structured tool calls (no expert prose)
+    and truncate each observation to ``obs_limit`` — matching how the prompt was constructed.
+    """
+    golden = label.get("golden_calls", [])
+    obs = label.get("observations", [])
+    msgs = [
+        {"role": "system", "content": system_prompt(label.get("tool_schemas", {}))},
+        {"role": "user", "content": label.get("task_request", "")},
+    ]
+    for i in range(min(k, len(golden))):
+        msgs.append({"role": "assistant", "content": json.dumps(golden[i])})
+        if i < len(obs):
+            msgs.append(
+                {
+                    "role": "user",
+                    "content": f"<observation>{str(obs[i])[:obs_limit]}</observation>",
+                }
+            )
+    return msgs
+
+
+def prune_prefix(
+    messages: list[dict],
+    *,
+    budget: int,
+    count_tokens: Callable[[str], int] | None = None,
+    keep_recent: int = 6,
+    old_call_chars: int = 200,
+) -> list[dict]:
+    """Recency-decayed prune of a Toolathlon prefix to fit ``budget`` content tokens.
+
+    The prefix bulk lives in two places, both in the OLD steps: bulky tool **observations**
+    (read-heavy tasks) and the bulky **arguments of old tool calls** (write/code-heavy tasks). Since
+    the snapshot restores world state, old history only needs to preserve the action *trace* + recent
+    context. So we always keep the system message + the task request + the last ``keep_recent``
+    messages verbatim, then reclaim budget from the OLDEST steps in priority order:
+
+    1. drop old observations (stale, bulky, re-readable via a tool);
+    2. truncate old tool-call arguments to ``old_call_chars`` (keep the action name + a head like the
+       file path — the cheap trace — and shed the big embedded scripts/data);
+    3. as a last resort, drop old tool calls entirely.
+
+    ``count_tokens`` measures a string's token length (pass the model tokenizer for CJK-accurate
+    sizing); it falls back to a ~3.5 chars/token heuristic. ``budget`` should already account for
+    chat-template overhead added on top of message content.
+    """
+    if count_tokens is None:
+
+        def count_tokens(s: str) -> int:  # noqa: E306
+            return int(len(str(s)) / 3.5)
+
+    sizes = [count_tokens(m.get("content", "")) for m in messages]
+    if sum(sizes) <= budget:
+        return messages
+
+    # Protected head: leading system message(s) + the first user (task) message.
+    head = 0
+    while head < len(messages) and messages[head].get("role") == "system":
+        head += 1
+    if head < len(messages) and messages[head].get("role") == "user":
+        head += 1
+    tail_start = max(head, len(messages) - keep_recent)
+    old = list(range(head, tail_start))
+
+    def _is_obs(m):
+        return m.get("role") == "user" and str(m.get("content", "")).startswith(
+            "<observation>"
+        )
+
+    cur = sum(sizes)
+    to_drop: set[int] = set()
+    truncated: dict[int, str] = {}
+
+    # Tier 1: drop old observations (oldest first).
+    for i in old:
+        if cur <= budget:
+            break
+        if _is_obs(messages[i]):
+            cur -= sizes[i]
+            to_drop.add(i)
+    # Tier 2: truncate old tool-call arguments (oldest first), preserving the name + head.
+    for i in old:
+        if cur <= budget:
+            break
+        if i in to_drop or messages[i].get("role") != "assistant":
+            continue
+        c = str(messages[i].get("content", ""))
+        if len(c) > old_call_chars:
+            new = c[:old_call_chars] + " …"
+            cur -= sizes[i] - count_tokens(new)
+            truncated[i] = new
+    # Tier 3 (last resort): drop old tool calls entirely (oldest first).
+    for i in old:
+        if cur <= budget:
+            break
+        if i in to_drop or messages[i].get("role") != "assistant":
+            continue
+        cur -= count_tokens(truncated[i]) if i in truncated else sizes[i]
+        to_drop.add(i)
+
+    out = []
+    for i, msg in enumerate(messages):
+        if i in to_drop:
+            continue
+        if i in truncated:
+            msg = {**msg, "content": truncated[i]}
+        out.append(msg)
+    return out

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -34,13 +34,13 @@ from typing import Any, Callable
 
 from modal_training_gym.common.dataset import DatasetConfig
 from modal_training_gym.common.environments.base import (
-    Action,
     DirectorySnapshotLibrary,
     EvalVerdict,
     Observation,
     SandboxEnvironment,
     SandboxEnvironmentPool,
     StepResult,
+    ToolCall,
 )
 
 # MCP servers whose state is confined to the agent workspace (snapshot-safe "Tier A").
@@ -229,7 +229,7 @@ def _absolutize_excel_paths(
 
 
 def dispatch_tool(
-    sandbox: Any, config: ToolathlonEnvConfig, action: Action
+    sandbox: Any, config: ToolathlonEnvConfig, action: ToolCall
 ) -> Observation:
     """Run one tool call inside ``sandbox`` and return an :class:`Observation`.
 
@@ -404,7 +404,7 @@ class ToolathlonEnvironment(SandboxEnvironment):
         self.config = config
         self.task_name = task_name
 
-    def step(self, action: Action) -> StepResult:
+    def step(self, action: ToolCall) -> StepResult:
         """Execute one tool call against the live MCP server; ``done`` on a terminal action."""
         obs = dispatch_tool(self.sandbox, self.config, action)
         return StepResult(observation=obs, done=action.name in DONE_TOOLS)
@@ -512,7 +512,9 @@ def build_task_snapshots(
 
     def _advance(sb: Any, step: int) -> None:
         call = golden_calls[step]
-        obs = dispatch_tool(sb, config, Action(call["name"], call.get("arguments", {})))
+        obs = dispatch_tool(
+            sb, config, ToolCall(call["name"], call.get("arguments", {}))
+        )
         if (
             obs.is_error
         ):  # surface a broken gateway/tool immediately, don't emit identical snapshots


### PR DESCRIPTION
Adds environment module with base data classes for an environment, steps, actions, tool results, and observations. Includes helpful classes for defining a pool of environments, which can live on Modal sandboxes, and creating filesystem & directory snapshots (useful for replaying expert trajectories and capturing state at each step). 

Implements [Toolathalon.xyz](https://toolathlon.xyz/introduction) sandbox environments.

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
