### PR TITLE
Recipe-merge fix, Framework enum consistency, and save-path tests

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -55,11 +55,27 @@ def _stop_app(app_id: str) -> None:
 
 def _merge_recipe(base: SlimeRecipe, overrides: SlimeRecipe) -> SlimeRecipe:
     base_fields = {f.name: getattr(base, f.name) for f in _dc.fields(base)}
+
+    # Fields that a recipe *subclass* declares in its own body are intentional
+    # config and must override the model preset even when they equal the
+    # SlimeRecipe default (e.g. a long-context recipe pinning
+    # context_parallel_size=1, or disabling use_kl_loss). For a plain SlimeRecipe
+    # (no subclass layer) this set is empty, so we fall back to "value differs
+    # from default" — which keeps an untouched recipe from clobbering the preset
+    # with bare defaults (e.g. a preset's n_samples_per_prompt=8 vs default 2).
+    declared: set[str] = set()
+    for cls in type(overrides).__mro__:
+        if cls is SlimeRecipe:
+            break
+        declared |= set(getattr(cls, "__annotations__", {}))
+
     for f in _dc.fields(overrides):
         if f.name not in base_fields:
             continue
         user_val = getattr(overrides, f.name)
-        base_fields[f.name] = user_val
+        default_val = _field_default(f)
+        if f.name in declared or default_val is _dc.MISSING or user_val != default_val:
+            base_fields[f.name] = user_val
     return type(base)(**base_fields)
 
 

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -58,14 +58,17 @@ def _merge_recipe(base: SlimeRecipe, overrides: SlimeRecipe) -> SlimeRecipe:
 
     # Fields that a recipe *subclass* declares in its own body are intentional
     # config and must override the model preset even when they equal the
-    # SlimeRecipe default (e.g. a long-context recipe pinning
-    # context_parallel_size=1, or disabling use_kl_loss). For a plain SlimeRecipe
-    # (no subclass layer) this set is empty, so we fall back to "value differs
-    # from default" — which keeps an untouched recipe from clobbering the preset
-    # with bare defaults (e.g. a preset's n_samples_per_prompt=8 vs default 2).
+    # framework base recipe's default (e.g. a long-context recipe pinning
+    # context_parallel_size=1, or disabling use_kl_loss). We collect those by
+    # walking the MRO from the concrete recipe down to — but not including — the
+    # framework's base recipe class (the immediate subclass of BaseTrainRecipe,
+    # e.g. SlimeRecipe / MilesConfig). For a plain base recipe (no subclass
+    # layer) this set is empty, so we fall back to "value differs from default"
+    # — which keeps an untouched recipe from clobbering the preset with bare
+    # defaults (e.g. a preset's n_samples_per_prompt=8 vs default 2).
     declared: set[str] = set()
     for cls in type(overrides).__mro__:
-        if cls is SlimeRecipe:
+        if cls is BaseTrainRecipe or BaseTrainRecipe in getattr(cls, "__bases__", ()):
             break
         declared |= set(getattr(cls, "__annotations__", {}))
 

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -1242,7 +1242,7 @@ def build_slime_app(
 
             result_kwargs = {
                 "app_name": app_name,
-                "framework": "slime",
+                "framework": Framework.SLIME,
                 "training_run_id": training_run_id,
                 "checkpoint_dir": save_root,
                 "model_config": model,

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -36,6 +36,30 @@ def _metadata_volume():
     return modal.Volume.from_name(METADATA_VOLUME_NAME, create_if_missing=True)
 
 
+def _reload_volume(vol) -> None:
+    """Best-effort refresh of ``vol`` against committed state.
+
+    ``Volume.reload()`` only succeeds for a volume attached to the *running*
+    Modal function. It raises otherwise — from the local ``train()``/eval
+    drivers, or inside a function that writes metadata without mounting this
+    volume (the training functions mount only HF cache / data / checkpoints).
+    Reload is just a freshness hint here: ``vol_get``/``vol_put`` resolve
+    committed state regardless, so a failed reload is skipped, not fatal.
+    """
+    try:
+        vol.reload()
+    except RuntimeError:
+        pass
+
+
+async def _reload_volume_async(vol) -> None:
+    """Async twin of :func:`_reload_volume`."""
+    try:
+        await vol.reload.aio()
+    except RuntimeError:
+        pass
+
+
 def _store_path(store: MetadataStore | str) -> str:
     if isinstance(store, MetadataStore):
         return store.value
@@ -106,7 +130,7 @@ def vol_get(store: MetadataStore | str, key: str) -> dict[str, Any]:
     try:
         return json.loads(b"".join(vol.read_file(path)))
     except FileNotFoundError:
-        vol.reload()
+        _reload_volume(vol)
     try:
         return json.loads(b"".join(vol.read_file(path)))
     except FileNotFoundError:
@@ -120,7 +144,7 @@ async def vol_get_async(store: MetadataStore | str, key: str) -> dict[str, Any]:
         chunks = [chunk async for chunk in vol.read_file.aio(path)]
         return json.loads(b"".join(chunks))
     except FileNotFoundError:
-        await vol.reload.aio()
+        await _reload_volume_async(vol)
     try:
         chunks = [chunk async for chunk in vol.read_file.aio(path)]
         return json.loads(b"".join(chunks))
@@ -130,7 +154,7 @@ async def vol_get_async(store: MetadataStore | str, key: str) -> dict[str, Any]:
 
 def vol_list(store: MetadataStore | str) -> list[dict[str, Any]]:
     vol = _metadata_volume()
-    vol.reload()
+    _reload_volume(vol)
     results = []
     try:
         for entry in vol.iterdir(_store_path(store)):
@@ -144,7 +168,7 @@ def vol_list(store: MetadataStore | str) -> list[dict[str, Any]]:
 
 async def vol_list_async(store: MetadataStore | str) -> list[dict[str, Any]]:
     vol = _metadata_volume()
-    await vol.reload.aio()
+    await _reload_volume_async(vol)
     results = []
     try:
         async for entry in vol.iterdir.aio(_store_path(store)):
@@ -178,7 +202,7 @@ def vol_get_summary_items(
     payload_key: str = SUMMARY_ITEMS_KEY,
 ) -> list[dict[str, Any]] | None:
     vol = _metadata_volume()
-    vol.reload()
+    _reload_volume(vol)
     try:
         payload = vol_get(store, key)
     except KeyError:
@@ -193,7 +217,7 @@ async def vol_get_summary_items_async(
     payload_key: str = SUMMARY_ITEMS_KEY,
 ) -> list[dict[str, Any]] | None:
     vol = _metadata_volume()
-    await vol.reload.aio()
+    await _reload_volume_async(vol)
     try:
         payload = await vol_get_async(store, key)
     except KeyError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Shared pytest fixtures and test doubles."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from modal_training_gym.utils import metadata
+
+
+class FakeVolume:
+    """In-memory stand-in for a Modal Volume that is *not* attached.
+
+    ``reload()`` raises like a real unattached/local volume; reads and writes
+    operate on an in-memory dict. A correct metadata layer must still complete a
+    ``save()`` against this — reload is only a freshness hint.
+    """
+
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    def reload(self) -> None:
+        raise RuntimeError("reload() can only be called from within a running function")
+
+    def read_file(self, path: str):
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return [self.files[path]]
+
+    def remove_file(self, path: str) -> None:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        del self.files[path]
+
+    def batch_upload(self):
+        files = self.files
+
+        class _Batch:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def put_file(self, fileobj: io.BytesIO, path: str) -> None:
+                files[path] = fileobj.read()
+
+        return _Batch()
+
+
+@pytest.fixture
+def fake_volume(monkeypatch) -> FakeVolume:
+    """Swap the metadata volume for an in-memory ``FakeVolume`` (no Modal, no GPU)."""
+    vol = FakeVolume()
+    monkeypatch.setattr(metadata, "_metadata_volume", lambda: vol)
+    return vol

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -1,16 +1,13 @@
-"""Save-path regression tests for the metadata layer.
+"""Drive the real ``save()`` chain to completion without Modal or a GPU.
 
-Two bugs reached `main` because nothing exercised a run all the way to
-``save()`` without a full GPU train: a ``Framework`` enum that wasn't
-JSON-serializable, and ``Volume.reload()`` crashing when the volume isn't
-attached (local driver / a function that doesn't mount it). These tests drive
-the real ``save()`` chain against an in-memory volume — no Modal, no GPU — so
-that path is covered in CI.
+``TrainingRun.save()`` and ``TrainResult.save()`` are exercised against an
+in-memory ``FakeVolume`` (see ``conftest.py``) so the full serialize-and-write
+path is covered in CI: the payload must stay JSON-serializable, and ``save()``
+must complete even when ``Volume.reload()`` is unavailable.
 """
 
 from __future__ import annotations
 
-import io
 import json
 import os
 
@@ -19,60 +16,11 @@ import pytest
 from modal_training_gym.common import run as run_mod
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.train_result import TrainResult
-from modal_training_gym.utils import metadata
 from modal_training_gym.utils.metadata import MetadataStore
 
 
-class _FakeVolume:
-    """In-memory stand-in for a Modal Volume that is *not* attached.
-
-    ``reload()`` raises like a real unattached/local volume; reads and writes
-    operate on an in-memory dict. A correct metadata layer must still complete a
-    ``save()`` against this — reload is only a freshness hint.
-    """
-
-    def __init__(self) -> None:
-        self.files: dict[str, bytes] = {}
-
-    def reload(self) -> None:
-        raise RuntimeError("reload() can only be called from within a running function")
-
-    def read_file(self, path: str):
-        if path not in self.files:
-            raise FileNotFoundError(path)
-        return [self.files[path]]
-
-    def remove_file(self, path: str) -> None:
-        if path not in self.files:
-            raise FileNotFoundError(path)
-        del self.files[path]
-
-    def batch_upload(self):
-        files = self.files
-
-        class _Batch:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_exc):
-                return False
-
-            def put_file(self, fileobj: io.BytesIO, path: str) -> None:
-                files[path] = fileobj.read()
-
-        return _Batch()
-
-
-@pytest.fixture
-def fake_volume(monkeypatch) -> _FakeVolume:
-    vol = _FakeVolume()
-    monkeypatch.setattr(metadata, "_metadata_volume", lambda: vol)
-    return vol
-
-
 def test_training_run_save_survives_unmounted_volume(fake_volume):
-    """The local-driver path that crashed: TrainingRun.save() must complete even
-    when reload() raises, and persist a valid JSON payload."""
+    """TrainingRun.save() completes when reload() raises, and persists valid JSON."""
     run_mod.TrainingRun(
         training_run_id="t1", framework=Framework.SLIME, config={}
     ).save()
@@ -81,19 +29,17 @@ def test_training_run_save_survives_unmounted_volume(fake_volume):
     assert json.loads(blob)["framework"] == "slime"
 
 
-def test_train_result_save_survives_unmounted_volume(fake_volume):
-    """TrainResult.save() is the path that hit both the reload crash and the
-    non-serializable Framework enum (asdict keeps the enum)."""
-    TrainResult(app_name="a", framework=Framework.MILES, training_run_id="t2").save()
+@pytest.mark.parametrize("fw", list(Framework))
+def test_train_result_save_survives_unmounted_volume(fake_volume, fw):
+    """TrainResult.save() completes when reload() raises, for every framework."""
+    TrainResult(app_name="a", framework=fw, training_run_id="t2").save()
 
     blob = fake_volume.files[f"{MetadataStore.TRAIN_RESULTS.value}/t2.json"]
-    assert json.loads(blob)["framework"] == "miles"
+    assert json.loads(blob)["framework"] == fw.value
 
 
 @pytest.mark.parametrize("fw", list(Framework))
 def test_train_result_payload_is_json_serializable(fw):
-    """Every Framework must round-trip through plain json.dumps — guards against
-    regressing the (str, Enum) base back to a bare Enum."""
     payload = TrainResult(app_name="a", framework=fw, training_run_id="t")._to_dict()
     assert json.loads(json.dumps(payload))["framework"] == fw.value
 

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -70,6 +70,10 @@ def test_remote_save_from_unmounted_container():
         from modal_training_gym.common.run import TrainingRun
         from modal_training_gym.common.train_result import TrainResult
 
+        # Framework is incidental here — this probes volume/reload mechanics,
+        # which are framework-independent. Per-framework serialization is
+        # covered by the fast parametrized tests above, so we don't pay for N
+        # real Modal apps to re-check it.
         rid = "ci-remote-save-probe"  # fixed id → overwrites, no junk accrual
         TrainingRun(training_run_id=rid, framework=Framework.SLIME, config={}).save()
         TrainResult(app_name=rid, framework=Framework.SLIME, training_run_id=rid).save()

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -1,0 +1,142 @@
+"""Save-path regression tests for the metadata layer.
+
+Two bugs reached `main` because nothing exercised a run all the way to
+``save()`` without a full GPU train: a ``Framework`` enum that wasn't
+JSON-serializable, and ``Volume.reload()`` crashing when the volume isn't
+attached (local driver / a function that doesn't mount it). These tests drive
+the real ``save()`` chain against an in-memory volume — no Modal, no GPU — so
+that path is covered in CI.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+
+import pytest
+
+from modal_training_gym.common import run as run_mod
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.train_result import TrainResult
+from modal_training_gym.utils import metadata
+from modal_training_gym.utils.metadata import MetadataStore
+
+
+class _FakeVolume:
+    """In-memory stand-in for a Modal Volume that is *not* attached.
+
+    ``reload()`` raises like a real unattached/local volume; reads and writes
+    operate on an in-memory dict. A correct metadata layer must still complete a
+    ``save()`` against this — reload is only a freshness hint.
+    """
+
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+
+    def reload(self) -> None:
+        raise RuntimeError("reload() can only be called from within a running function")
+
+    def read_file(self, path: str):
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return [self.files[path]]
+
+    def remove_file(self, path: str) -> None:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        del self.files[path]
+
+    def batch_upload(self):
+        files = self.files
+
+        class _Batch:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def put_file(self, fileobj: io.BytesIO, path: str) -> None:
+                files[path] = fileobj.read()
+
+        return _Batch()
+
+
+@pytest.fixture
+def fake_volume(monkeypatch) -> _FakeVolume:
+    vol = _FakeVolume()
+    monkeypatch.setattr(metadata, "_metadata_volume", lambda: vol)
+    return vol
+
+
+def test_training_run_save_survives_unmounted_volume(fake_volume):
+    """The local-driver path that crashed: TrainingRun.save() must complete even
+    when reload() raises, and persist a valid JSON payload."""
+    run_mod.TrainingRun(
+        training_run_id="t1", framework=Framework.SLIME, config={}
+    ).save()
+
+    blob = fake_volume.files[f"{MetadataStore.TRAINING_RUNS.value}/t1.json"]
+    assert json.loads(blob)["framework"] == "slime"
+
+
+def test_train_result_save_survives_unmounted_volume(fake_volume):
+    """TrainResult.save() is the path that hit both the reload crash and the
+    non-serializable Framework enum (asdict keeps the enum)."""
+    TrainResult(
+        app_name="a", framework=Framework.MILES, training_run_id="t2"
+    ).save()
+
+    blob = fake_volume.files[f"{MetadataStore.TRAIN_RESULTS.value}/t2.json"]
+    assert json.loads(blob)["framework"] == "miles"
+
+
+@pytest.mark.parametrize("fw", list(Framework))
+def test_train_result_payload_is_json_serializable(fw):
+    """Every Framework must round-trip through plain json.dumps — guards against
+    regressing the (str, Enum) base back to a bare Enum."""
+    payload = TrainResult(app_name="a", framework=fw, training_run_id="t")._to_dict()
+    assert json.loads(json.dumps(payload))["framework"] == fw.value
+
+
+def test_reload_volume_is_best_effort(fake_volume):
+    """The helper must swallow reload failures (local / unattached)."""
+    metadata._reload_volume(fake_volume)  # must not raise
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_MODAL_TESTS") != "1",
+    reason="hits Modal (no GPU); opt in with RUN_MODAL_TESTS=1",
+)
+def test_remote_save_from_unmounted_container():
+    """The faithful remote counterpart: run save() inside a real Modal container
+    that does *not* mount the metadata volume — the exact context where the
+    original training run crashed with `volume … not attached`. The fake-volume
+    tests simulate that; this proves it against real Modal Volume semantics
+    (reload unavailable, but the client-side write still lands).
+    """
+    import modal
+
+    image = (
+        modal.Image.debian_slim(python_version="3.12")
+        .pip_install("modal>=1.4.0", "pydantic")
+        .add_local_python_source("modal_training_gym")
+    )
+    app = modal.App("training-gym-metadata-save-probe")
+
+    # NB: deliberately no volumes= — this is the unmounted case.
+    @app.function(image=image, serialized=True)
+    def _save_probe() -> str:
+        from modal_training_gym.common.framework import Framework
+        from modal_training_gym.common.run import TrainingRun
+        from modal_training_gym.common.train_result import TrainResult
+
+        rid = "ci-remote-save-probe"  # fixed id → overwrites, no junk accrual
+        TrainingRun(training_run_id=rid, framework=Framework.SLIME, config={}).save()
+        TrainResult(app_name=rid, framework=Framework.SLIME, training_run_id=rid).save()
+        return "ok"
+
+    with modal.enable_output():
+        with app.run():
+            assert _save_probe.remote() == "ok"

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -84,9 +84,7 @@ def test_training_run_save_survives_unmounted_volume(fake_volume):
 def test_train_result_save_survives_unmounted_volume(fake_volume):
     """TrainResult.save() is the path that hit both the reload crash and the
     non-serializable Framework enum (asdict keeps the enum)."""
-    TrainResult(
-        app_name="a", framework=Framework.MILES, training_run_id="t2"
-    ).save()
+    TrainResult(app_name="a", framework=Framework.MILES, training_run_id="t2").save()
 
     blob = fake_volume.files[f"{MetadataStore.TRAIN_RESULTS.value}/t2.json"]
     assert json.loads(blob)["framework"] == "miles"

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -19,14 +19,13 @@ from modal_training_gym.common.train_result import TrainResult
 from modal_training_gym.utils.metadata import MetadataStore
 
 
-def test_training_run_save_survives_unmounted_volume(fake_volume):
-    """TrainingRun.save() completes when reload() raises, and persists valid JSON."""
-    run_mod.TrainingRun(
-        training_run_id="t1", framework=Framework.SLIME, config={}
-    ).save()
+@pytest.mark.parametrize("fw", list(Framework))
+def test_training_run_save_survives_unmounted_volume(fake_volume, fw):
+    """TrainingRun.save() completes when reload() raises, for every framework."""
+    run_mod.TrainingRun(training_run_id="t1", framework=fw, config={}).save()
 
     blob = fake_volume.files[f"{MetadataStore.TRAINING_RUNS.value}/t1.json"]
-    assert json.loads(blob)["framework"] == "slime"
+    assert json.loads(blob)["framework"] == fw.value
 
 
 @pytest.mark.parametrize("fw", list(Framework))


### PR DESCRIPTION
Small robustness fixes + tests for the training config/save path, surfaced while bringing up the Vime PR (#148) end-to-end.

> This branch started as a `Volume.reload()` fix, but #151 landed the same fix independently — so that's merged in and dropped here. What remains:

### 1. Recipe merge: presets *and* subclass recipes both win
#151 made `_merge_recipe` always copy the user recipe's value over the model preset, so a plain `SlimeRecipe`'s untouched defaults clobbered the preset (e.g. the `Qwen3-4B` preset's `n_samples_per_prompt=8` → default `2`), failing `test_recipe_param_summary`. The prior rule (override only when value ≠ default) had the opposite problem: it dropped fields a recipe *subclass* deliberately pins to a default value (e.g. the long-context recipe's `context_parallel_size=1`).

Fix: a field overrides the preset if the recipe subclass **declares it** (intentional, even when it equals the default) **or** its value differs from the default. A plain `SlimeRecipe` declares nothing extra, so it falls back to the latter and no longer clobbers presets. (Folds in @joyliu-q 's #151 rollback request.)

### 2. Framework enum consistency on TrainResult
The slime launcher set `TrainResult`'s framework to the literal `"slime"` while miles passed the `Framework` enum. `TrainResult.framework` is typed `Framework`, so unify on the enum (json-safe via #149's `(str, Enum)`).

### 3. Save-path regression tests (`tests/test_metadata_persistence.py`)
The reload + enum bugs both slipped in because nothing exercised a run through to `save()` without a full GPU train. These drive the real `save()` chain against an in-memory volume — no GPU, no Modal — and a parametrized `json.dumps` over every `Framework`. Plus an opt-in remote variant (`RUN_MODAL_TESTS=1`) that runs `save()` in a container with the metadata volume unmounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)