### PR TITLE
Verify all directory snapshots are unexpired from Modal dict

### DIFF
--- a/modal_training_gym/common/environments/base.py
+++ b/modal_training_gym/common/environments/base.py
@@ -258,6 +258,20 @@ class DirectorySnapshotLibrary:
     def has(self, item: str, step: int) -> bool:
         return self.key(item, step) in self.catalog()
 
+    def missing_steps(self, item: str, n_steps: int) -> list[int]:
+        """Steps in ``0..n_steps`` with no cataloged snapshot.
+
+        Reads each present entry (not just a membership check) so the check
+        also refreshes the entry's server-side TTL — ``modal.Dict`` entries
+        expire after 7 days of inactivity (no reads or writes).
+        """
+        catalog = self.catalog()
+        return [
+            step
+            for step in range(n_steps + 1)
+            if catalog.get(self.key(item, step)) is None
+        ]
+
     def mount(self, sandbox: Any, item: str, step: int) -> None:
         """Mount the ``(item, step)`` snapshot at ``root`` inside ``sandbox``."""
         sandbox.mount_image(self.root, self.get(item, step))

--- a/modal_training_gym/common/environments/base.py
+++ b/modal_training_gym/common/environments/base.py
@@ -258,6 +258,7 @@ class DirectorySnapshotLibrary:
     def has(self, item: str, step: int) -> bool:
         return self.key(item, step) in self.catalog()
 
+    # TODO(joyliu-q/atoniolo76) Switch to named images when feature releases
     def missing_steps(self, item: str, n_steps: int) -> list[int]:
         """Steps in ``0..n_steps`` with no cataloged snapshot.
 

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -543,19 +543,25 @@ def build_snapshot_library(
 ) -> None:
     """Build the ``(task, K)`` snapshot catalog, one Modal container per task, in parallel.
 
-    Resumable: a task is skipped if its final snapshot (K = len(golden)) is already cataloged, so
-    re-runs after a partial build (or a TTL refresh of only some tasks) are cheap.
+    Resumable and self-healing: a task is skipped only if *every* snapshot K = 0..len(golden) is
+    still cataloged (catalog entries expire after 7 days of inactivity — see
+    ``DirectorySnapshotLibrary.missing_steps``, whose reads also refresh the surviving entries'
+    TTLs). Tasks with any expired/missing step are rebuilt in full.
     """
     import modal
 
     snapshots = DirectorySnapshotLibrary(config.snapshot_catalog, config.snapshot_root)
     pending = []
     for task_name, golden_calls in task_to_golden.items():
-        if snapshots.has(task_name, len(golden_calls)):
+        missing = snapshots.missing_steps(task_name, len(golden_calls))
+        if not missing:
             print(
-                f"  {task_name}: already cataloged ({len(golden_calls) + 1}), skipping"
+                f"  {task_name}: all {len(golden_calls) + 1} snapshots cataloged (TTLs refreshed), skipping"
             )
         else:
+            print(
+                f"  {task_name}: {len(missing)}/{len(golden_calls) + 1} snapshots missing, rebuilding"
+            )
             pending.append((task_name, golden_calls))
     if not pending:
         return

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -569,9 +569,9 @@ def build_snapshot_library(
     app = modal.App(f"{config.sandbox_app}-builder")
 
     @app.function(
-        image=modal.Image.debian_slim(python_version="3.12").pip_install(
-            "modal~=1.4.3"
-        ),
+        image=modal.Image.debian_slim(python_version="3.12")
+        .pip_install("modal~=1.4.3")
+        .add_local_python_source("modal_training_gym", copy=True),
         timeout=60 * 60,
         max_containers=16,
         serialized=True,


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Toolathlon directory snapshots are saved in a Modal dict. All entries expire after 7 days of inactivity. Verifies that reads on every snapshot key return a value.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
