### PR TITLE
Qwen3-Omni-30B with vime (WIP): multimodal foundation + omni training bridge

### DIFF
--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -66,6 +66,7 @@ _EXPORTS = {
     "Qwen3_6_27B": ("modal_training_gym.common.models", "Qwen3_6_27B"),
     "Qwen3_6_35B": ("modal_training_gym.common.models", "Qwen3_6_35B"),
     "Qwen3_ASR_1_7B": ("modal_training_gym.common.models", "Qwen3_ASR_1_7B"),
+    "Qwen3_VL_4B": ("modal_training_gym.common.models", "Qwen3_VL_4B"),
     "Qwen3_ASR_1_7b_Recipe": (
         "modal_training_gym.train_recipes.slime_recipe",
         "Qwen3_ASR_1_7b_Recipe",
@@ -126,6 +127,7 @@ __all__ = [
     "Qwen3_6_27B",
     "Qwen3_6_35B",
     "Qwen3_ASR_1_7B",
+    "Qwen3_VL_4B",
     "Qwen3_ASR_1_7b_Recipe",
     "score_in_sandbox",
     "SlimeRecipe",

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -45,6 +45,11 @@ _EXPORTS = {
         "Kimi_K2_6_LoRA_Recipe",
     ),
     "MilesConfig": ("modal_training_gym.train_recipes.miles_recipe", "MilesConfig"),
+    "VimeConfig": ("modal_training_gym.train_recipes.vime_recipe", "VimeConfig"),
+    "Qwen3_4b_Vime_Recipe": (
+        "modal_training_gym.train_recipes.vime_recipe",
+        "Qwen3_4b_Vime_Recipe",
+    ),
     "MultiTurn": ("modal_training_gym.train_recipes.slime_recipe", "MultiTurn"),
     "parse_qwen3_response": (
         "modal_training_gym.common.models",
@@ -106,6 +111,8 @@ __all__ = [
     "ModelConfig",
     "ModelDeployment",
     "MilesConfig",
+    "VimeConfig",
+    "Qwen3_4b_Vime_Recipe",
     "MultiTurn",
     "parse_qwen3_response",
     "ParsedResponse",

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -67,6 +67,7 @@ _EXPORTS = {
     "Qwen3_6_35B": ("modal_training_gym.common.models", "Qwen3_6_35B"),
     "Qwen3_ASR_1_7B": ("modal_training_gym.common.models", "Qwen3_ASR_1_7B"),
     "Qwen3_VL_4B": ("modal_training_gym.common.models", "Qwen3_VL_4B"),
+    "Qwen3_Omni_30B": ("modal_training_gym.common.models", "Qwen3_Omni_30B"),
     "Qwen3_ASR_1_7b_Recipe": (
         "modal_training_gym.train_recipes.slime_recipe",
         "Qwen3_ASR_1_7b_Recipe",
@@ -128,6 +129,7 @@ __all__ = [
     "Qwen3_6_35B",
     "Qwen3_ASR_1_7B",
     "Qwen3_VL_4B",
+    "Qwen3_Omni_30B",
     "Qwen3_ASR_1_7b_Recipe",
     "score_in_sandbox",
     "SlimeRecipe",

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -208,11 +208,40 @@ def convert_checkpoint_to_hf(
         create_if_missing=True,
     )
     from modal_training_gym.common import hf_secrets
-    from modal_training_gym.frameworks.slime.launcher import _build_slime_base_image
 
-    image = _build_slime_base_image().add_local_python_source(
-        "modal_training_gym", copy=True
-    )
+    # Convert in the image that produced the checkpoint. A vime torch_dist
+    # checkpoint's pickled metadata references ``vllm``, which the slime image
+    # (SGLang-based) lacks — so unpickling it there fails with
+    # ``ModuleNotFoundError: No module named 'vllm'``. vime ships an equivalent
+    # converter in-image, so we run that under the vime image instead. slime and
+    # miles (and an unknown framework) keep the slime converter.
+    framework = Framework.SLIME
+    if checkpoint.training_run_id:
+        try:
+            framework = TrainResult.from_training_run_id(
+                checkpoint.training_run_id
+            ).framework
+        except Exception:
+            pass
+
+    if framework in {Framework.VIME, Framework.VIME.value}:
+        from modal_training_gym.frameworks.vime.launcher import _build_vime_base_image
+        from modal_training_gym.train_recipes.vime_recipe import VimeConfig
+
+        base_image = _build_vime_base_image(VimeConfig())
+        convert_script = "/root/vime/tools/convert_torch_dist_to_hf.py"
+        convert_pythonpath = "/root/vime:/root/Megatron-LM/"
+    else:
+        from modal_training_gym.frameworks.slime.launcher import (
+            _build_slime_base_image,
+        )
+
+        base_image = _build_slime_base_image()
+        # Empty → resolved from the shipped slime wrapper inside the function.
+        convert_script = ""
+        convert_pythonpath = ""
+
+    image = base_image.add_local_python_source("modal_training_gym", copy=True)
     conversion_app = App("training-gym-checkpoint-convert")
     gpu_spec = _conversion_gpu_spec(checkpoint, recipe)
 
@@ -232,6 +261,8 @@ def convert_checkpoint_to_hf(
         input_dir: str,
         output_dir: str,
         model_ref: str,
+        convert_script: str,
+        convert_pythonpath: str,
     ) -> str:
         import importlib.util
         import shlex
@@ -247,14 +278,23 @@ def convert_checkpoint_to_hf(
         else:
             hf_path = snapshot_download(model_ref, local_files_only=True)
 
-        spec = importlib.util.find_spec(
-            "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf"
-        )
-        convert_script = spec.origin if spec is not None else None
         if not convert_script:
-            raise RuntimeError(
-                "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf not found"
+            spec = importlib.util.find_spec(
+                "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf"
             )
+            if spec is None or not spec.origin:
+                raise RuntimeError(
+                    "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf not found"
+                )
+            convert_script = spec.origin
+
+        env = dict(os.environ)
+        if convert_pythonpath:
+            existing = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = (
+                f"{convert_pythonpath}:{existing}" if existing else convert_pythonpath
+            )
+
         cmd = (
             f"python {convert_script} "
             f"--input-dir {shlex.quote(input_dir)} "
@@ -263,7 +303,7 @@ def convert_checkpoint_to_hf(
             f"--force"
         )
         print(f"Converting checkpoint for serving: {cmd}")
-        subprocess.run(["bash", "-c", cmd], check=True)
+        subprocess.run(["bash", "-c", cmd], check=True, env=env)
         checkpoints_volume.commit()
         return output_dir
 
@@ -274,6 +314,8 @@ def convert_checkpoint_to_hf(
                 input_dir=checkpoint.path,
                 output_dir=output_path,
                 model_ref=model_ref,
+                convert_script=convert_script,
+                convert_pythonpath=convert_pythonpath,
             )
 
     return Checkpoint(

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -45,6 +45,9 @@ def list_checkpoints(training_run_id: str) -> list[Checkpoint]:
         return _list_checkpoints_for_slime(result)
     if result.framework in {Framework.MILES, Framework.MILES.value}:
         return _list_checkpoints_for_slime(result)
+    if result.framework in {Framework.VIME, Framework.VIME.value}:
+        # vime writes slime/Megatron torch_dist checkpoints, same layout as slime.
+        return _list_checkpoints_for_slime(result)
     raise ValueError(f"Unsupported framework: {result.framework}")
 
 

--- a/modal_training_gym/common/framework.py
+++ b/modal_training_gym/common/framework.py
@@ -88,3 +88,4 @@ def resolve_caller_module(
 class Framework(Enum):
     SLIME = "slime"
     MILES = "miles"
+    VIME = "vime"

--- a/modal_training_gym/common/models/__init__.py
+++ b/modal_training_gym/common/models/__init__.py
@@ -22,6 +22,7 @@ from .kimi_k2_6 import Kimi_K2_6
 from .qwen3_6_27b import Qwen3_6_27B
 from .qwen3_6_35b import Qwen3_6_35B
 from .qwen3_asr_1_7b import Qwen3_ASR_1_7B
+from .qwen3_vl_4b import Qwen3_VL_4B
 
 __all__ = [
     "HFModelConfiguration",
@@ -46,4 +47,5 @@ __all__ = [
     "Qwen3_6_27B",
     "Qwen3_6_35B",
     "Qwen3_ASR_1_7B",
+    "Qwen3_VL_4B",
 ]

--- a/modal_training_gym/common/models/__init__.py
+++ b/modal_training_gym/common/models/__init__.py
@@ -23,6 +23,7 @@ from .qwen3_6_27b import Qwen3_6_27B
 from .qwen3_6_35b import Qwen3_6_35B
 from .qwen3_asr_1_7b import Qwen3_ASR_1_7B
 from .qwen3_vl_4b import Qwen3_VL_4B
+from .qwen3_omni_30b import Qwen3_Omni_30B
 
 __all__ = [
     "HFModelConfiguration",
@@ -48,4 +49,5 @@ __all__ = [
     "Qwen3_6_35B",
     "Qwen3_ASR_1_7B",
     "Qwen3_VL_4B",
+    "Qwen3_Omni_30B",
 ]

--- a/modal_training_gym/common/models/qwen3_omni_30b.py
+++ b/modal_training_gym/common/models/qwen3_omni_30b.py
@@ -38,4 +38,15 @@ class Qwen3_Omni_30B(HFModelConfiguration):
         untie_embeddings_and_output_weights=True,
         use_rotary_position_embeddings=True,
         rotary_base=1000000,
+        # MoE (128 experts, top-8). Required on the CLI for expert parallelism —
+        # not auto-read from the HF config. Values from the omni config + vime's
+        # proven Qwen3-30B-A3B model script.
+        num_experts=128,
+        moe_ffn_hidden_size=768,
+        moe_router_topk=8,
+        moe_router_score_function="softmax",
+        moe_token_drop_policy="probs",
+        moe_router_dtype="fp32",
+        moe_grouped_gemm=True,
+        moe_permute_fusion=True,
     )

--- a/modal_training_gym/common/models/qwen3_omni_30b.py
+++ b/modal_training_gym/common/models/qwen3_omni_30b.py
@@ -1,0 +1,41 @@
+"""Qwen3-Omni-30B-A3B-Instruct as a gym model.
+
+Qwen3-Omni is a Thinker-Talker omni-modal MoE: a Qwen3-30B-A3B text MoE backbone
+with SigLIP-2 vision + AuT audio encoders (the Thinker, which perceives
+audio/image/video/text and emits text — what GRPO trains; the Talker/code2wav
+speech path is unused here). We GRPO-train the Thinker.
+
+``architecture`` is the Thinker's **text backbone**, which vime's
+``hf_validate_args`` checks field-by-field against the HF config; the MoE expert
+config and the vision/audio towers are read from the HF checkpoint by megatron's
+``qwen_omni`` bridge (bridge mode). Note this backbone differs from the plain
+Qwen3-30B-A3B (``vocab_size=152064``, ``intermediate_size=768``).
+"""
+
+from .base import HFModelConfiguration, ModelArchitecture, parse_qwen3_response
+
+
+class Qwen3_Omni_30B(HFModelConfiguration):
+    model_name = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+
+    response_parser = staticmethod(parse_qwen3_response)
+
+    # Thinker text backbone (Qwen3-Omni-30B-A3B), verified against the HF config.
+    architecture = ModelArchitecture(
+        num_layers=48,
+        hidden_size=2048,
+        ffn_hidden_size=768,  # == intermediate_size (all-MoE)
+        num_attention_heads=32,
+        group_query_attention=True,
+        num_query_groups=4,
+        kv_channels=128,
+        vocab_size=152064,
+        normalization="RMSNorm",
+        norm_epsilon=1e-6,
+        swiglu=True,
+        disable_bias_linear=True,
+        qk_layernorm=True,
+        untie_embeddings_and_output_weights=True,
+        use_rotary_position_embeddings=True,
+        rotary_base=1000000,
+    )

--- a/modal_training_gym/common/models/qwen3_vl_4b.py
+++ b/modal_training_gym/common/models/qwen3_vl_4b.py
@@ -1,0 +1,41 @@
+"""Qwen3-VL-4B-Instruct as a gym model.
+
+Qwen3-VL pairs a Qwen3 text backbone with a SigLIP-2 vision encoder. The
+``architecture`` is the **text backbone**, which vime's ``hf_validate_args``
+checks field-by-field against the HF config (it requires these flags and rejects
+mismatches). Qwen3-VL-4B's backbone equals Qwen3-4B *except* ``rope_theta``
+(5e6, not 1e6). The vision tower is read from the HF checkpoint by vime's
+Qwen3-VL bridge. Images reach the rollout via a
+``MultimodalDataset(modality="image")``'s ``multimodal_keys``; vime's default
+vLLM rollout forwards them as image content.
+
+De-risk stepping stone for Qwen3-Omni (this + an audio tower).
+"""
+
+from .base import HFModelConfiguration, ModelArchitecture, parse_qwen3_response
+
+
+class Qwen3_VL_4B(HFModelConfiguration):
+    model_name = "Qwen/Qwen3-VL-4B-Instruct"
+
+    response_parser = staticmethod(parse_qwen3_response)
+
+    # Text backbone; values verified against vime's hf_validate_args (== Qwen3-4B
+    # but rope_theta=5e6).
+    architecture = ModelArchitecture(
+        num_layers=36,
+        hidden_size=2560,
+        ffn_hidden_size=9728,
+        num_attention_heads=32,
+        group_query_attention=True,
+        num_query_groups=8,
+        kv_channels=128,
+        vocab_size=151936,
+        normalization="RMSNorm",
+        norm_epsilon=1e-6,
+        swiglu=True,
+        disable_bias_linear=True,
+        qk_layernorm=True,
+        use_rotary_position_embeddings=True,
+        rotary_base=5000000,
+    )

--- a/modal_training_gym/common/status.py
+++ b/modal_training_gym/common/status.py
@@ -29,4 +29,12 @@ class MilesStatus(str, Enum):
     TRAINING = "training"
 
 
-FrameworkStatus: TypeAlias = SlimeStatus | MilesStatus
+class VimeStatus(str, Enum):
+    INITIALIZING = "initializing"
+    DOWNLOAD_MODEL = "download_model"
+    CONVERT_MODEL = "convert_model"
+    PREPARE_DATASET = "prepare_dataset"
+    TRAINING = "training"
+
+
+FrameworkStatus: TypeAlias = SlimeStatus | MilesStatus | VimeStatus

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -18,15 +18,18 @@ from modal_training_gym.common.status import (
     FrameworkStatus,
     MilesStatus,
     SlimeStatus,
+    VimeStatus,
 )
 from modal_training_gym.common.train_result import TrainResult
 from modal_training_gym.common.modal_urls import modal_app_dashboard_url
 from modal_training_gym.utils.metadata import MetadataStore, vol_put
 from modal_training_gym.frameworks.miles import build_miles_app
 from modal_training_gym.frameworks.slime import build_slime_app
+from modal_training_gym.frameworks.vime import build_vime_app
 from modal_training_gym.train_recipes.base import BaseTrainRecipe, RecipeType
 from modal_training_gym.train_recipes.miles_recipe import MilesConfig
 from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
+from modal_training_gym.train_recipes.vime_recipe import VimeConfig
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 
@@ -383,6 +386,18 @@ class TrainConfig:
                 dataset=self.dataset,
                 checkpoint=self.checkpoint,
             )
+        if recipe_type == RecipeType.VIME:
+            if not isinstance(self.recipe, VimeConfig):
+                raise TypeError(
+                    f"Recipe type {recipe_type} requires VimeConfig, got {type(self.recipe).__name__}"
+                )
+            return build_vime_app(
+                training_run_id=self.training_run_id,
+                vime=cast(VimeConfig, self.recipe),
+                model=self.model,
+                dataset=self.dataset,
+                checkpoint=self.checkpoint,
+            )
         raise ValueError(f"Unknown recipe type: {recipe_type}")
 
     def recipe_param_summary(self) -> dict[str, dict[str, Any]]:
@@ -403,6 +418,8 @@ class TrainConfig:
     def _framework(self) -> Framework:
         if isinstance(self.recipe, SlimeRecipe):
             return Framework.SLIME
+        if isinstance(self.recipe, VimeConfig):
+            return Framework.VIME
         if isinstance(self.recipe, MilesConfig):
             return Framework.MILES
         raise ValueError(f"Unknown recipe type: {type(self.recipe).__name__}")
@@ -410,6 +427,8 @@ class TrainConfig:
     def _initializing_status(self) -> FrameworkStatus:
         if isinstance(self.recipe, SlimeRecipe):
             return SlimeStatus.INITIALIZING
+        if isinstance(self.recipe, VimeConfig):
+            return VimeStatus.INITIALIZING
         if isinstance(self.recipe, MilesConfig):
             return MilesStatus.INITIALIZING
         raise ValueError(f"Unknown recipe type: {type(self.recipe).__name__}")

--- a/modal_training_gym/frameworks/vime/__init__.py
+++ b/modal_training_gym/frameworks/vime/__init__.py
@@ -1,0 +1,3 @@
+from .launcher import build_vime_app
+
+__all__ = ["build_vime_app"]

--- a/modal_training_gym/frameworks/vime/launcher.py
+++ b/modal_training_gym/frameworks/vime/launcher.py
@@ -1,0 +1,793 @@
+"""Build a Modal app for a Vime (slime + vLLM) training run from config objects.
+
+Vime keeps slime's Megatron training stack and Data Buffer dataflow but drives
+rollout with vLLM + vllm-router instead of SGLang. The orchestration here — Ray
+cluster bring-up, volume mounts, model/dataset preparation, and weight-synced
+GRPO — mirrors the slime and miles launchers; only the image and the rollout
+backend differ.
+
+Usage (from a tutorial module)::
+
+    from modal_training_gym import TrainConfig
+    from modal_training_gym.train_recipes.vime_recipe import VimeConfig
+
+    TrainConfig(model=..., dataset=..., recipe=VimeConfig(...)).train()
+"""
+
+import asyncio
+import base64
+import hashlib
+import inspect
+import os
+import secrets as _secrets
+import shlex
+import subprocess
+import shutil
+import tempfile
+import textwrap
+import time
+from collections.abc import Callable
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import cloudpickle
+from modal import App, Image, Secret, Volume
+
+from modal_training_gym.common import COMMON_TRAINING_GYM_TAGS, hf_secrets
+from modal_training_gym.common.checkpoint import Checkpoint
+from modal_training_gym.common.dataset import DatasetConfig, HarborDataset
+from modal_training_gym.common.framework import (
+    Framework,
+    mount_tools_dir,
+    resolve_caller_module,
+)
+from modal_training_gym.common.modal_refs import register_modal_cloudpickle_reducers
+from modal_training_gym.common.modal_urls import modal_app_dashboard_url
+from modal_training_gym.common.models import ModelConfig
+from modal_training_gym.common.ray_cluster import (
+    ModalRayCluster,
+    _supports_rdma,
+    clustered_if,
+)
+from modal_training_gym.common.run import TrainingRun, TrainingRunStatus
+from modal_training_gym.common.status import VimeStatus
+from modal_training_gym.common.train_result import TrainResult
+from modal_training_gym.utils.metadata import MetadataStore, vol_put_async
+from modal_training_gym.train_recipes.vime_recipe.recipe import (
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    VimeConfig,
+)
+from modal_training_gym.frameworks.vime.modal_helpers.utils import (
+    build_train_cmd,
+    get_checkpoint_conversion_policy,
+    prepare_vime_config,
+    resolve_checkpoint_ref,
+)
+
+VIME_ROOT = "/root/vime"
+# v0.8.0+ makes per-task CPU/memory requests configurable via enforcement
+# policies ("limit"/"ignore"), letting sandboxes burst on Modal and bill by
+# actual CPU-/RAM-second usage instead of over-provisioning a static reservation.
+HARBOR_PKG_VERSION = "0.8.0"
+
+
+def _build_vime_base_image(vime: VimeConfig) -> Image:
+    image = (
+        Image.from_registry(vime.docker_image)
+        .entrypoint([])
+        .run_commands(
+            f"rm -rf {HF_CACHE_PATH} 2>/dev/null || true",
+        )
+    )
+    if vime.image_env:
+        image = image.env(vime.image_env)
+    if vime.image_run_commands:
+        image = image.run_commands(*vime.image_run_commands)
+    return image
+
+
+def _has_torch_dist_checkpoint(save_path: str) -> bool:
+    if not os.path.isdir(save_path):
+        return False
+
+    tracker_path = os.path.join(save_path, "latest_checkpointed_iteration.txt")
+    if os.path.isfile(tracker_path):
+        try:
+            with open(tracker_path) as f:
+                marker = f.read().strip()
+        except OSError:
+            marker = ""
+        if marker == "release":
+            return os.path.isdir(os.path.join(save_path, "release"))
+        if marker.isdigit():
+            iter_dir = f"iter_{int(marker):07d}"
+            return os.path.isdir(os.path.join(save_path, iter_dir))
+
+    try:
+        return any(
+            entry.is_dir()
+            and (entry.name == "release" or entry.name.startswith("iter_"))
+            for entry in os.scandir(save_path)
+        )
+    except OSError:
+        return False
+
+
+def build_vime_app(
+    *,
+    training_run_id: str,
+    vime: VimeConfig,
+    model: ModelConfig,
+    dataset: DatasetConfig,
+    checkpoint: Checkpoint | None = None,
+    name: str | None = None,
+) -> App:
+    app_name = name or vime.name or f"vime-{type(vime).__name__.lstrip('_').lower()}"
+
+    caller_module = resolve_caller_module()
+    if caller_module is not None and caller_module.__name__ != "__main__":
+        cloudpickle.register_pickle_by_value(caller_module)
+    register_modal_cloudpickle_reducers()
+
+    caller_script = None
+    if caller_module is not None:
+        mod_file = getattr(caller_module, "__file__", None)
+        if mod_file and os.path.isfile(mod_file):
+            caller_script = os.path.abspath(mod_file)
+
+    image = _build_vime_base_image(vime)
+
+    for patch_file in vime.patch_files:
+        image = image.add_local_file(
+            patch_file,
+            remote_path=f"/tmp/{os.path.basename(patch_file)}",
+            copy=True,
+        )
+
+    if vime.local_vime:
+        image = image.add_local_dir(
+            vime.local_vime,
+            remote_path=VIME_ROOT,
+            copy=True,
+            ignore=["**/__pycache__", "**/*.pyc", "**/.git", "**/.venv"],
+        )
+
+    if vime.image_overlay is not None:
+        image = vime.image_overlay(image)
+        vime.image_overlay = None
+
+    if isinstance(dataset, HarborDataset):
+        image = image.uv_pip_install(f"harbor=={HARBOR_PKG_VERSION}")
+
+    image = image.add_local_python_source("modal_training_gym", copy=True)
+    image = image.uv_pip_install("randomname")
+    image = mount_tools_dir(image)
+
+    if caller_script is not None:
+        caller_module_name = os.path.splitext(os.path.basename(caller_script))[0]
+        image = image.add_local_file(
+            caller_script,
+            remote_path=f"/root/{caller_module_name}.py",
+            copy=True,
+        )
+
+    def _set_custom_config_value(key: str, value: str) -> None:
+        cfg = (
+            dict(vime.custom_config_path or {})
+            if isinstance(vime.custom_config_path, dict)
+            else {}
+        )
+        cfg[key] = value
+        vime.custom_config_path = cfg
+
+    def _ship_callable(
+        fn: Any,
+        *,
+        fallback_name: str,
+        set_path: Callable[[str], None],
+    ) -> None:
+        nonlocal image
+        if fn is None:
+            return
+        fn_mod = getattr(fn, "__module__", None) or ""
+        if fn_mod.startswith("modal_training_gym"):
+            return
+        try:
+            fn_file = os.path.abspath(inspect.getfile(fn))
+        except (TypeError, OSError):
+            fn_file = None
+        if fn_file and os.path.isfile(fn_file) and fn_file != caller_script:
+            fn_module_name = os.path.splitext(os.path.basename(fn_file))[0]
+            image = image.add_local_file(
+                fn_file,
+                remote_path=f"/root/{fn_module_name}.py",
+                copy=True,
+            )
+            set_path(f"{fn_module_name}.{getattr(fn, '__name__', fallback_name)}")
+            return
+        fn_name = getattr(fn, "__name__", fallback_name)
+        try:
+            payload = base64.b64encode(cloudpickle.dumps(fn)).decode("ascii")
+        except Exception:
+            module_src = textwrap.dedent(inspect.getsource(fn))
+        else:
+            module_src = textwrap.dedent(
+                f"""
+                import base64
+                import cloudpickle
+
+                {fn_name} = cloudpickle.loads(base64.b64decode({payload!r}))
+                """
+            ).lstrip()
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            prefix=f"notebook_{fallback_name}_",
+            delete=False,
+        ) as tmp:
+            tmp.write(module_src)
+            tmp_path = tmp.name
+        mod_name = os.path.splitext(os.path.basename(tmp_path))[0]
+        image = image.add_local_file(
+            tmp_path,
+            remote_path=f"/root/{mod_name}.py",
+            copy=True,
+        )
+        set_path(f"{mod_name}.{fn_name}")
+
+    _ship_callable(
+        vime.custom_rm_function,
+        fallback_name="custom_rm",
+        set_path=lambda path: _set_custom_config_value("custom_rm_path", path),
+    )
+    _ship_callable(
+        vime.custom_generate_function,
+        fallback_name="custom_generate",
+        set_path=lambda path: _set_custom_config_value(
+            "custom_generate_function_path", path
+        ),
+    )
+    vime.custom_rm_function = None
+    vime.custom_generate_function = None
+
+    hf_cache_volume = Volume.from_name("huggingface-cache", create_if_missing=True)
+    data_volume = Volume.from_name(f"{app_name}-data", create_if_missing=True)
+    checkpoints_volume_name = (
+        checkpoint.checkpoints_volume_name
+        if checkpoint is not None and checkpoint.checkpoints_volume_name
+        else f"{app_name}-checkpoints"
+    )
+    checkpoints_mount_path = (
+        checkpoint.checkpoints_mount_path.rstrip("/") or "/"
+        if checkpoint is not None and checkpoint.checkpoints_mount_path
+        else str(CHECKPOINTS_PATH).rstrip("/")
+    )
+    checkpoints_volume = Volume.from_name(
+        checkpoints_volume_name, create_if_missing=True
+    )
+    if checkpoint is not None and checkpoint.path and not model.model_path:
+        model.model_path = checkpoint.path
+
+    all_volumes: dict[str | PurePosixPath, Any] = {
+        str(HF_CACHE_PATH): hf_cache_volume,
+        str(DATA_PATH): data_volume,
+        checkpoints_mount_path: checkpoints_volume,
+    }
+
+    tags = {
+        **COMMON_TRAINING_GYM_TAGS,
+        "_modal_framework": "vime",
+        **vime.app_tags,
+    }
+    if vime.wandb is not None:
+        tags["_modal_wandb_project"] = vime.wandb.project
+        if vime.wandb.group:
+            tags["_modal_wandb_group"] = vime.wandb.group
+
+    app = App(app_name, tags=tags)
+    gpu_spec = f"{vime.gpu_type}:{vime.actor_num_gpus_per_node}"
+
+    @app.function(
+        image=image,
+        volumes={
+            str(HF_CACHE_PATH): hf_cache_volume,
+            checkpoints_mount_path: checkpoints_volume,
+        },
+        timeout=4 * 60 * 60,
+        secrets=hf_secrets(),
+        serialized=True,
+        name="download",
+    )
+    def download(
+        training_run_id: str = "",
+        framework_status_url: str = "",
+        framework_status_token: str = "",
+    ):
+        from modal_training_gym.common.status_reporter import (
+            enqueue_framework_status,
+            flush as flush_status_reporter,
+        )
+
+        if training_run_id:
+            enqueue_framework_status(
+                training_run_id,
+                VimeStatus.DOWNLOAD_MODEL.value,
+                url=framework_status_url or None,
+                token=framework_status_token or None,
+                is_active=True,
+            )
+        hf_cache_volume.reload()
+        checkpoints_volume.reload()
+        model.download()
+        vime.download_model()
+        vime.post_process_model()
+        hf_cache_volume.commit()
+        checkpoints_volume.commit()
+        if training_run_id:
+            flush_status_reporter(timeout_seconds=2.0)
+
+    @app.function(
+        image=image,
+        volumes={str(DATA_PATH): data_volume},
+        timeout=4 * 60 * 60,
+        secrets=hf_secrets(),
+        serialized=True,
+        name="prepare_dataset",
+    )
+    def prepare_dataset():
+        data_volume.reload()
+        prompt_data, eval_paths = VimeConfig._resolve_data_paths(dataset)
+        if dataset.always_prepare and os.path.exists(prompt_data):
+            import shutil
+
+            data_dir = os.path.dirname(prompt_data)
+            print(f"always_prepare=True - removing {data_dir}")
+            shutil.rmtree(data_dir, ignore_errors=True)
+        dataset.prepare(prompt_data, eval_paths)
+        dataset.validate_prepared(prompt_data)
+        for ep in (eval_paths or {}).values():
+            dataset.validate_prepared(ep)
+        data_volume.commit()
+
+    convert_nnodes = get_checkpoint_conversion_policy(vime, model=model)[0]
+    convert_multi_node = convert_nnodes > 1
+
+    @app.function(
+        image=image,
+        gpu=gpu_spec,
+        volumes=all_volumes,
+        timeout=4 * 60 * 60,
+        experimental_options={"efa_enabled": True} if convert_multi_node else {},
+        serialized=True,
+        name="convert_checkpoint",
+    )
+    @clustered_if(convert_multi_node, convert_nnodes, gpu_type=vime.gpu_type)
+    def convert_checkpoint(
+        training_run_id: str = "",
+        framework_status_url: str = "",
+        framework_status_token: str = "",
+    ):
+        from modal_training_gym.common.status_reporter import (
+            enqueue_framework_status,
+            flush as flush_status_reporter,
+        )
+
+        if training_run_id:
+            enqueue_framework_status(
+                training_run_id,
+                VimeStatus.CONVERT_MODEL.value,
+                url=framework_status_url or None,
+                token=framework_status_token or None,
+                is_active=True,
+            )
+
+        if getattr(vime, "megatron_to_hf_mode", None) == "bridge":
+            print("Bridge mode - no conversion needed.")
+            if training_run_id:
+                flush_status_reporter(timeout_seconds=2.0)
+            return
+
+        hf_cache_volume.reload()
+        checkpoints_volume.reload()
+
+        conversion_hf_checkpoint = (
+            getattr(vime, "megatron_conversion_hf_checkpoint", None)
+            or getattr(vime, "hf_checkpoint", "")
+            or model.model_path
+            or model.model_name
+        )
+        hf_path = resolve_checkpoint_ref(conversion_hf_checkpoint)
+        save_path = str(vime.ref_load)
+        num_nodes, nproc_per_node, extra_args = get_checkpoint_conversion_policy(
+            vime, model=model
+        )
+
+        if _has_torch_dist_checkpoint(save_path):
+            print(
+                f"Found existing torch_dist checkpoint at {save_path}; skipping conversion."
+            )
+            return
+
+        if num_nodes == 1:
+            node_rank, master_addr, nnodes = 0, "127.0.0.1", 1
+        else:
+            import modal.experimental
+
+            info = modal.experimental.get_cluster_info()
+            node_rank = info.rank
+            master_addr = info.container_ipv4_ips[0]
+            nnodes = len(info.container_ipv4_ips)
+
+        torchrun_args = [f"--nproc-per-node={nproc_per_node}"]
+        if nnodes > 1:
+            torchrun_args += [
+                f"--nnodes={nnodes}",
+                f"--node-rank={node_rank}",
+                f"--master-addr={master_addr}",
+                "--master-port=12355",
+            ]
+
+        import importlib.util
+
+        spec = importlib.util.find_spec(
+            "modal_training_gym.frameworks.vime.modal_helpers.convert_hf_to_torch_dist"
+        )
+        convert_script = (
+            spec.origin
+            if spec is not None and num_nodes > 1
+            else f"{VIME_ROOT}/tools/convert_hf_to_torch_dist.py"
+        )
+        if not convert_script:
+            raise RuntimeError("Vime checkpoint conversion script not found")
+
+        if vime.vime_model_script:
+            cmd = (
+                f"source {VIME_ROOT}/{vime.vime_model_script} && "
+                f"torchrun {' '.join(torchrun_args)} {convert_script} "
+                f"${{MODEL_ARGS[@]}} {' '.join(extra_args)} "
+                f"--hf-checkpoint {shlex.quote(hf_path)} --save {shlex.quote(save_path)}"
+            )
+        else:
+            cmd = (
+                f"torchrun {' '.join(torchrun_args)} {convert_script} "
+                f"{' '.join(extra_args)} "
+                f"--hf-checkpoint {shlex.quote(hf_path)} --save {shlex.quote(save_path)}"
+            )
+
+        env = {**os.environ, **vime.environment}
+        if num_nodes > 1:
+            env["SKIP_RELEASE_RENAME"] = "1"
+
+        print(
+            f"Conversion layout: nodes={num_nodes}, nproc_per_node={nproc_per_node}, "
+            f"node_rank={node_rank}"
+        )
+        print(f"Running: bash -c {cmd!r}")
+        subprocess.run(["bash", "-c", cmd], check=True, env=env)
+        checkpoints_volume.commit()
+
+        if node_rank == 0:
+            print(f"Saved Megatron torch_dist checkpoint to {save_path}")
+
+        if training_run_id:
+            flush_status_reporter(timeout_seconds=2.0)
+
+    # Modal's clustered scheduler demands a full GPU node (8×). Use it for any
+    # multi-node run, or for a single full node on RDMA-capable hardware (vime's
+    # colocated vLLM weight sync benefits from the RDMA/CUDA-IPC path). A partial
+    # single node (e.g. a 1-GPU smoke test) runs as a plain function instead.
+    _multi_node = vime.total_nodes > 1
+    _full_node = vime.actor_num_gpus_per_node >= 8
+    _use_clustered = _multi_node or (_full_node and _supports_rdma(vime.gpu_type))
+
+    @app.function(
+        image=image,
+        gpu=gpu_spec,
+        memory=vime.memory,
+        cloud=vime.cloud,
+        region=vime.region,
+        volumes=all_volumes,
+        secrets=[
+            *(
+                []
+                if vime.wandb is None
+                else [Secret.from_name(vime.wandb.modal_wandb_secret_name)]
+            ),
+        ],
+        timeout=24 * 60 * 60,
+        experimental_options={"efa_enabled": True} if _use_clustered else {},
+        serialized=True,
+        name="train",
+    )
+    @clustered_if(_use_clustered, vime.total_nodes, gpu_type=vime.gpu_type)
+    async def train(
+        modal_app_id: str = "",
+        modal_app_url: str = "",
+        framework_status_url: str = "",
+        framework_status_token: str = "",
+    ):
+        modal_app_id = modal_app_id or os.environ.get("MODAL_APP_ID", "")
+        modal_app_url = modal_app_url or modal_app_dashboard_url(modal_app_id)
+        if framework_status_url:
+            os.environ["TRAINING_GYM_FRAMEWORK_STATUS_URL"] = framework_status_url
+        if framework_status_token:
+            os.environ["TRAINING_GYM_FRAMEWORK_STATUS_TOKEN"] = framework_status_token
+
+        await asyncio.gather(
+            hf_cache_volume.reload.aio(),
+            data_volume.reload.aio(),
+            checkpoints_volume.reload.aio(),
+        )
+
+        cluster = ModalRayCluster()
+        cluster.discover_cluster(vime.total_nodes)
+
+        # vime's get_host_info() honors VIME_HOST_IP to pin the address the vLLM
+        # engines and vllm-router bind/register on (vime/utils/http_utils.py).
+        # Without it, UDP-probe IP discovery can pick the wrong interface on Modal.
+        os.environ["VIME_HOST_IP"] = cluster.node_ip
+
+        prep_id = hashlib.sha1(training_run_id.encode("utf-8")).hexdigest()[:16]
+        prep_marker = os.path.join(
+            checkpoints_mount_path, f".training_gym_prepared_{prep_id}"
+        )
+        prep_error = f"{prep_marker}.error"
+
+        run_record: TrainingRun | None = None
+
+        if cluster.is_head:
+            print(f"Training run id: {training_run_id}")
+            config_summary = {
+                "model": {"model_name": model.model_name} if model else {},
+                "recipe": {
+                    "gpu_type": vime.gpu_type,
+                    "actor_num_nodes": vime.actor_num_nodes,
+                    "actor_num_gpus_per_node": vime.actor_num_gpus_per_node,
+                },
+                "wandb": (
+                    {"project": vime.wandb.project, "group": vime.wandb.group}
+                    if vime.wandb
+                    else {}
+                ),
+                "dataset": {
+                    "hf_repo": getattr(dataset, "hf_repo", ""),
+                    "name": type(dataset).__name__,
+                },
+                "lr": vime.lr,
+                "global_batch_size": vime.global_batch_size,
+            }
+            # The local TrainConfig.train() driver creates the initial
+            # TrainingRun record before invoking download/convert_checkpoint
+            # so those phases are visible in the dashboard. Reuse it; fall
+            # back to a fresh record if someone invokes train() directly.
+            try:
+                run_record = await TrainingRun.from_id_async(training_run_id)
+                run_record.modal_app_id = modal_app_id
+                run_record.modal_app_url = modal_app_url
+                run_record.config = config_summary
+                run_record.framework_status = VimeStatus.INITIALIZING
+            except KeyError:
+                created_at = int(time.time())
+                run_record = TrainingRun(
+                    training_run_id=training_run_id,
+                    modal_app_id=modal_app_id,
+                    modal_app_url=modal_app_url,
+                    framework=Framework.VIME,
+                    config=config_summary,
+                    framework_status=VimeStatus.INITIALIZING,
+                    created_at=created_at,
+                    started_at=created_at,
+                )
+            if not framework_status_token:
+                framework_status_token = _secrets.token_urlsafe(32)
+            await run_record.save_async()
+            await vol_put_async(
+                MetadataStore.FRAMEWORK_STATUS_TOKENS,
+                training_run_id,
+                {"token": framework_status_token},
+            )
+            print(f"TrainingRun recorded: {training_run_id}")
+
+        # In-flight status updates are fire-and-forget HTTP POSTs to the
+        # dashboard so they don't block on Modal Volume writes. Terminal
+        # state is committed synchronously below.
+        from modal_training_gym.common.status_reporter import (
+            enqueue_framework_status,
+        )
+
+        async def _set_framework_status(status: VimeStatus) -> None:
+            if run_record is None:
+                return
+            run_record.framework_status = status
+            enqueue_framework_status(
+                training_run_id, status.value, token=framework_status_token
+            )
+
+        async def _prepare_shared_inputs() -> None:
+            await _set_framework_status(VimeStatus.DOWNLOAD_MODEL)
+            if model:
+                cache_dir = (
+                    HF_CACHE_PATH
+                    / "hub"
+                    / ("models--" + model.model_name.replace("/", "--"))
+                )
+                snapshots_dir = cache_dir / "snapshots"
+                has_snapshot = snapshots_dir.is_dir() and any(snapshots_dir.iterdir())
+                model_path = getattr(model, "model_path", None)
+                has_model_path = True
+                if model_path:
+                    model_path_obj = Path(model_path)
+                    has_model_path = model_path_obj.exists() and (
+                        not model_path_obj.is_dir() or any(model_path_obj.iterdir())
+                    )
+                if not has_snapshot or not has_model_path:
+                    print(f"Downloading model {model.model_name}...")
+                    model.download()
+                if hasattr(model, "prepare_runtime_cache"):
+                    model.prepare_runtime_cache()
+
+            vime.download_model()
+            await _set_framework_status(VimeStatus.CONVERT_MODEL)
+            vime.post_process_model()
+            await hf_cache_volume.commit.aio()
+            await checkpoints_volume.commit.aio()
+
+            await _set_framework_status(VimeStatus.PREPARE_DATASET)
+            prompt_data, eval_paths = VimeConfig._resolve_data_paths(dataset)
+            needs_prepare = not os.path.exists(prompt_data)
+            if dataset.always_prepare and os.path.exists(prompt_data):
+                data_dir = os.path.dirname(prompt_data)
+                print(f"always_prepare=True - removing {data_dir}")
+                shutil.rmtree(data_dir, ignore_errors=True)
+                needs_prepare = True
+            if needs_prepare:
+                print(f"Preparing dataset ({prompt_data})...")
+                dataset.prepare(prompt_data, eval_paths)
+                await data_volume.commit.aio()
+            dataset.validate_prepared(prompt_data)
+            for ep in (eval_paths or {}).values():
+                if os.path.exists(ep):
+                    dataset.validate_prepared(ep)
+
+        if cluster.is_head:
+            try:
+                await _prepare_shared_inputs()
+            except BaseException as exc:
+                if run_record is not None:
+                    finished_at = int(time.time())
+                    run_record.status = TrainingRunStatus.FAILED
+                    run_record.ended_at = finished_at
+                    run_record.completed_at = finished_at
+                    run_record.duration_seconds = max(
+                        0, finished_at - run_record.started_at
+                    )
+                    await run_record.save_async()
+                os.makedirs(os.path.dirname(prep_error), exist_ok=True)
+                with open(prep_error, "w") as f:
+                    f.write(repr(exc))
+                await checkpoints_volume.commit.aio()
+                raise
+            os.makedirs(os.path.dirname(prep_marker), exist_ok=True)
+            with open(prep_marker, "w") as f:
+                f.write(str(time.time()))
+            await checkpoints_volume.commit.aio()
+        else:
+            deadline = time.time() + 4 * 60 * 60
+            while True:
+                await asyncio.gather(
+                    hf_cache_volume.reload.aio(),
+                    data_volume.reload.aio(),
+                    checkpoints_volume.reload.aio(),
+                )
+                if os.path.exists(prep_marker):
+                    break
+                if os.path.exists(prep_error):
+                    with open(prep_error) as f:
+                        raise RuntimeError(f"Head preparation failed: {f.read()}")
+                if time.time() > deadline:
+                    raise TimeoutError("Timed out waiting for head preparation marker")
+                await asyncio.sleep(5)
+
+        cluster.start_ray()
+
+        if not cluster.is_head:
+            await cluster.wait_forever()
+            return
+        assert run_record is not None
+
+        try:
+            prepare_vime_config(vime, model, tempfile.mkdtemp())
+
+            if wandb_key := os.environ.get("WANDB_API_KEY", ""):
+                if vime.wandb is not None:
+                    vime.wandb.key = wandb_key
+
+            recipe_default_save_root = str(CHECKPOINTS_PATH).rstrip("/")
+            mounted_save_root = checkpoints_mount_path
+            configured_save_root = (
+                str(vime.save).rstrip("/") if vime.save else mounted_save_root
+            )
+            base_save_root = (
+                mounted_save_root
+                if configured_save_root == recipe_default_save_root
+                else configured_save_root
+            )
+            save_root = (
+                f"{mounted_save_root}/{training_run_id}"
+                if base_save_root == mounted_save_root
+                else configured_save_root
+            )
+            os.makedirs(save_root, exist_ok=True)
+
+            original_save = vime.save
+            original_load = vime.load
+            vime.save = save_root
+            if _has_torch_dist_checkpoint(save_root):
+                print(
+                    f"Detected existing checkpoint in {save_root}; "
+                    "will resume training from last saved iteration."
+                )
+                vime.load = save_root
+            try:
+                cmd = build_train_cmd(vime, VIME_ROOT, model=model, dataset=dataset)
+            finally:
+                vime.save = original_save
+                vime.load = original_load
+
+            runtime_env = {
+                "env_vars": {
+                    "no_proxy": f"127.0.0.1,{cluster.head_addr}",
+                    "MASTER_ADDR": cluster.head_addr,
+                    **vime.environment,
+                }
+            }
+
+            mode = "async" if vime.async_mode else "sync"
+            print(
+                f"Training {app_name} - {vime.total_nodes} node(s) x {gpu_spec} ({mode})"
+            )
+            print(f"Command: {cmd}, runtime_env: {runtime_env}")
+
+            await _set_framework_status(VimeStatus.TRAINING)
+            async with cluster.forward_dashboard() as tunnel:
+                print(f"Ray dashboard: {tunnel.url}")
+                await cluster.submit_and_tail(cmd, runtime_env=runtime_env)
+
+            result_kwargs = {
+                "app_name": app_name,
+                "framework": Framework.VIME,
+                "training_run_id": training_run_id,
+                "checkpoint_dir": save_root,
+                "model_config": model,
+                "checkpoints_volume_name": checkpoints_volume_name,
+                "checkpoints_mount_path": checkpoints_mount_path,
+            }
+            accepted_fields = set(inspect.signature(TrainResult).parameters)
+            result = TrainResult(
+                **{k: v for k, v in result_kwargs.items() if k in accepted_fields}
+            )
+            await result.save_async()
+            run_record.status = TrainingRunStatus.COMPLETED
+            await checkpoints_volume.commit.aio()
+            print(f"TrainResult saved: {training_run_id}")
+            return result._to_dict()
+        except KeyboardInterrupt:
+            run_record.status = TrainingRunStatus.STOPPED
+            raise
+        except BaseException:
+            run_record.status = TrainingRunStatus.FAILED
+            raise
+        finally:
+            finished_at = int(time.time())
+            run_record.ended_at = finished_at
+            if run_record.completed_at is None:
+                run_record.completed_at = finished_at
+            run_record.duration_seconds = max(0, finished_at - run_record.started_at)
+            await run_record.save_async()
+
+    for tag, fn in app.registered_functions.items():
+        setattr(app, tag, fn)
+
+    return app

--- a/modal_training_gym/frameworks/vime/modal_helpers/utils.py
+++ b/modal_training_gym/frameworks/vime/modal_helpers/utils.py
@@ -1,0 +1,148 @@
+"""Helpers for the Vime launcher.
+
+Checkpoint-ref resolution (HF repo → local snapshot), the Megatron conversion
+layout policy, YAML config materialization, and assembly of the ``train.py`` Ray
+job command. Mirrors the slime/miles helpers, adjusted for vime's paths and flags.
+"""
+
+import os
+import shlex
+from os import PathLike
+
+_CONVERSION_EXTRA_ARGS = [
+    ("decoder_first_pipeline_num_layers", "decoder-first-pipeline-num-layers"),
+    ("decoder_last_pipeline_num_layers", "decoder-last-pipeline-num-layers"),
+    ("mtp_num_layers", "mtp-num-layers"),
+    ("make_vocab_size_divisible_by", "make-vocab-size-divisible-by"),
+]
+
+
+def is_local_checkpoint_ref(ref: str | PathLike) -> bool:
+    return str(ref).startswith("/")
+
+
+def resolve_checkpoint_ref(
+    ref: str | PathLike,
+    *,
+    local_files_only: bool = True,
+) -> str:
+    ref_str = str(ref)
+    if is_local_checkpoint_ref(ref_str):
+        return ref_str
+
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(ref_str, local_files_only=local_files_only)
+
+
+def get_checkpoint_conversion_policy(
+    vime_cfg, model=None
+) -> tuple[int, int, list[str]]:
+    gpus_per_node = getattr(vime_cfg, "actor_num_gpus_per_node", 8)
+    actor_nodes = getattr(vime_cfg, "actor_num_nodes", 1)
+    tp = getattr(vime_cfg, "tensor_model_parallel_size", 1)
+    pp = getattr(vime_cfg, "pipeline_model_parallel_size", 1)
+
+    world_size = tp * pp if (tp > 1 or pp > 1) else gpus_per_node
+    max_world_size = actor_nodes * gpus_per_node
+    if world_size > max_world_size:
+        raise ValueError(
+            f"checkpoint conversion world_size={world_size} exceeds actor cluster capacity "
+            f"{actor_nodes}x{gpus_per_node}={max_world_size}"
+        )
+
+    for num_nodes in range(1, actor_nodes + 1):
+        if world_size % num_nodes != 0:
+            continue
+        nproc_per_node = world_size // num_nodes
+        if nproc_per_node > gpus_per_node:
+            continue
+
+        extra_args: list[str] = []
+        if tp > 1 or pp > 1:
+            extra_args += [
+                f"--tensor-model-parallel-size {tp}",
+                f"--pipeline-model-parallel-size {pp}",
+            ]
+        for attr, flag in _CONVERSION_EXTRA_ARGS:
+            if x := getattr(vime_cfg, attr, None):
+                extra_args.append(f"--{flag} {x}")
+
+        if model and getattr(model, "architecture", None):
+            arch = model.architecture
+            for attr, flag in [
+                ("num_layers", "num-layers"),
+                ("hidden_size", "hidden-size"),
+                ("ffn_hidden_size", "ffn-hidden-size"),
+                ("num_attention_heads", "num-attention-heads"),
+                ("num_query_groups", "num-query-groups"),
+                ("kv_channels", "kv-channels"),
+                ("vocab_size", "vocab-size"),
+                ("norm_epsilon", "norm-epsilon"),
+                ("rotary_base", "rotary-base"),
+            ]:
+                val = getattr(arch, attr, 0)
+                if val:
+                    extra_args.append(f"--{flag} {val}")
+            if arch.group_query_attention:
+                extra_args.append("--group-query-attention")
+            if arch.swiglu:
+                extra_args.append("--swiglu")
+            if arch.disable_bias_linear:
+                extra_args.append("--disable-bias-linear")
+            if arch.qk_layernorm:
+                extra_args.append("--qk-layernorm")
+            if arch.untie_embeddings_and_output_weights:
+                extra_args.append("--untie-embeddings-and-output-weights")
+            if arch.normalization and arch.normalization != "LayerNorm":
+                extra_args.append(f"--normalization {arch.normalization}")
+            if arch.use_rotary_position_embeddings:
+                extra_args.append("--use-rotary-position-embeddings")
+                extra_args.append("--position-embedding-type rope")
+
+        return num_nodes, nproc_per_node, extra_args
+
+    raise ValueError(
+        f"cannot find checkpoint conversion layout for world_size={world_size} "
+        f"with actor_num_nodes={actor_nodes}, actor_num_gpus_per_node={gpus_per_node}"
+    )
+
+
+def prepare_vime_config(vime_cfg, model, tmpdir: str) -> None:
+    import yaml
+
+    from modal_training_gym.train_recipes.vime_recipe.recipe import YAML_CONFIG_FIELDS
+
+    if (
+        model
+        and not model.model_path
+        and model.model_name
+        and not str(model.model_name).startswith("/")
+    ):
+        model.model_path = resolve_checkpoint_ref(model.model_name)
+
+    for attr in ("hf_checkpoint", "load", "ref_load", "critic_load"):
+        if val := getattr(vime_cfg, attr, None):
+            object.__setattr__(vime_cfg, attr, resolve_checkpoint_ref(val))
+
+    for field in YAML_CONFIG_FIELDS:
+        if isinstance(val := getattr(vime_cfg, field, None), dict):
+            path = os.path.join(tmpdir, f"{field}.yaml")
+            with open(path, "w") as f:
+                yaml.dump(val, f)
+            print(f"Materialized {field} -> {path}")
+            object.__setattr__(vime_cfg, field, path)
+
+
+def build_train_cmd(vime_cfg, vime_root: str, model=None, dataset=None) -> str:
+    train_script = (
+        f"{vime_root}/{'train_async.py' if vime_cfg.async_mode else 'train.py'}"
+    )
+    cli_args = shlex.join(vime_cfg.cli_args(dataset=dataset, model=model))
+    if vime_cfg.vime_model_script:
+        inner = (
+            f"source {vime_root}/{vime_cfg.vime_model_script} && "
+            f"python3 {train_script} ${{MODEL_ARGS[@]}} {cli_args}"
+        )
+        return f"bash -c {shlex.quote(inner)}"
+    return f"python3 {train_script} {cli_args}"

--- a/modal_training_gym/train_recipes/base.py
+++ b/modal_training_gym/train_recipes/base.py
@@ -5,6 +5,7 @@ from enum import Enum
 class RecipeType(Enum):
     SLIME = "slime"
     MILES = "miles"
+    VIME = "vime"
 
 
 class BaseTrainRecipe(ABC):

--- a/modal_training_gym/train_recipes/vime_recipe/__init__.py
+++ b/modal_training_gym/train_recipes/vime_recipe/__init__.py
@@ -1,0 +1,7 @@
+from modal_training_gym.train_recipes.vime_recipe.recipe import VimeConfig
+from modal_training_gym.train_recipes.vime_recipe.qwen3_4b import Qwen3_4b_Vime_Recipe
+
+__all__ = [
+    "VimeConfig",
+    "Qwen3_4b_Vime_Recipe",
+]

--- a/modal_training_gym/train_recipes/vime_recipe/qwen3_4b.py
+++ b/modal_training_gym/train_recipes/vime_recipe/qwen3_4b.py
@@ -1,0 +1,36 @@
+from modal_training_gym.train_recipes.vime_recipe.recipe import VimeConfig
+
+
+class Qwen3_4b_Vime_Recipe(VimeConfig):
+    """Qwen3-4B GRPO on a single 8×H100 node, colocated, vLLM rollout.
+
+    Mirrors the slime ``Qwen3_4b_Recipe`` defaults but routes the rollout
+    through vime's vLLM backend. Vime upstream ships ``scripts/run-qwen3-4B.sh``;
+    these defaults track it. Bring your own ``custom_rm_function`` (and optionally
+    ``wandb=WandbConfig(...)``).
+    """
+
+    gpu_type: str = "H100"
+    colocate: bool = True
+    actor_num_nodes: int = 1
+    actor_num_gpus_per_node: int = 8
+
+    tensor_model_parallel_size: int = 1
+    sequence_parallel: bool = False
+    rollout_num_gpus_per_engine: int = 1
+
+    num_rollout: int = 1
+    rollout_batch_size: int = 16
+    n_samples_per_prompt: int = 8
+    rollout_max_response_len: int = 4096
+    rollout_temperature: float = 1.0
+
+    save_interval: int = 10
+    megatron_to_hf_mode: str = "bridge"
+
+    lr: float = 5e-7
+    max_tokens_per_gpu: int = 8192
+    eval_interval: int | None = 10
+    eval_max_response_len: int = 4096
+
+    vllm_gpu_memory_utilization: float = 0.7

--- a/modal_training_gym/train_recipes/vime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/vime_recipe/recipe.py
@@ -1,0 +1,369 @@
+import json
+import math
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import modal
+
+from modal_training_gym.common.dataset import DatasetConfig
+from modal_training_gym.common.models import ModelConfig
+from modal_training_gym.common.wandb import WandbConfig
+from modal_training_gym.train_recipes.base import BaseTrainRecipe, RecipeType
+
+HF_CACHE_PATH = Path("/root/.cache/huggingface")
+DATA_PATH = Path("/data")
+CHECKPOINTS_PATH = Path("/checkpoints")
+
+_VIME_SKIP = {
+    "recipe_type",
+    "environment",
+    "async_mode",
+    "vime_model_script",
+    "source_hf_checkpoint",
+    "megatron_conversion_hf_checkpoint",
+    "docker_image",
+    "gpu_type",
+    "memory",
+    "cloud",
+    "region",
+    "name",
+    "app_tags",
+    "image_overlay",
+    "image_run_commands",
+    "image_env",
+    "local_vime",
+    "patch_files",
+    "wandb",
+    "custom_rm_function",
+    "custom_generate_function",
+}
+
+YAML_CONFIG_FIELDS = ("eval_config", "custom_config_path", "vllm_config")
+JSON_CONFIG_FIELDS = ("train_env_vars", "apply_chat_template_kwargs", "multimodal_keys")
+
+
+class VimeConfig(BaseTrainRecipe):
+    """Training Gym config for Vime training on Modal.
+
+    Vime (https://github.com/vllm-project/vime) is the vLLM project's fork of
+    slime: it keeps slime's Megatron training stack and Data Buffer dataflow and
+    swaps the rollout backend from SGLang to vLLM + vllm-router. This config
+    mirrors ``MilesConfig`` (which mirrors the standalone slime/vime CLI) while
+    adding Training Gym model, dataset, wandb, and custom reward wiring.
+
+    Non-launcher attributes become Vime CLI flags (``--key-with-dashes``). vLLM
+    engine options use the ``--vllm-`` prefix and router options the
+    ``--vllm-router-`` / ``--router-`` prefix, matching vime's argument surface
+    (``vime/backends/vllm_utils/arguments.py``). Any extra attribute set on a
+    subclass or via kwargs is forwarded as a flag, so the full vLLM
+    ``AsyncEngineArgs`` surface is reachable as ``vllm_<arg>``.
+    """
+
+    recipe_type: RecipeType = RecipeType.VIME
+
+    # Prebuilt vime image (vLLM + Megatron + vllm-router), see vime quick-start.
+    docker_image: str = "inferactinc/public:vime-latest"
+    gpu_type: str = "H100"
+    memory: tuple[int, int] | None = None
+    cloud: str | None = None
+    region: str | None = None
+    name: str = ""
+    app_tags: dict = {}
+    image_overlay: Callable[[modal.Image], modal.Image] | None = None
+    image_run_commands: list[str] = []
+    image_env: dict[str, str] = {}
+    local_vime: str | None = None
+    patch_files: list[str] = []
+
+    # vime runs ``python3 /root/vime/train.py``; both vime and Megatron-LM must be
+    # importable (mirrors vime's run scripts: PYTHONPATH=${VIME_ROOT}:/root/Megatron-LM/).
+    environment: dict = {
+        "PYTHONPATH": "/root/vime:/root/Megatron-LM/",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        "NCCL_NVLS_ENABLE": "1",
+    }
+    async_mode: bool = False
+    vime_model_script: str = ""
+    source_hf_checkpoint: str | None = None
+    megatron_conversion_hf_checkpoint: str | None = None
+    wandb: WandbConfig | None = None
+
+    actor_num_nodes: int = 1
+    actor_num_gpus_per_node: int = 8
+    rollout_num_gpus: int | None = None
+    colocate: bool = True
+    use_critic: bool = False
+    critic_num_nodes: int | None = None
+    critic_num_gpus_per_node: int | None = None
+
+    hf_checkpoint: str = ""
+    save: str = str(CHECKPOINTS_PATH)
+    load: str = ""
+    ref_load: str = ""
+    megatron_to_hf_mode: str = "bridge"
+    save_interval: int = 10
+
+    num_rollout: int = 1
+    rollout_batch_size: int = 16
+    n_samples_per_prompt: int = 8
+    rollout_max_response_len: int = 4096
+    rollout_temperature: float = 1.0
+    rollout_shuffle: bool = True
+    rollout_num_gpus_per_engine: int = 1
+
+    tensor_model_parallel_size: int = 1
+    pipeline_model_parallel_size: int = 1
+    sequence_parallel: bool = False
+    train_backend: str = "megatron"
+
+    global_batch_size: int = 16
+    lr: float = 1e-6
+    lr_decay_style: str = "constant"
+    weight_decay: float = 0.1
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.98
+    optimizer: str = "adam"
+
+    lora_rank: int | None = None
+    lora_alpha: int | None = None
+    lora_dropout: float | None = None
+    target_modules: str | None = None
+    no_gradient_accumulation_fusion: bool = False
+    use_tis: bool = False
+
+    advantage_estimator: str = "grpo"
+    eps_clip: float = 0.2
+    eps_clip_high: float = 0.28
+    kl_loss_type: str = "low_var_kl"
+    kl_loss_coef: float = 0.0
+    entropy_coef: float = 0.0
+    use_kl_loss: bool = False
+    rm_type: str | None = None
+
+    attention_dropout: float = 0.0
+    hidden_dropout: float = 0.0
+    attention_softmax_in_fp32: bool = True
+    accumulate_allreduce_grads_in_fp32: bool = True
+    use_dynamic_batch_size: bool = True
+    max_tokens_per_gpu: int = 9216
+
+    eval_interval: int | None = None
+    n_samples_per_eval_prompt: int = 4
+    eval_max_response_len: int = 16384
+    eval_top_p: float = 1.0
+    eval_config: dict | str | None = None
+    skip_eval_before_train: bool = False
+
+    custom_config_path: dict | str | None = None
+    apply_chat_template_kwargs: str | dict = ""
+
+    # ── vLLM rollout engine + vllm-router (replaces slime/miles sglang_*) ──────
+    # Flag names follow vime's argument surface; the launcher leaves
+    # router ip/port unset so vime auto-assigns them on the head node.
+    vllm_gpu_memory_utilization: float = 0.7
+    vllm_router_policy: str = "consistent_hash"
+    router_request_timeout_secs: int = 14400
+    vllm_server_concurrency: int = 512
+    vllm_router_ip: str | None = None
+    vllm_router_port: int | None = None
+    vllm_config: dict | str | None = None
+
+    custom_rm_function: Callable | None = None
+    custom_generate_function: Callable | None = None
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.environment = dict(type(self).environment)
+        self.app_tags = dict(type(self).app_tags)
+        self.image_run_commands = list(type(self).image_run_commands)
+        self.image_env = dict(type(self).image_env)
+        self.patch_files = list(type(self).patch_files)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def _class_fields(self) -> dict[str, Any]:
+        fields: dict[str, Any] = {}
+        for cls in reversed(type(self).__mro__):
+            if cls is object:
+                continue
+            fields.update(
+                {
+                    k: v
+                    for k, v in vars(cls).items()
+                    if not k.startswith("_")
+                    and not isinstance(v, (staticmethod, classmethod, property))
+                    and not callable(v)
+                }
+            )
+        return fields
+
+    @staticmethod
+    def _resolve_data_paths(ds: DatasetConfig) -> tuple[str, dict[str, str] | None]:
+        hf_repo = getattr(ds, "hf_repo", "")
+        name = hf_repo.replace("/", "_") if hf_repo else type(ds).__name__
+        fmt = getattr(ds, "output_format", "parquet")
+        ext = "jsonl" if fmt == "jsonl" else "parquet"
+        split = getattr(ds, "hf_split", "train")
+        prompt_data = f"{DATA_PATH}/{name}/{split}.{ext}"
+        eval_prompt_data = {"eval": f"{DATA_PATH}/{name}/eval.{ext}"}
+        return prompt_data, eval_prompt_data
+
+    @staticmethod
+    def _dataset_to_fields(ds: DatasetConfig) -> dict[str, Any]:
+        prompt_data, eval_paths = VimeConfig._resolve_data_paths(ds)
+        eval_prompt_data: list[str] | None = None
+        if eval_paths:
+            eval_prompt_data = [
+                v for name, path in eval_paths.items() for v in (name, path)
+            ]
+        return {
+            "prompt_data": prompt_data,
+            "eval_prompt_data": eval_prompt_data,
+            "input_key": ds.input_key,
+            "label_key": ds.label_key,
+            "apply_chat_template": ds.apply_chat_template,
+        }
+
+    @staticmethod
+    def _model_to_fields(m: ModelConfig) -> dict[str, Any]:
+        fields: dict[str, Any] = {"hf_checkpoint": m.model_path or m.model_name}
+        arch = getattr(m, "architecture", None)
+        if arch is None:
+            return fields
+        fields.update(
+            {
+                "num_layers": arch.num_layers,
+                "hidden_size": arch.hidden_size,
+                "ffn_hidden_size": arch.ffn_hidden_size,
+                "num_attention_heads": arch.num_attention_heads,
+                "group_query_attention": arch.group_query_attention,
+                "num_query_groups": arch.num_query_groups,
+                "kv_channels": arch.kv_channels,
+                "vocab_size": arch.vocab_size,
+                "normalization": arch.normalization,
+                "norm_epsilon": arch.norm_epsilon,
+                "swiglu": arch.swiglu,
+                "disable_bias_linear": arch.disable_bias_linear,
+                "qk_layernorm": arch.qk_layernorm,
+                "untie_embeddings_and_output_weights": arch.untie_embeddings_and_output_weights,
+                "use_rotary_position_embeddings": arch.use_rotary_position_embeddings,
+                "rotary_base": arch.rotary_base,
+            }
+        )
+        optional = {
+            "num_experts": arch.num_experts,
+            "moe_ffn_hidden_size": arch.moe_ffn_hidden_size,
+            "moe_shared_expert_intermediate_size": arch.moe_shared_expert_intermediate_size,
+            "moe_router_topk": arch.moe_router_topk,
+            "moe_router_score_function": arch.moe_router_score_function,
+            "moe_token_drop_policy": arch.moe_token_drop_policy,
+            "moe_router_dtype": arch.moe_router_dtype,
+            "moe_aux_loss_coeff": arch.moe_aux_loss_coeff,
+            "spec": arch.megatron_spec,
+            "rotary_percent": arch.rotary_percent
+            if arch.rotary_percent != 1.0
+            else None,
+        }
+        fields.update({k: v for k, v in optional.items() if v not in (None, "", 0)})
+        for key in (
+            "moe_grouped_gemm",
+            "moe_shared_expert_gate",
+            "moe_permute_fusion",
+            "apply_layernorm_1p",
+            "use_gated_attention",
+            "attention_output_gate",
+        ):
+            if getattr(arch, key):
+                fields[key] = True
+        return fields
+
+    @staticmethod
+    def _wandb_to_fields(w: WandbConfig) -> dict[str, Any]:
+        return {
+            "use_wandb": True,
+            "wandb_project": w.project,
+            "wandb_group": w.group,
+            "wandb_key": w.key,
+            "disable_wandb_random_suffix": w.disable_random_suffix,
+        }
+
+    def _fields(
+        self,
+        dataset: DatasetConfig | None = None,
+        model: ModelConfig | None = None,
+    ) -> dict[str, Any]:
+        fields = self._class_fields()
+        fields.update(vars(self))
+        if model is not None:
+            for k, v in self._model_to_fields(model).items():
+                if k == "hf_checkpoint" and fields.get(k):
+                    continue
+                fields[k] = v
+        if dataset is not None:
+            fields.update(self._dataset_to_fields(dataset))
+        if self.wandb is not None:
+            fields.update(self._wandb_to_fields(self.wandb))
+        return {k: v for k, v in fields.items() if k not in _VIME_SKIP}
+
+    def cli_args(
+        self,
+        dataset: DatasetConfig | None = None,
+        model: ModelConfig | None = None,
+    ) -> list[str]:
+        out: list[str] = []
+        for key, val in self._fields(dataset=dataset, model=model).items():
+            if val is None or val is False or val == "":
+                continue
+            flag = f"--{key.replace('_', '-')}"
+            if val is True:
+                out.append(flag)
+            elif isinstance(val, dict) and key in JSON_CONFIG_FIELDS:
+                out += [flag, json.dumps(val)]
+            elif isinstance(val, list):
+                out += [flag] + [str(v) for v in val]
+            else:
+                out += [flag, str(val)]
+        return out
+
+    @property
+    def total_nodes(self) -> int:
+        f = self._fields()
+        gpus_per_node = f.get("actor_num_gpus_per_node", 8)
+        actor_nodes = f.get("actor_num_nodes", 1)
+        colocate = f.get("colocate", False)
+        use_critic = f.get("use_critic", False)
+        critic_nodes = f.get("critic_num_nodes") or actor_nodes
+        critic_gpus = f.get("critic_num_gpus_per_node") or gpus_per_node
+        rollout_gpus = f.get("rollout_num_gpus")
+
+        training_gpus = actor_nodes * gpus_per_node
+        if use_critic:
+            training_gpus += critic_nodes * critic_gpus
+
+        if colocate:
+            total_gpus = training_gpus
+        else:
+            rollout_gpus = rollout_gpus or (actor_nodes * gpus_per_node)
+            total_gpus = training_gpus + rollout_gpus
+
+        if total_gpus % gpus_per_node != 0:
+            raise ValueError(
+                f"total_gpus={total_gpus} is not a multiple of gpus_per_node={gpus_per_node}. "
+                "Adjust actor_num_nodes, rollout_num_gpus, or actor_num_gpus_per_node."
+            )
+        return math.ceil(total_gpus / gpus_per_node)
+
+    def download_model(self) -> None:
+        from modal_training_gym.frameworks.vime.modal_helpers.utils import (
+            resolve_checkpoint_ref,
+        )
+
+        ref = self.source_hf_checkpoint or self.hf_checkpoint
+        if ref:
+            resolve_checkpoint_ref(ref, local_files_only=False)
+
+    def post_process_model(self) -> None:
+        pass
+
+    def post_process_data(self) -> None:
+        pass

--- a/modal_training_gym/train_recipes/vime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/vime_recipe/recipe.py
@@ -216,13 +216,18 @@ class VimeConfig(BaseTrainRecipe):
             eval_prompt_data = [
                 v for name, path in eval_paths.items() for v in (name, path)
             ]
-        return {
+        fields: dict[str, Any] = {
             "prompt_data": prompt_data,
             "eval_prompt_data": eval_prompt_data,
             "input_key": ds.input_key,
             "label_key": ds.label_key,
             "apply_chat_template": ds.apply_chat_template,
         }
+        # A MultimodalDataset declares ``{modality: media_column}``; vime's default
+        # rollout forwards those columns to the engine as image/audio content.
+        if getattr(ds, "multimodal_keys", None):
+            fields["multimodal_keys"] = ds.multimodal_keys
+        return fields
 
     @staticmethod
     def _model_to_fields(m: ModelConfig) -> dict[str, Any]:

--- a/omni.md
+++ b/omni.md
@@ -1,0 +1,147 @@
+# Qwen3-Omni-30B with Vime — scoping & journal
+
+Status: **partial — training bridge works; omni rollout blocked on an upstream
+vLLM-omni bug.** Branch `ben/vime-qwen3-omni-30b`, off `ben/VimeRecipe` / #148.
+Goal: GRPO-train **Qwen3-Omni-30B-A3B** with vime on a multimodal (audio+image+text)
+dataset, serve+eval, and visualize all modalities on the dashboard.
+
+## TL;DR state
+- ✅ **vime multimodal foundation** (image): `MultimodalDataset` `multimodal_keys` →
+  vime rollout → bridge train. Validated end-to-end with **Qwen3-VL-4B image+text GRPO**
+  on Modal (committed). This is the reusable base for omni.
+- ✅ **Qwen3-Omni-30B `qwen_omni` training bridge loads the 30B MoE Thinker into
+  Megatron** (the research-gated unknown — resolved). Cleared arch validation, MoE
+  expert-parallel args, the chat-template path, and the audio-tower TP-divisibility.
+- ❌ **Blocked: the omni vLLM *rollout* engine** fails at init with
+  `RuntimeError: cu_seqlens_q must be on CUDA` — an upstream vLLM bug in the
+  Qwen3-Omni vision/audio encoder warmup (vLLM 0.22 in the image; known omni encoder
+  issues exist upstream). Not a gym/vime config bug. Until rollout serves omni, GRPO
+  can't run. Options: bump/patch vLLM in the image, a serving workaround
+  (limit-mm / encoder attn backend), or upstream fix.
+- 📋 **Not started** (gated on rollout): audio in the rollout (vime is vision-only),
+  `convert_qwen3omni_to_hf` for serving, the audio+image+text dataset, dashboard.
+
+## Feasibility probe (vime image `inferactinc/public:vime-latest`)
+- transformers **5.9.0**, vllm **0.22.0**, torch 2.11.0+cu129.
+- transformers has `Qwen3OmniMoeConfig` / `Qwen3OmniMoeForConditionalGeneration` /
+  `Qwen3OmniMoeThinkerForConditionalGeneration`, and `Qwen3VLMoe*`.
+- `AutoConfig(Qwen/Qwen3-Omni-30B-A3B-Instruct)` → `Qwen3OmniMoeConfig`, subconfigs
+  `thinker_config` (perception→text — **what we train**), `talker_config` (speech
+  out — not needed for GRPO), `code2wav_config` (vocoder — not needed).
+- vLLM **serves** `Qwen3OmniMoeForConditionalGeneration` (+ `Qwen3VLMoe`, `Qwen3ASR`,
+  `Qwen2_5Omni`). → **rollout side is supported.**
+- megatron→HF: vime ships `megatron_to_hf/qwen3_vl.py` (vision+text MoE) and
+  megatron.bridge has a `qwen3_asr` model dir (audio+text), but **no `qwen3_omni`**.
+  → **training/convert bridge for the omni Thinker is the patch gap.**
+
+## Architecture
+Qwen3-Omni Thinker = Qwen3-30B-A3B **MoE text backbone** + **SigLIP-2 vision** encoder
++ **AuT audio** encoder (≈ Qwen3-VL-30B-A3B + an audio tower). So:
+- the text/vision half ≈ vime's supported **Qwen3-VL-30B-A3B** (qwen3_vl bridge),
+- the audio half ≈ the gym's existing **Qwen3-ASR** work (audio tower via megatron.bridge).
+
+## Plan (one experiment at a time; de-risk cheap → expensive)
+**Phase 1 — validate vime multimodal plumbing on a small VL model (cheap).**
+Build the gym's vime multimodal path (multi-media `MultimodalDataset`, `--multimodal-keys`,
+VLM rollout, VL bridge load + megatron→HF convert) on **Qwen3-VL-4B-Instruct**, image+text
+GRPO, single node. Mirrors vime's `examples/geo3k_vlm_multi_turn`. Isolates "does gym×vime
+multimodal work" from the omni audio patch.
+
+**Phase 2 — Qwen3-Omni-30B-A3B (the target).**
+Add: `Qwen3_Omni_30B` model config (Thinker text-MoE `architecture` + vision/audio specs),
+a vime omni recipe preset, an **audio+image+text** dataset, and the **omni Thinker megatron
+bridge patch** (extend qwen3_vl with the AuT audio tower; reference the gym's qwen3_asr
+audio handling). Multinode. Train → serve (vLLM omni) → eval.
+
+**Dashboard** — EvalsPage already renders audio/image (from the ASR work). Multi-modality
+rows may need a small extension; per the ask, bundle if cheap, else a follow-up PR.
+
+## Open risks
+- Omni Thinker megatron bridge (HF→megatron load for training, megatron→HF for serve) —
+  no upstream mapping; the core patch. May need to combine qwen3_vl + qwen3_asr logic.
+- Multimodal rollout: does vime's vLLM rollout pass audio (not just image) to the engine?
+  geo3k proves image; audio is unverified.
+- Training only the Thinker (ignore Talker/code2wav) cleanly.
+- 30B MoE multinode cost/topology.
+
+## Plumbing facts (from vime source)
+- Multimodal rollout: vime's **default** vLLM rollout forwards `multimodal_inputs["images"]`
+  as image content when `--multimodal-keys '{"image":"images"}'` is set (no custom fn for
+  single-turn). **Audio is NOT in that default path** (vllm_rollout only handles images) →
+  omni audio needs a rollout extension. Prompt must contain the modality placeholder
+  (`<image>`/`<audio>`/`<video>`). Image column accepts data-URI/URL/path → PIL.
+- Gym wiring: `VimeConfig._dataset_to_fields` now forwards `ds.multimodal_keys` (added).
+- Conversion (megatron→HF) dispatches by `model_name` to per-model converters incl.
+  `convert_qwen3vl_to_hf` (maps `vision_model.*`→`model.visual.*`). **No `qwen3_omni`
+  converter** → must add one (extend VL + audio tower) and patch it into the vime image.
+
+## Omni bridge: GOOD NEWS — training bridge likely exists
+megatron.bridge ships model dirs incl. **`qwen_omni`**, `qwen_vl`, `qwen3_asr`,
+`qwen_audio` (`.../megatron/bridge/models/`). So the **training-side** HF→megatron
+load for the Qwen3-Omni Thinker is probably built-in (AutoBridge dispatch), unlike
+the megatron→HF *converter* (no `qwen3_omni` in vime's `megatron_to_hf` → serving
+gap remains).
+
+Qwen3-Omni-30B-A3B **Thinker** text backbone (exact, from config): num_layers=48,
+hidden=2048, intermediate_size=768 (==moe_intermediate_size; all-MoE), heads=32,
+kv_heads=4, head_dim=128, vocab=**152064**, rms_norm_eps=1e-6, 128 experts top-8,
+tie_word_embeddings=False. `rope_theta`/`rope_scaling` **absent** (MRoPE via
+`rope_parameters`) — validation behavior TBD (try rotary_base=1e6). MoE/vision/audio
+sub-configs are read from the HF checkpoint (vime only validates the 6 base text fields).
+
+Cost lever: vime's `hf_validate_args` runs at `parse_args` **before** the 60GB
+download, so arch flags can be cleared on a cheap **1-GPU fast-fail** run, then go
+multinode for the real 30B train.
+
+## Omni patch surface (Phase 2)
+1. Training bridge: HF→megatron load of the omni Thinker (VL text-MoE + vision + AuT audio).
+2. megatron→HF converter `convert_qwen3omni_to_hf` (qwen3_vl + audio tower), registered in dispatch.
+3. Rollout: pass audio (+image) to the vLLM engine (extend default rollout / custom fn).
+4. Dataset: multi-modality (image+audio+text); extend single-modality `MultimodalDataset`.
+
+## Audio rollout gap (confirmed)
+vime's rollout + data pipeline are **vision-only**: `process_vision_info` and the
+image path in `vllm_rollout.py` (line ~303 reads only `multimodal_inputs["images"]`).
+No `process_audio_info` / no audio passed to the engine. So audio needs a patch:
+extract audio from the `<audio>`-placeholdered messages and send it to vLLM as
+`input_audio` content (vLLM omni accepts it). Patch into the vime image like the
+gym's slime ASR patches. This is the hardest omni-specific piece — gated on the
+image+text omni run proving the `qwen_omni` bridge first.
+
+## Experiments log
+- ✅ Probe (CPU): versions + omni support mapped. run `ap-gHxzjIHu4HYbMKJUL97LcZ`.
+- Phase 1 Qwen3-VL-4B image+text GRPO (1×H100), iterating:
+  - ❌ rope_theta mismatch (VL-4B uses 5e6, not Qwen3-4B's 1e6) — vime `hf_validate_args`.
+  - ❌ `architecture=None` → all base fields mismatch (vime *requires* the 6 base text
+    fields: hidden_size/heads/layers/ffn/norm_eps/rope_theta; MoE/vision read from HF).
+  - ❌ vLLM KV cache OOM: VL default max_model_len=262144 (256K) → 36 GiB KV. Fix:
+    `--vllm-max-model-len 8192`.
+  - ✅ **Multimodal rollout VALIDATED**: image → vime default rollout → vLLM VL inference
+    → `<|vision_start|><|image_pad|><|vision_end|>` prompt, model answered "yellow",
+    **reward 1.0**. The gym×vime image plumbing works end to end.
+  - ❌ then CUDA OOM at the megatron train step (VL-4B optim states + colocated vLLM >80GB
+    on 1 GPU). Fix in flight: `optimizer_cpu_offload` (+ precision-aware/overlap), vllm
+    util 0.5. → the same memory lever omni-30B needs.
+  - ✅ re-run `bxz2simu4`: **VL image+text GRPO trains end-to-end** (8 steps, image
+  rollout reward 1.0, optimizer offload, checkpoint `convex-bit-2dc9af577e02`).
+  Multimodal foundation validated + committed.
+- Phase 2 Qwen3-Omni-30B-A3B image+text on **1×8 H100** (TP4/EP8/SP + offload, vime's
+  proven 30B-A3B parallelism):
+  - ✅ arch cleared `hf_validate_args` (MoE/rope/intermediate checks skipped as predicted).
+  - ❌ `num_experts must be non None to use expert model parallelism` — MoE fields
+    aren't auto-read; must pass `--num-experts` etc. Added to the model arch (128
+    experts, moe_ffn 768, top-8, softmax) + `moe_token_dispatcher_type=alltoall`.
+  - ✅ `bqcqearo7`: **`qwen_omni` bridge loaded the 30B Thinker into Megatron** (MoE
+    model built, num_experts=128 accepted). Failed at RolloutManager init:
+    `tokenizer.chat_template is not set` — omni keeps its template on the processor,
+    not the bare tokenizer vime templates with client-side.
+  - Fix: `apply_chat_template=False` (vime still builds the multimodal message list
+    via multimodal_keys; vLLM applies the omni template server-side — same as the
+    ASR config).
+  - ✅ `bqzyveu7p`: chat-template fixed. Failed in vLLM rollout engine: the omni
+    **audio tower** has 20 attn heads → `divide(20, tp=8)` assertion (rollout TP=8).
+    vLLM loads the full omni (audio+vision towers) even for image+text rollout.
+  - Fix: `rollout_num_gpus_per_engine=4` (TP=4 divides both 20 and 32). ⏳ `omni_smoke4`.
+  - ❌ `few-circuit-0fe326978cc4` (rollout TP=4): audio-tower heads OK; new wall —
+    omni vLLM engine init `RuntimeError: cu_seqlens_q must be on CUDA` (encoder warmup,
+    upstream vLLM-omni bug). **Stopped expensive omni iteration here** (the major wall).

--- a/tests/test_vime_recipe.py
+++ b/tests/test_vime_recipe.py
@@ -1,0 +1,53 @@
+"""Unit tests for the Vime (slime + vLLM) recipe.
+
+Kept deliberately small — the other framework recipes carry no dedicated recipe
+tests, so this only pins the behavior that is *new* to vime and easy to get
+wrong: the vLLM/router CLI surface (not SGLang) and the fresh-bridge load
+contract.
+"""
+
+from __future__ import annotations
+
+from modal_training_gym.common.models import ModelArchitecture, ModelConfig
+from modal_training_gym.train_recipes.base import RecipeType
+from modal_training_gym.train_recipes.vime_recipe import Qwen3_4b_Vime_Recipe
+
+
+def _model() -> ModelConfig:
+    return ModelConfig(
+        model_name="Qwen/Qwen3-0.6B",
+        architecture=ModelArchitecture(
+            num_layers=28,
+            hidden_size=1024,
+            ffn_hidden_size=3072,
+            num_attention_heads=16,
+            group_query_attention=True,
+            num_query_groups=8,
+            kv_channels=128,
+            vocab_size=151936,
+        ),
+    )
+
+
+def test_recipe_type_is_vime():
+    assert Qwen3_4b_Vime_Recipe().recipe_type is RecipeType.VIME
+
+
+def test_cli_args_use_vllm_router_not_sglang():
+    """The whole point of vime: vLLM/router flags, never SGLang flags."""
+    args = Qwen3_4b_Vime_Recipe().cli_args()
+    assert "--vllm-gpu-memory-utilization" in args
+    assert "--vllm-router-policy" in args
+    assert not any("sglang" in a for a in args)
+
+
+def test_fresh_bridge_run_omits_load_flags():
+    """Bridge-mode contract: with empty load/ref_load, no --load/--ref-load is
+    emitted, so vime falls back to ``--hf-checkpoint`` and bridge-loads the HF
+    snapshot. Emitting an empty --load would break that fallback.
+    """
+    args = Qwen3_4b_Vime_Recipe().cli_args(model=_model())
+    assert "--load" not in args
+    assert "--ref-load" not in args
+    assert "--hf-checkpoint" in args
+    assert args[args.index("--megatron-to-hf-mode") + 1] == "bridge"


### PR DESCRIPTION
Follow-up to #148 (vime framework). Goal: GRPO-train **Qwen3-Omni-30B-A3B** (audio+image+text) with vime. **WIP / draft** — the multimodal foundation works and the omni *training* bridge is validated; the omni *rollout* engine is blocked on an upstream vLLM bug. Full investigation journal in `omni.md`.

## What works (validated on Modal)
- **vime multimodal foundation**: `VimeConfig._dataset_to_fields` now forwards a `MultimodalDataset`'s `multimodal_keys`, so vime's default vLLM rollout receives image content. Added `Qwen3_VL_4B`.
  - ✅ **Qwen3-VL-4B image+text GRPO ran end-to-end on 1×H100** (image rollout → reward → Megatron GRPO with optimizer offload → checkpoint). This is the reusable base for omni.
- **`Qwen3_Omni_30B` model config** (Thinker text-MoE arch + 128-expert MoE fields, verified against vime's `hf_validate_args`).
  - ✅ **megatron's `qwen_omni` bridge loads the 30B Thinker MoE into Megatron** (1×8 H100, TP4/EP8/SP + optimizer offload — vime's proven 30B-A3B parallelism). The research-gated unknown (does the omni Thinker load for training?) is **resolved**. Cleared, in order: arch validation → MoE expert-parallel args → chat-template path → audio-tower TP-divisibility (rollout TP must divide the audio tower's 20 heads → TP=4).

## What's blocked
- **Omni vLLM rollout engine** fails at init: `RuntimeError: cu_seqlens_q must be on CUDA` — an **upstream vLLM bug** in the Qwen3-Omni vision/audio encoder warmup (vLLM 0.22 in the vime image; vLLM has known omni-encoder issues in this range). Not a gym/vime config bug. GRPO can't roll out until omni serves. Options: bump/patch vLLM in the image, a serving workaround (limit-mm / encoder attn backend), or wait for an upstream fix.

## Not started (gated on rollout working)
- Audio in the rollout — vime's rollout is **vision-only** (`process_vision_info`; images-only path). Needs a `process_audio_info` + passing `input_audio` to the engine, patched into the vime image (like the gym's slime ASR patches).
- `convert_qwen3omni_to_hf` (megatron→HF) for serving — vime has `qwen3_vl` but no omni converter.
- Audio+image+text dataset + dashboard multi-modality viz.

## Scope note
This draft includes the **VL multimodal foundation** (the validated, reusable base) + the omni scaffolding. The image+text `Qwen3-VL` work could be split into its own mergeable PR if preferred; omni itself stays WIP behind the vLLM blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)