### PR TITLE
Bump Harbor version + Use Harbor without cursed resources

### DIFF
--- a/modal_training_gym/common/eval.py
+++ b/modal_training_gym/common/eval.py
@@ -389,6 +389,41 @@ def extract_code(text: str, model: "ModelConfig | None" = None) -> str:
     return content
 
 
+# Modal's per-container default resource request (modal.com/docs/guide/resources).
+# Used as the request "floor" for the "limit" enforcement policy so sandboxes bill by
+# actual CPU-/RAM-second usage rather than a static reservation.
+_MODAL_DEFAULT_CPU_REQUEST = 0.125
+_MODAL_DEFAULT_MEMORY_REQUEST = 128  # MiB
+
+#: Accepted CPU/memory enforcement policies, mirroring Harbor v0.8.0's ``--cpus`` /
+#: ``--memory`` flags. Modal bills for ``max(request, actual usage)``, so reserving more
+#: than a sandbox uses over-provisions and inflates cost.
+RESOURCE_POLICIES = ("reserve", "limit", "ignore")
+
+
+def _sandbox_resource(
+    value: float, policy: str, default_request: float
+) -> float | tuple[float, float] | None:
+    """Translate a Harbor-style enforcement *policy* into a Modal cpu/memory kwarg.
+
+    - ``"reserve"`` — reserve *value* outright (billed for the full reservation, even
+      when idle). This is the static-reservation behavior that over-provisions on Modal.
+    - ``"limit"`` — request the small Modal default and cap bursting at *value*, so the
+      sandbox is billed by actual usage up to that ceiling.
+    - ``"ignore"`` — no enforcement; returns ``None`` so the caller omits the kwarg and
+      the sandbox bursts freely on Modal's default request, billed by actual usage.
+    """
+    if policy == "reserve":
+        return value
+    if policy == "limit":
+        return (min(default_request, value), value)
+    if policy == "ignore":
+        return None
+    raise ValueError(
+        f"invalid resource policy {policy!r}; expected one of {RESOURCE_POLICIES}"
+    )
+
+
 def score_in_sandbox(
     code: str,
     *,
@@ -397,12 +432,21 @@ def score_in_sandbox(
     sandbox_cpu: float = 1.0,
     sandbox_memory: int = 1024,
     python_version: str = "3.11",
+    cpu_policy: str = "limit",
+    memory_policy: str = "limit",
 ) -> tuple[float, dict[str, Any]]:
     """Run *code* against *test_cases* in a Modal sandbox.
 
     Each test case is a dict with ``input`` and ``expected_output`` keys.
     The code is executed once per test case with the input piped to stdin.
     Returns ``(fraction_passed, metadata_dict)``.
+
+    ``cpu_policy`` and ``memory_policy`` control how ``sandbox_cpu`` / ``sandbox_memory``
+    are enforced on Modal (see :data:`RESOURCE_POLICIES`). The default ``"limit"`` treats
+    them as burst ceilings rather than reservations, so the sandbox is billed by actual
+    CPU-/RAM-second usage instead of over-provisioning a static reservation. Use
+    ``"ignore"`` to let tasks burst above the configured values, or ``"reserve"`` for the
+    legacy fixed-reservation behavior.
     """
     import modal
 
@@ -443,16 +487,26 @@ def score_in_sandbox(
 
     app = modal.App.lookup("training-gym-sandbox-rm", create_if_missing=True)
     image = modal.Image.debian_slim(python_version=python_version)
+
+    resource_kwargs: dict[str, Any] = {}
+    cpu_arg = _sandbox_resource(sandbox_cpu, cpu_policy, _MODAL_DEFAULT_CPU_REQUEST)
+    if cpu_arg is not None:
+        resource_kwargs["cpu"] = cpu_arg
+    memory_arg = _sandbox_resource(
+        sandbox_memory, memory_policy, _MODAL_DEFAULT_MEMORY_REQUEST
+    )
+    if memory_arg is not None:
+        resource_kwargs["memory"] = memory_arg
+
     sb = modal.Sandbox.create(
         "python",
         "-c",
         runner,
         cases_payload,
         image=image,
-        cpu=sandbox_cpu,
-        memory=sandbox_memory,
         timeout=timeout_sec,
         app=app,
+        **resource_kwargs,
     )
     sb.wait()
 
@@ -489,6 +543,8 @@ class HarborEval(EvalConfig):
     sandbox_timeout: int = 60
     sandbox_cpu: float = 1.0
     sandbox_memory: int = 1024
+    sandbox_cpu_policy: str = "limit"
+    sandbox_memory_policy: str = "limit"
     sandbox_python_version: str = "3.11"
     extract_code_fn: Callable[[str], str] | None = None
 
@@ -544,6 +600,8 @@ class HarborEval(EvalConfig):
             timeout_sec=self.sandbox_timeout,
             sandbox_cpu=self.sandbox_cpu,
             sandbox_memory=self.sandbox_memory,
+            cpu_policy=self.sandbox_cpu_policy,
+            memory_policy=self.sandbox_memory_policy,
             python_version=self.sandbox_python_version,
         )
 

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -47,7 +47,10 @@ from modal_training_gym.frameworks.miles.modal_helpers.utils import (
 )
 
 MILES_ROOT = "/root/miles"
-HARBOR_PKG_VERSION = "0.6.6"
+# v0.8.0+ makes per-task CPU/memory requests configurable via enforcement
+# policies ("limit"/"ignore"), letting sandboxes burst on Modal and bill by
+# actual CPU-/RAM-second usage instead of over-provisioning a static reservation.
+HARBOR_PKG_VERSION = "0.8.0"
 
 _MILES_PATCHES = Path(__file__).parent / "modal_helpers" / "patches"
 _PATCH_SGLANG_ABORT_B64 = encode_patch("patch_sglang_abort", _MILES_PATCHES)

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -73,7 +73,10 @@ from modal_training_gym.common.framework import Framework
 SLIME_ROOT = "/root/slime"
 # Pin by digest to prevent mutable-tag drift.  Tag: nightly-dev-20260529a
 SLIME_IMAGE = "slimerl/slime@sha256:087a57732cf4fb271729df47530b01a9530144f4339247efc422f03e2b6988e1"
-HARBOR_PKG_VERSION = "0.6.6"
+# v0.8.0+ makes per-task CPU/memory requests configurable via enforcement
+# policies ("limit"/"ignore"), letting sandboxes burst on Modal and bill by
+# actual CPU-/RAM-second usage instead of over-provisioning a static reservation.
+HARBOR_PKG_VERSION = "0.8.0"
 
 _SLIME_PATCHES = Path(__file__).parent / "modal_helpers" / "patches"
 _PATCH_VALIDATION_B64 = encode_patch("patch_validation", _SLIME_PATCHES)

--- a/tutorials/rl/001_sandboxes/001_sandboxes.ipynb
+++ b/tutorials/rl/001_sandboxes/001_sandboxes.ipynb
@@ -211,7 +211,15 @@
     "\n",
     "For training, we reuse the same `score_in_sandbox` and `extract_code`\n",
     "helpers that `HarborEval` uses internally \u2014 wrapped in an async\n",
-    "reward function for SLIME's `custom_rm_function`."
+    "reward function for SLIME's `custom_rm_function`.\n",
+    "\n",
+    "`score_in_sandbox` enforces `sandbox_cpu`/`sandbox_memory` with a\n",
+    "`\"limit\"` policy by default: rather than reserving that capacity up\n",
+    "front, the values become burst ceilings, so Modal bills each sandbox\n",
+    "by actual CPU-/RAM-second usage instead of the (usually idle)\n",
+    "reservation. Pass `cpu_policy=\"ignore\"` to let rollouts burst above\n",
+    "the configured values, or `\"reserve\"` for the legacy fixed-reservation\n",
+    "behavior."
    ]
   },
   {

--- a/tutorials/rl/001_sandboxes/001_sandboxes.py
+++ b/tutorials/rl/001_sandboxes/001_sandboxes.py
@@ -81,6 +81,14 @@ base_model = Qwen3_4B()
 # For training, we reuse the same `score_in_sandbox` and `extract_code`
 # helpers that `HarborEval` uses internally — wrapped in an async
 # reward function for SLIME's `custom_rm_function`.
+#
+# `score_in_sandbox` enforces `sandbox_cpu`/`sandbox_memory` with a
+# `"limit"` policy by default: rather than reserving that capacity up
+# front, the values become burst ceilings, so Modal bills each sandbox
+# by actual CPU-/RAM-second usage instead of the (usually idle)
+# reservation. Pass `cpu_policy="ignore"` to let rollouts burst above
+# the configured values, or `"reserve"` for the legacy fixed-reservation
+# behavior.
 
 async def sandbox_rm(args, sample, **kwargs) -> float:
     import asyncio

--- a/tutorials/tutorial_generator/rl/001_sandboxes.py
+++ b/tutorials/tutorial_generator/rl/001_sandboxes.py
@@ -178,6 +178,14 @@ def _train_intro():
     For training, we reuse the same `score_in_sandbox` and `extract_code`
     helpers that `HarborEval` uses internally — wrapped in an async
     reward function for SLIME's `custom_rm_function`.
+
+    `score_in_sandbox` enforces `sandbox_cpu`/`sandbox_memory` with a
+    `"limit"` policy by default: rather than reserving that capacity up
+    front, the values become burst ceilings, so Modal bills each sandbox
+    by actual CPU-/RAM-second usage instead of the (usually idle)
+    reservation. Pass `cpu_policy="ignore"` to let rollouts burst above
+    the configured values, or `"reserve"` for the legacy fixed-reservation
+    behavior.
     """
 
 


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
