### PR TITLE
Add separate parsing functions for Qwen3.6 models

### DIFF
--- a/modal_training_gym/common/models/__init__.py
+++ b/modal_training_gym/common/models/__init__.py
@@ -6,6 +6,7 @@ from .base import (
     ToolCall,
     parse_glm_response,
     parse_kimi_k2_response,
+    parse_qwen3_6_response,
     parse_qwen3_response,
 )
 from .glm_4_7 import GLM_4_7
@@ -40,6 +41,7 @@ __all__ = [
     "ToolCall",
     "parse_glm_response",
     "parse_kimi_k2_response",
+    "parse_qwen3_6_response",
     "parse_qwen3_response",
     "Qwen3_6_27B",
     "Qwen3_6_35B",

--- a/modal_training_gym/common/models/base.py
+++ b/modal_training_gym/common/models/base.py
@@ -320,18 +320,48 @@ def _coerce_arg_value(raw: str) -> Any:
         return raw.strip()
 
 
-# ── Qwen3 family ───────────────────────────────────────────────────────
+# ── Qwen family ────────────────────────────────────────────────────────
 
 _QWEN3_TOOL_CALL_RE = re.compile(r"<tool_call>\s*(.*?)\s*</tool_call>", re.DOTALL)
+# Qwen3.5/3.6 (Qwen3-Coder lineage) wire format inside <tool_call> blocks:
+#   <function=NAME>
+#   <parameter=KEY>
+#   value (may span lines)
+#   </parameter>
+#   </function>
+_QWEN3_XML_FN_RE = re.compile(r"<function=([^>\n]+)>\s*(.*?)\s*(?:</function>|\Z)", re.DOTALL)
+_QWEN3_XML_PARAM_RE = re.compile(r"<parameter=([^>\n]+)>\n?(.*?)\n?</parameter>", re.DOTALL)
 
 
-def parse_qwen3_response(text: str) -> ParsedResponse:
-    """Parse Qwen3-family model output into structured content.
+def _parse_json_tool_block(block: str) -> ToolCall | None:
+    """Qwen3 wire format: the ``<tool_call>`` body is one JSON object."""
+    try:
+        data = json.loads(block)
+        return ToolCall(name=data.get("name", ""), arguments=data.get("arguments", {}))
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
+        return None
 
-    Handles ``<think>``/``</think>`` reasoning blocks,
-    ``<|im_start|>``/``<|im_end|>`` chat-template delimiters,
-    and ``<tool_call>``/``</tool_call>`` tool invocations.
-    """
+
+def _parse_xml_tool_block(block: str) -> ToolCall | None:
+    """Qwen3.5/3.6 wire format: ``<function=NAME>`` + ``<parameter=KEY>`` pairs."""
+    fn = _QWEN3_XML_FN_RE.search(block)
+    if fn is None:
+        return None
+    # values are rendered raw by the chat template (JSON only for non-strings),
+    # so JSON-decode where possible and keep the raw string otherwise
+    args = {
+        key.strip(): _coerce_arg_value(value)
+        for key, value in _QWEN3_XML_PARAM_RE.findall(fn.group(2))
+    }
+    return ToolCall(name=fn.group(1).strip(), arguments=args)
+
+
+def _parse_qwen_chat(
+    text: str, block_parsers: tuple[Callable[[str], ToolCall | None], ...]
+) -> ParsedResponse:
+    """Shared Qwen chat scaffolding: ``<think>`` blocks, ``<|im_*|>`` delimiters,
+    and ``<tool_call>`` extraction; each block is decoded by the first
+    ``block_parser`` that accepts it."""
     text = text.replace("\r\n", "\n").replace("\r", "\n")
 
     if "<|im_start|>assistant" in text:
@@ -347,16 +377,11 @@ def parse_qwen3_response(text: str) -> ParsedResponse:
 
     tool_calls: list[ToolCall] = []
     for match in _QWEN3_TOOL_CALL_RE.finditer(text):
-        try:
-            data = json.loads(match.group(1))
-            tool_calls.append(
-                ToolCall(
-                    name=data.get("name", ""),
-                    arguments=data.get("arguments", {}),
-                )
-            )
-        except (json.JSONDecodeError, KeyError, TypeError):
-            continue
+        for block_parser in block_parsers:
+            call = block_parser(match.group(1))
+            if call is not None:
+                tool_calls.append(call)
+                break
     content = _QWEN3_TOOL_CALL_RE.sub("", text).strip()
 
     return ParsedResponse(
@@ -364,6 +389,28 @@ def parse_qwen3_response(text: str) -> ParsedResponse:
         tool_calls=tool_calls,
         thinking=thinking,
     )
+
+
+def parse_qwen3_response(text: str) -> ParsedResponse:
+    """Parse Qwen3-family model output into structured content.
+
+    Handles ``<think>``/``</think>`` reasoning blocks,
+    ``<|im_start|>``/``<|im_end|>`` chat-template delimiters,
+    and ``<tool_call>``/``</tool_call>`` tool invocations with Qwen3's
+    JSON body (``{"name": ..., "arguments": {...}}``).
+    """
+    return _parse_qwen_chat(text, (_parse_json_tool_block,))
+
+
+def parse_qwen3_6_response(text: str) -> ParsedResponse:
+    """Parse Qwen3.5/3.6-family model output into structured content.
+
+    Same chat scaffolding as :func:`parse_qwen3_response`, but tool calls use
+    the Qwen3-Coder-lineage XML body (``<function=...><parameter=...>...``)
+    that the Qwen3.5/3.6 chat template emits. A JSON body is tolerated as a
+    fallback so format drift still parses to a real call.
+    """
+    return _parse_qwen_chat(text, (_parse_xml_tool_block, _parse_json_tool_block))
 
 
 # ── GLM family (GLM-4.5 / 4.6 / 4.7) ───────────────────────────────────

--- a/modal_training_gym/common/models/base.py
+++ b/modal_training_gym/common/models/base.py
@@ -329,8 +329,12 @@ _QWEN3_TOOL_CALL_RE = re.compile(r"<tool_call>\s*(.*?)\s*</tool_call>", re.DOTAL
 #   value (may span lines)
 #   </parameter>
 #   </function>
-_QWEN3_XML_FN_RE = re.compile(r"<function=([^>\n]+)>\s*(.*?)\s*(?:</function>|\Z)", re.DOTALL)
-_QWEN3_XML_PARAM_RE = re.compile(r"<parameter=([^>\n]+)>\n?(.*?)\n?</parameter>", re.DOTALL)
+_QWEN3_XML_FN_RE = re.compile(
+    r"<function=([^>\n]+)>\s*(.*?)\s*(?:</function>|\Z)", re.DOTALL
+)
+_QWEN3_XML_PARAM_RE = re.compile(
+    r"<parameter=([^>\n]+)>\n?(.*?)\n?</parameter>", re.DOTALL
+)
 
 
 def _parse_json_tool_block(block: str) -> ToolCall | None:

--- a/modal_training_gym/common/models/qwen3_6_27b.py
+++ b/modal_training_gym/common/models/qwen3_6_27b.py
@@ -1,6 +1,6 @@
 """Qwen3.6-27B model spec as a concrete HFModelConfiguration subclass."""
 
-from .base import HFModelConfiguration, ModelArchitecture, parse_qwen3_response
+from .base import HFModelConfiguration, ModelArchitecture, parse_qwen3_6_response
 
 
 class Qwen3_6_27B(HFModelConfiguration):
@@ -13,7 +13,7 @@ class Qwen3_6_27B(HFModelConfiguration):
     (slime). Downloads from ``Qwen/Qwen3.6-27B`` on HuggingFace.
     """
 
-    response_parser = staticmethod(parse_qwen3_response)
+    response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.6-27B"
     architecture = ModelArchitecture(

--- a/modal_training_gym/common/models/qwen3_6_35b.py
+++ b/modal_training_gym/common/models/qwen3_6_35b.py
@@ -1,6 +1,6 @@
 """Qwen3.6-35B-A3B model spec as a concrete HFModelConfiguration subclass."""
 
-from .base import HFModelConfiguration, ModelArchitecture, parse_qwen3_response
+from .base import HFModelConfiguration, ModelArchitecture, parse_qwen3_6_response
 
 
 class Qwen3_6_35B(HFModelConfiguration):
@@ -11,7 +11,7 @@ class Qwen3_6_35B(HFModelConfiguration):
     frameworks (slime). Downloads from ``Qwen/Qwen3.6-35B-A3B`` on HuggingFace.
     """
 
-    response_parser = staticmethod(parse_qwen3_response)
+    response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.6-35B-A3B"
     architecture = ModelArchitecture(


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Qwen3.6 outputs tool calls in a different format than the 3 family's <toolcall>{some_json}</toolcall>. It replaces the {some_json} with XML of the function name, parameters, etc.

<img width="610" height="262" alt="image" src="https://github.com/user-attachments/assets/1dd9d971-e2a7-478b-8cf5-3301fe7ca18f" />

Adds separate paths in model/base.py to handling parsing for different Qwen model families and JSON/XML. Updates imports/exports.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
