### PR TITLE
Fix 27B tutorial NCCL NVLS error

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -732,6 +732,7 @@ def build_slime_app(
             )
 
         env = {**os.environ, **slime.environment}
+        env.pop("NCCL_NVLS_ENABLE", None)
         if num_nodes > 1:
             env["SKIP_RELEASE_RENAME"] = "1"
         print(


### PR DESCRIPTION
The one-shot convert_checkpoint torchrun inherits NCCL_NVLS_ENABLE=1 from the Slime recipe environment. On hosts with a broken Fabric Manager / NVSwitch state, force-enabling NVLS turns a recoverable multicast bind failure (CUDA error 401) into a fatal NCCL init error, killing the run before training starts. Dropping the forced flag lets NCCL auto-detect NVLS and fall back gracefully. Training env is unchanged.
