### PR TITLE
Fix sglang serve crash on Modal >=1.5.0 (proxy_regions -> routing_region)

### DIFF
--- a/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
@@ -110,7 +110,7 @@ def build_sglang_serve_app(
         include_source=False,
         port=sglang_port,
         exit_grace_period=25,
-        proxy_regions=["us-east"],
+        routing_region="us-east",
         target_concurrency=8,
     )
     class SGLangEndpoint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Reusable building blocks for Modal multi-node training examples"
 requires-python = ">=3.12"
 dependencies = [
-    "modal>=1.4.0",
+    "modal>=1.5.0",
     "cloudpickle",
     "datasets",
     "msgspec",

--- a/uv.lock
+++ b/uv.lock
@@ -965,7 +965,7 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.4.1"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -977,15 +977,14 @@ dependencies = [
     { name = "rich" },
     { name = "synchronicity" },
     { name = "toml" },
-    { name = "typer" },
     { name = "types-certifi" },
     { name = "types-toml" },
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/b2/cdc155ef06863e3ca325fb0d6ea8feb0acd9213ff7a8a32ff1adcc37e077/modal-1.4.1.tar.gz", hash = "sha256:aadbf31e82b9ace8c77de2ee4d2c431f76ee6af54a908640fae0bdee557fd9c5", size = 685664, upload-time = "2026-03-31T01:44:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/f9/87425e60db2a8597b248417772b409c49ca3a05ff6b1282a21cd7d856f09/modal-1.5.0.tar.gz", hash = "sha256:15033cf84f5f4f9f8a3dcf47a768cfcca36d1ad38ab7b3459fd3cbc29aa84a77", size = 771722, upload-time = "2026-06-09T22:37:27.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/9d/cba0aed472b303481dc931b8dea693db8ecc1fb720308a69d4c679a69a71/modal-1.4.1-py3-none-any.whl", hash = "sha256:3befc9c4ac1b18ac4bf5bcb92aa6b7a5fa966c799d1dbf0cfc78ea075b2ab030", size = 787809, upload-time = "2026-03-31T01:44:29.691Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/85e476e7d32c0a648d5aa97c4335ac02357d059c2bb734cf175b08446597/modal-1.5.0-py3-none-any.whl", hash = "sha256:9c5687eff775d1372bd70b87e43499e40777a1de160f23786c00807bf342fcb6", size = 882122, upload-time = "2026-06-09T22:37:24.608Z" },
 ]
 
 [[package]]
@@ -1020,7 +1019,7 @@ requires-dist = [
     { name = "cloudpickle" },
     { name = "datasets" },
     { name = "fastapi" },
-    { name = "modal", specifier = ">=1.4.0" },
+    { name = "modal", specifier = ">=1.5.0" },
     { name = "msgspec" },
     { name = "openai" },
     { name = "pydantic" },
@@ -1852,14 +1851,14 @@ wheels = [
 
 [[package]]
 name = "synchronicity"
-version = "0.12.2"
+version = "0.12.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/5e/50ea27817003665c7cc4f5bdad309f13d6329037f657848ee87fe06c3740/synchronicity-0.12.2.tar.gz", hash = "sha256:6fd605a5035d1ec74ce48fffaca80ea00345c84ca34223914e2436fb4f162ff9", size = 60018, upload-time = "2026-04-06T15:06:15.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/38/901ed2557527541e90e89366212538463de96f9393de95fee2f7928d1321/synchronicity-0.12.4.tar.gz", hash = "sha256:f9e38d0c37d8e56b5dcb22cc0083591a535a42187d3d97ea9aef6e84bd122640", size = 60339, upload-time = "2026-06-16T15:43:06.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/44/4f6ba4e2c171847e6f9a460213b196bbf26edea43d0e66889c7ccc55d368/synchronicity-0.12.2-py3-none-any.whl", hash = "sha256:9dbaca81fb7f2b57c6dea326e514e1c80e9ccfd9c9618515e84fa6091026273b", size = 41312, upload-time = "2026-04-06T15:06:14.459Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/44/ed8f5c1ce8d6a4d986a5629fcd17fca6e91952e43ffa9bdb7d640341e50d/synchronicity-0.12.4-py3-none-any.whl", hash = "sha256:87c53625f680ed1a6992fccda5adeb6705904fdb0c820e04d384358708f2607c", size = 41013, upload-time = "2026-06-16T15:43:05.233Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Deploying the sglang serve recipe on Modal **>=1.5.0** crashes with:

```
TypeError: _App._experimental_server() got an unexpected keyword argument 'proxy_regions'
```

Modal 1.5.0 renamed the routing-region kwarg on `App._experimental_server` from `proxy_regions: list[str]` to `routing_region: str` (which Modal internally expands back to `proxy_regions=[routing_region]`).

`modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py` still passed `proxy_regions=["us-east"]`, so the decorator now rejects the call.

## Fix

Use `routing_region="us-east"` to match the current Modal API.

Note: `serve_vllm.py` is unaffected — it uses `@modal.experimental.http_server(...)` (the flash decorator), which still accepts `proxy_regions` on both 1.4.x and 1.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)