### PR TITLE
Bump context length for Qwen 27B, GLM 4.7, Deepseek v4 Flash

### DIFF
--- a/modal_training_gym/deploy_recipes/sglang_recipe/deepseek_v4_flash.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/deepseek_v4_flash.py
@@ -17,7 +17,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 _DEEPSEEK_V4_FLASH_DEFAULTS = {
     "gpu": "B200",
     "tp": 4,
-    "context_length": 32768,
+    "context_length": 262144,
     "mem_fraction_static": 0.80,
     "chunked_prefill_size": 4096,
     "max_running_requests": 16,

--- a/modal_training_gym/deploy_recipes/sglang_recipe/glm_4_7.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/glm_4_7.py
@@ -5,7 +5,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 _GLM_4_7_DEFAULTS = {
     "gpu": "H200",
     "tp": 8,
-    "context_length": 32768,
+    "context_length": 65536,
     "mem_fraction_static": 0.70,
     "chunked_prefill_size": 8192,
     "max_running_requests": 8,

--- a/modal_training_gym/deploy_recipes/sglang_recipe/qwen3_6_27b.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/qwen3_6_27b.py
@@ -5,7 +5,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 _QWEN3_6_27B_DEFAULTS = {
     "gpu": "H100",
     "tp": 4,
-    "context_length": 32768,
+    "context_length": 262144,
     "mem_fraction_static": 0.80,
     "chunked_prefill_size": 8192,
     "max_running_requests": 16,


### PR DESCRIPTION
Make the context length for various models more true to official model capability.