### PR TITLE
Fix vLLM serving (DeploymentConfig + VllmRecipe)

### DIFF
--- a/modal_training_gym/common/deployment.py
+++ b/modal_training_gym/common/deployment.py
@@ -163,18 +163,26 @@ class DeploymentConfig:
             strategy=strategy,
         )
 
-        if recipe.recipe_type == DeployRecipeType.SGLANG:
-            server = getattr(app, "SGLangEndpoint", None)
-            if server is None and hasattr(app, "registered_functions"):
-                server = app.registered_functions.get("SGLangEndpoint")
-            if server is None:
-                raise RuntimeError(
-                    f"Deployed {self.app_name!r} but could not resolve SGLang endpoint server handle."
-                )
-            urls = asyncio.run(server.get_urls())
-            url = next(iter(urls.values()), None) if urls else None
-        else:
-            url = app.serve.get_web_url()
+        # SGLang and vLLM both register their endpoint via
+        # ``@app._experimental_server`` — SGLang as ``SGLangEndpoint``, vLLM as
+        # ``Server`` — and both expose the Flash URLs through ``get_urls()``.
+        endpoint_name = (
+            "SGLangEndpoint"
+            if recipe.recipe_type == DeployRecipeType.SGLANG
+            else "Server"
+        )
+        server = getattr(app, endpoint_name, None)
+        if server is None and hasattr(app, "registered_classes"):
+            server = app.registered_classes.get(endpoint_name)
+        if server is None and hasattr(app, "registered_functions"):
+            server = app.registered_functions.get(endpoint_name)
+        if server is None:
+            raise RuntimeError(
+                f"Deployed {self.app_name!r} but could not resolve the "
+                f"{endpoint_name!r} server handle."
+            )
+        urls = asyncio.run(server.get_urls())
+        url = next(iter(urls.values()), None) if urls else None
         modal_app_id = app.app_id
         modal_app_url = modal_app_dashboard_url(modal_app_id)
         if not url:

--- a/modal_training_gym/deploy_recipes/vllm_recipe/serve_vllm.py
+++ b/modal_training_gym/deploy_recipes/vllm_recipe/serve_vllm.py
@@ -1,10 +1,12 @@
 """vLLM serving helper — builds a Modal app that hosts a model via vLLM.
 
-Thin wrapper around the canonical
-[Modal vLLM inference example](https://modal.com/docs/examples/vllm_inference):
-one `@modal.web_server`-decorated function that runs `vllm serve` and
-exposes the OpenAI-compatible chat-completions API at
-`https://<workspace>--<app_name>-serve.modal.run/v1/chat/completions`.
+The model is served by ``Server``, a Modal *server* class registered with
+``@app._experimental_server`` (Modal's low-latency routing service for inference
+workloads) — the same mechanism the SGLang endpoint uses. Its ``@modal.enter()``
+launches ``vllm serve``; Modal proxies HTTP straight to the vLLM port and exposes
+the OpenAI-compatible chat-completions API, so there's no separate wrapper
+function. Serving via vLLM (rather than SGLang) keeps eval/serving on the same
+engine as a vime/vLLM rollout.
 
 `model_path` accepts either:
   - a **HuggingFace repo id** (e.g. `"Qwen/Qwen3-4B"`) — vLLM downloads
@@ -84,22 +86,20 @@ def build_vllm_serve_app(
     _extra = list(recipe.extra_vllm_args or [])
     _deployment_id = deployment_id
 
-    @app.cls(
+    @app._experimental_server(
         image=image,
         gpu=f"{gpu}:{n_gpu}",
         scaledown_window=10 * 60,
-        timeout=24 * 60 * 60,
+        startup_timeout=10 * 60,
         volumes=volumes,
         secrets=hf_secrets(),
         serialized=True,
         include_source=False,
-    )
-    @modal.experimental.http_server(
         port=vllm_port,
-        startup_timeout=10 * 60,
+        exit_grace_period=25,
         proxy_regions=["us-east"],
+        target_concurrency=32,
     )
-    @modal.concurrent(max_inputs=32)
     class Server:
         @modal.enter()
         def startup(self):
@@ -151,4 +151,8 @@ def build_vllm_serve_app(
         setattr(app, tag, fn)
     for tag, cls in app.registered_classes.items():
         setattr(app, tag, cls)
+    # `_experimental_server` returns the `_Server` handle (carries `get_urls()`);
+    # bind it under its class name so deployment URL resolution can reach it
+    # (mirrors the SGLang endpoint).
+    setattr(app, "Server", Server)
     return app


### PR DESCRIPTION
vLLM serving via `DeploymentConfig(recipe=VllmRecipe(...)).serve()` is currently broken on `main` (Modal ≥1.4), independent of any framework. Two bugs:

1. **App construction fails.** `serve_vllm.py` stacked `@app.cls` + `@modal.experimental.http_server` + `@modal.concurrent(max_inputs=32)`. For Flash `http_server` functions, Modal now rejects `max_inputs` (`TypeError: ... use @modal.concurrent(target_inputs=...) instead`), so `.serve()` raised before deploying.
2. **URL resolution fails.** `deployment.py` resolved the endpoint URL with `app.serve.get_web_url()`, but the vLLM app registers a class named `Server` (there is no `serve` attribute) → `AttributeError: 'App' object has no attribute 'serve'`.

## Fix
Mirror the **working SGLang path**, which registers its endpoint with `@app._experimental_server(...)` (returns a `_Server` handle exposing `get_urls()`):
- `serve_vllm.py` — replace the `@app.cls + http_server + concurrent(max_inputs=)` stack with `@app._experimental_server(..., port=…, target_concurrency=32, …)`, and bind `app.Server` (mirrors `app.SGLangEndpoint`).
- `deployment.py` — resolve the URL identically for both engines: pick the endpoint name (`SGLangEndpoint` / `Server`) and call `get_urls()`.

Net: `+35 / −23` across the two files.

## Why it matters
Lets eval/serving run on **vLLM**, the same engine as a vime (or any vLLM) rollout — on-policy consistency, rather than falling back to SGLang.

## Validation
Served Qwen3-0.6B from a vime checkpoint on vLLM and ran a haiku eval end-to-end on Modal — deployed (`…-server.us-east.modal.direct`), generated, scored, and persisted an `EvalResult` (`denim-assumption-103f9e90911c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)