### PR TITLE
Dashboard: fix training list flicker between empty state and actual runs

### DIFF
--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -38,6 +38,12 @@
   // gates the cold-start skeleton.
   let refreshing = $state(false);
   let runsRequestId = 0;
+  // The /runs endpoint reads from a Modal volume that can momentarily list
+  // empty mid-reload, returning a 200 with []. Treat a short run of empty
+  // responses as transient and keep the rows we already have, rather than
+  // flashing "No training runs found yet." and repopulating on the next poll.
+  let consecutiveEmptyRuns = 0;
+  const EMPTY_RUNS_TOLERANCE = 3;
   let evalsRequestId = 0;
   let deploymentsRequestId = 0;
   let hasLoadedEvals = $state(false);
@@ -238,6 +244,18 @@
     try {
       const runs = await fetchWithTimeout(fetchRuns, 30000, "runs");
       if (isStale()) return;
+      // A lone empty response while we already have runs is almost always a
+      // transient backend reload, not a real "all runs gone" — ignore it for a
+      // few polls so the list doesn't flicker. Accept the empty only if it
+      // persists (real reset) or we never had data (genuine cold-empty).
+      if (!runs.length && allRuns.length) {
+        consecutiveEmptyRuns += 1;
+        if (consecutiveEmptyRuns < EMPTY_RUNS_TOLERANCE) {
+          loading = false;
+          return;
+        }
+      }
+      consecutiveEmptyRuns = 0;
       allRuns = runs;
       // Auto-enable newly-seen recipes/statuses without resetting the user's
       // current filter selection on every refresh.


### PR DESCRIPTION
## Problem
The training runs list alternates between **\"No training runs found yet.\"** and showing the actual jobs every few seconds.

## Root cause
`GET /runs` reads from a Modal volume that can momentarily list empty during a reload, returning a `200` with `[]`. `fetchRuns` only throws on a non-OK HTTP status, so an empty-but-successful response flows through, and the 5s auto-refresh runs `allRuns = []`. The list flips to the empty state, then repopulates on the next poll — hence the flicker.

## Fix
Treat a lone empty `/runs` response as transient **when we already have runs**: ignore it for up to `EMPTY_RUNS_TOLERANCE` (3) consecutive polls and keep the current rows. This mirrors the existing catch-block behavior that preserves data on transient *failures*.

- A genuinely persistent empty (real reset) is still accepted once it sticks past the tolerance.
- A cold start with no prior data still shows the empty state immediately (the guard only applies when `allRuns.length > 0`).

## Testing
`npm run build` passes (only pre-existing unused-CSS warnings, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)