### PR TITLE
Reload volume to get fresh rollout results on requests to training-gym-dashboard server

### DIFF
--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -102,20 +102,27 @@ async def vol_put_async(
 
 def vol_get(store: MetadataStore | str, key: str) -> dict[str, Any]:
     vol = _metadata_volume()
+    path = f"{_store_path(store)}/{key}.json"
     try:
-        data = b"".join(vol.read_file(f"{_store_path(store)}/{key}.json"))
-        return json.loads(data)
+        return json.loads(b"".join(vol.read_file(path)))
+    except FileNotFoundError:
+        vol.reload()
+    try:
+        return json.loads(b"".join(vol.read_file(path)))
     except FileNotFoundError:
         raise KeyError(key) from None
 
 
 async def vol_get_async(store: MetadataStore | str, key: str) -> dict[str, Any]:
     vol = _metadata_volume()
+    path = f"{_store_path(store)}/{key}.json"
     try:
-        chunks = [
-            chunk
-            async for chunk in vol.read_file.aio(f"{_store_path(store)}/{key}.json")
-        ]
+        chunks = [chunk async for chunk in vol.read_file.aio(path)]
+        return json.loads(b"".join(chunks))
+    except FileNotFoundError:
+        await vol.reload.aio()
+    try:
+        chunks = [chunk async for chunk in vol.read_file.aio(path)]
         return json.loads(b"".join(chunks))
     except FileNotFoundError:
         raise KeyError(key) from None
@@ -123,6 +130,7 @@ async def vol_get_async(store: MetadataStore | str, key: str) -> dict[str, Any]:
 
 def vol_list(store: MetadataStore | str) -> list[dict[str, Any]]:
     vol = _metadata_volume()
+    vol.reload()
     results = []
     try:
         for entry in vol.iterdir(_store_path(store)):
@@ -136,6 +144,7 @@ def vol_list(store: MetadataStore | str) -> list[dict[str, Any]]:
 
 async def vol_list_async(store: MetadataStore | str) -> list[dict[str, Any]]:
     vol = _metadata_volume()
+    await vol.reload.aio()
     results = []
     try:
         async for entry in vol.iterdir.aio(_store_path(store)):
@@ -168,6 +177,8 @@ def vol_get_summary_items(
     key: str = SUMMARY_KEY,
     payload_key: str = SUMMARY_ITEMS_KEY,
 ) -> list[dict[str, Any]] | None:
+    vol = _metadata_volume()
+    vol.reload()
     try:
         payload = vol_get(store, key)
     except KeyError:
@@ -181,6 +192,8 @@ async def vol_get_summary_items_async(
     key: str = SUMMARY_KEY,
     payload_key: str = SUMMARY_ITEMS_KEY,
 ) -> list[dict[str, Any]] | None:
+    vol = _metadata_volume()
+    await vol.reload.aio()
     try:
         payload = await vol_get_async(store, key)
     except KeyError:


### PR DESCRIPTION
Fixes bug where requests to training-gym-dashboard server gets stale volume state, preventing the user from viewing rollouts on a dashboard where the container has been running since before the training run was launched.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
