### PR TITLE
Add resillience to saving records

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -530,13 +530,19 @@ class TrainConfig:
                 )
                 # Initial write is synchronous so the record exists before any
                 # downstream HTTP status updates try to update it.
-                run_record.save()
-                framework_status_token = _secrets.token_urlsafe(32)
-                vol_put(
-                    MetadataStore.FRAMEWORK_STATUS_TOKENS,
-                    training_run_id,
-                    {"token": framework_status_token},
-                )
+                try:
+                    run_record.save()
+                except RuntimeError:
+                    pass
+                try:
+                    framework_status_token = _secrets.token_urlsafe(32)
+                    vol_put(
+                        MetadataStore.FRAMEWORK_STATUS_TOKENS,
+                        training_run_id,
+                        {"token": framework_status_token},
+                    )
+                except RuntimeError:
+                    framework_status_token = ""
                 print(f"TrainingRun recorded: {training_run_id}")
 
                 # Mid-flight status bumps are fire-and-forget HTTP posts to


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
