### PR TITLE
Make Framework JSON-serializable (str, Enum)

### DIFF
--- a/modal_training_gym/common/framework.py
+++ b/modal_training_gym/common/framework.py
@@ -85,6 +85,9 @@ def resolve_caller_module(
     return None
 
 
-class Framework(Enum):
+class Framework(str, Enum):
+    # ``str`` mixin so a Framework serializes straight to its value in plain
+    # ``json.dumps`` (e.g. TrainResult, whose ``asdict`` payload doesn't coerce
+    # enums) — matching the SlimeStatus/MilesStatus convention.
     SLIME = "slime"
     MILES = "miles"


### PR DESCRIPTION
`TrainResult._to_dict()` uses `dataclasses.asdict`, which leaves `framework` as a bare `Framework` enum. When a completed run persists its `TrainResult` to the metadata volume, `json.dumps` then raises `TypeError: Object of type Framework is not JSON serializable`.

Mixing in `str` (matching the existing `SlimeStatus`/`MilesStatus` enums) makes a `Framework` serialize straight to its value. Enum identity (`is`) and `.value` are unaffected.

Latent since the enum was introduced — it only fires once a run reaches `TrainResult.save()`, which the expensive/rare miles runs evidently never did. Surfaced while bringing up a cheap framework run end-to-end (see #148).

Tiny, self-contained; split out from #148 so that PR stays vime-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)