### PR TITLE
Use sandbox v2 in training gym

### DIFF
--- a/modal_training_gym/common/environments/base.py
+++ b/modal_training_gym/common/environments/base.py
@@ -201,7 +201,7 @@ class SandboxEnvironmentPool:
         """Create a long-lived sandbox from ``image`` (defaults to :meth:`build_image`)."""
         import modal
 
-        return modal.Sandbox.create(
+        return modal.Sandbox._experimental_create(
             *command,
             image=image if image is not None else self.build_image(),
             app=self.app_handle(),

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -505,7 +505,7 @@ def build_task_snapshots(
     import modal
 
     app = modal.App.lookup(config.sandbox_app, create_if_missing=True)
-    sandbox = modal.Sandbox.create(
+    sandbox = modal.Sandbox._experimental_create(
         "sleep", "infinity", image=build_env_image(config), app=app, timeout=60 * 60
     )
     snapshots = DirectorySnapshotLibrary(config.snapshot_catalog, config.snapshot_root)

--- a/modal_training_gym/common/eval.py
+++ b/modal_training_gym/common/eval.py
@@ -526,7 +526,7 @@ def score_in_sandbox(
     if memory_arg is not None:
         resource_kwargs["memory"] = memory_arg
 
-    sb = modal.Sandbox.create(
+    sb = modal.Sandbox._experimental_create(
         "python",
         "-c",
         runner,

--- a/tutorials/agent/000_agent_sandbox/000_agent_sandbox.ipynb
+++ b/tutorials/agent/000_agent_sandbox/000_agent_sandbox.ipynb
@@ -242,7 +242,7 @@
    "source": [
     "sandbox_app = modal.App.lookup(\"agent-sandbox-tutorial\", create_if_missing=True)\n",
     "\n",
-    "sandbox = modal.Sandbox.create(\n",
+    "sandbox = modal.Sandbox._experimental_create(\n",
     "    \"sleep\", \"infinity\",\n",
     "    app=sandbox_app,\n",
     "    image=modal.Image.debian_slim(python_version=\"3.12\"),\n",

--- a/tutorials/agent/000_agent_sandbox/000_agent_sandbox.py
+++ b/tutorials/agent/000_agent_sandbox/000_agent_sandbox.py
@@ -181,7 +181,7 @@ def _main_impl() -> None:
 
     sandbox_app = modal.App.lookup("agent-sandbox-tutorial", create_if_missing=True)
 
-    sandbox = modal.Sandbox.create(
+    sandbox = modal.Sandbox._experimental_create(
         "sleep", "infinity",
         app=sandbox_app,
         image=modal.Image.debian_slim(python_version="3.12"),

--- a/tutorials/tutorial_generator/agent/000_agent_sandbox.py
+++ b/tutorials/tutorial_generator/agent/000_agent_sandbox.py
@@ -204,7 +204,7 @@ def _sandbox_section():
 def _create_sandbox():
     sandbox_app = modal.App.lookup("agent-sandbox-tutorial", create_if_missing=True)
 
-    sandbox = modal.Sandbox.create(
+    sandbox = modal.Sandbox._experimental_create(
         "sleep", "infinity",
         app=sandbox_app,
         image=modal.Image.debian_slim(python_version="3.12"),


### PR DESCRIPTION
This PR upgrades all evals and training examples to use [Sandbox V2](https://modal.com/docs/guide/sandbox-v2), which is more performant for RL tasks.