### PR TITLE
Bump context length for Qwen 35b

### DIFF
--- a/modal_training_gym/deploy_recipes/sglang_recipe/qwen3_6_35b.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/qwen3_6_35b.py
@@ -5,7 +5,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 _QWEN3_6_35B_DEFAULTS = {
     "gpu": "H100",
     "tp": 4,
-    "context_length": 32768,
+    "context_length": 262144,
     "mem_fraction_static": 0.80,
     "chunked_prefill_size": 8192,
     "max_running_requests": 16,


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
