### PR TITLE
Ensure gym dashboard is deployed on train() and evaluate()

### DIFF
--- a/modal_training_gym/common/eval.py
+++ b/modal_training_gym/common/eval.py
@@ -302,8 +302,12 @@ class EvalConfig:
         debug: bool = False,
         max_concurrency: int = 1,
     ) -> EvalResult:
+        from modal_training_gym.setup import ensure_dashboard_deployed
+
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be >= 1")
+
+        ensure_dashboard_deployed()
 
         self.save()
         deployment.wait_until_ready()

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -490,7 +490,14 @@ class TrainConfig:
             flush as flush_status_reporter,
         )
 
+        from modal_training_gym.setup import ensure_dashboard_deployed
+
         training_run_id = self.training_run_id
+
+        # Auto-provision the observability dashboard the first time anyone
+        # runs a training job. Idempotent and best-effort — a deploy failure
+        # only costs status reporting, not the run itself.
+        ensure_dashboard_deployed()
 
         # Resolve the dashboard URL locally so we can pass it into the
         # container — the toml lives on the user's machine, not in Modal.

--- a/modal_training_gym/setup.py
+++ b/modal_training_gym/setup.py
@@ -30,15 +30,23 @@ from modal_training_gym._dashboard import (
     ensure_creds_secret,
 )
 
+DASHBOARD_APP_NAME = "training-gym-dashboard"
+DASHBOARD_WEB_FUNCTION = "fastapi_app"
 
-def setup() -> str:
-    """Deploy the training-gym dashboard, persist its URL, and return it."""
+
+def setup(interactive: bool = True) -> str:
+    """Deploy the training-gym dashboard, persist its URL, and return it.
+
+    ``interactive=False`` resolves Modal credentials silently (from env vars
+    or ``~/.modal.toml``) and never prompts — used by the auto-deploy path in
+    ``TrainConfig.train()`` so a training run is never blocked on stdin.
+    """
     import modal
 
     from modal_training_gym._dashboard import app, fastapi_app
     from modal_training_gym.common.config import CONFIG_PATH, save_dashboard_url
 
-    if not ensure_creds_secret(interactive=True):
+    if not ensure_creds_secret(interactive=interactive):
         print(
             f"WARNING: continuing without the {MODAL_CREDS_SECRET_NAME!r} "
             "Modal Secret — the dashboard will not be able to stream Modal "
@@ -53,3 +61,63 @@ def setup() -> str:
     print(f"\nDashboard deployed: {web_url}")
     print(f"Saved dashboard URL to {CONFIG_PATH}")
     return web_url
+
+
+def deployed_dashboard_url() -> str | None:
+    """Return the live dashboard web URL if its app is deployed, else ``None``.
+
+    Authoritative check against Modal (not the local toml): looks up the
+    deployed ``fastapi_app`` function and returns its web URL. Any lookup
+    failure — not deployed, no credentials, network blip — yields ``None``.
+    """
+    import modal
+    from modal.exception import NotFoundError
+
+    try:
+        fn = modal.Function.from_name(DASHBOARD_APP_NAME, DASHBOARD_WEB_FUNCTION)
+        fn.hydrate()
+        return fn.get_web_url()
+    except NotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def ensure_dashboard_deployed() -> str | None:
+    """Deploy the dashboard if it isn't already; return its web URL (or ``None``).
+
+    Idempotent: if the app is already deployed we only reconcile the cached URL
+    in ``~/.training-gym.toml`` and return; we never redeploy.
+
+    Best-effort and guaranteed not to raise: this is called from the hot path
+    of ``train()`` and ``evaluate()``, where dashboard provisioning is a
+    convenience, not a precondition. Any failure — Modal deploy errors
+    (network, auth, image build, outage), a read-only/full disk on the toml
+    write, or an import error — is swallowed with a warning so the run itself
+    is never aborted. Callers therefore don't need their own try/except.
+    """
+    try:
+        from modal_training_gym.common.config import (
+            get_dashboard_url,
+            save_dashboard_url,
+        )
+
+        web_url = deployed_dashboard_url()
+        if web_url:
+            # Already deployed — keep the local toml in sync with the live URL.
+            if get_dashboard_url() != web_url:
+                save_dashboard_url(web_url)
+            return web_url
+
+        print(
+            f"Training-gym dashboard ({DASHBOARD_APP_NAME!r}) is not deployed — "
+            "deploying it now (this happens once)."
+        )
+        return setup(interactive=False)
+    except Exception as exc:
+        print(
+            f"WARNING: could not ensure the training-gym dashboard is deployed: "
+            f"{exc}. Continuing without dashboard status reporting; run "
+            "`training-gym setup` to deploy it manually."
+        )
+        return None


### PR DESCRIPTION
At the start of .train and .evaluate being run, validate that the dashboard is deployed:

If yes, do nothing and update metadata URL if it exists.
If not, deploy it.