### PR TITLE
Remove stale imports from f4312b3 commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ rest of the cells run as-is.
 
 | Tutorial | Summary | Difficulty | Framework | Launch |
 |---|---|---|---|---|
-| [`001_qwen27b`](tutorials/singlenode/001_qwen27b/001_qwen27b.ipynb) | Train Qwen3.6-27B on DAPO-math with GRPO | Advanced | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/singlenode/001_qwen27b/001_qwen27b.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
 | [`000_qwen35b`](tutorials/singlenode/000_qwen35b/000_qwen35b.ipynb) | Train Qwen3.6-35B-A3B on DAPO-math with GRPO | Advanced | `slime` | <a href="https://modal.com/notebooks/new/https://github.com/modal-projects/training-gym/blob/main/tutorials/singlenode/000_qwen35b/000_qwen35b.ipynb" target="_blank" rel="nofollow noopener noreferrer"><img src="https://modal-cdn.com/open-in-modal.svg" alt="Open in Modal"></a> |
 
 ### Agents

--- a/docs-next/astro.config.mjs
+++ b/docs-next/astro.config.mjs
@@ -172,7 +172,7 @@ export default defineConfig({
                 { label: 'Qwen3-14B', link: '/reference/models/qwen3_14b/' },
                 { label: 'Qwen3-30B-A3B', link: '/reference/models/qwen3_30b/' },
                 { label: 'Qwen3-32B', link: '/reference/models/qwen3_32b/' },
-                { label: 'Qwen3.6-27B', link: '/reference/models/qwen3_6_27b/' },
+                
                 { label: 'Qwen3.6-35B-A3B', link: '/reference/models/qwen3_6_35b/' },
               ],
             },
@@ -182,7 +182,7 @@ export default defineConfig({
                 { label: 'TrainConfig', link: '/reference/training/trainconfig/' },
                 { label: 'MultiTurn', link: '/reference/training/multiturn/' },
                 { label: 'SlimeRecipe', link: '/reference/training/slimerecipe/' },
-                { label: 'Qwen3_6_27b_Recipe', link: '/reference/training/qwen3_6_27b_recipe/' },
+                
                 { label: 'Qwen3_6_35b_Recipe', link: '/reference/training/qwen3_6_35b_recipe/' },
               ],
             },

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -58,7 +58,6 @@ _EXPORTS = {
     "Qwen3_14B": ("modal_training_gym.common.models", "Qwen3_14B"),
     "Qwen3_30B": ("modal_training_gym.common.models", "Qwen3_30B"),
     "Qwen3_32B": ("modal_training_gym.common.models", "Qwen3_32B"),
-    "Qwen3_6_27B": ("modal_training_gym.common.models", "Qwen3_6_27B"),
     "Qwen3_6_35B": ("modal_training_gym.common.models", "Qwen3_6_35B"),
     "Qwen3_ASR_1_7B": ("modal_training_gym.common.models", "Qwen3_ASR_1_7B"),
     "Qwen3_ASR_1_7b_Recipe": (
@@ -116,9 +115,7 @@ __all__ = [
     "Qwen3_14B",
     "Qwen3_30B",
     "Qwen3_32B",
-    "Qwen3_6_27B",
-    "Qwen3_6_35B",
-    "Qwen3_ASR_1_7B",
+    "Qwen3_6_R_1_7B",
     "Qwen3_ASR_1_7b_Recipe",
     "score_in_sandbox",
     "SlimeRecipe",

--- a/modal_training_gym/common/models/__init__.py
+++ b/modal_training_gym/common/models/__init__.py
@@ -19,7 +19,7 @@ from .qwen3_30b import Qwen3_30B
 from .qwen3_32b import Qwen3_32B
 from .kimi_k2_5 import Kimi_K2_5
 from .kimi_k2_6 import Kimi_K2_6
-from .qwen3_6_27b import Qwen3_6_27B
+
 from .qwen3_6_35b import Qwen3_6_35B
 from .qwen3_asr_1_7b import Qwen3_ASR_1_7B
 
@@ -43,7 +43,6 @@ __all__ = [
     "parse_kimi_k2_response",
     "parse_qwen3_6_response",
     "parse_qwen3_response",
-    "Qwen3_6_27B",
     "Qwen3_6_35B",
     "Qwen3_ASR_1_7B",
 ]

--- a/modal_training_gym/deploy_recipes/sglang_recipe/__init__.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/__init__.py
@@ -23,9 +23,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.qwen3_30b import (
 from modal_training_gym.deploy_recipes.sglang_recipe.qwen3_32b import (
     Qwen3_32b_SglangRecipe,
 )
-from modal_training_gym.deploy_recipes.sglang_recipe.qwen3_6_27b import (
-    Qwen3_6_27b_SglangRecipe,
-)
+
 from modal_training_gym.deploy_recipes.sglang_recipe.qwen3_6_35b import (
     Qwen3_6_35b_SglangRecipe,
 )
@@ -44,6 +42,5 @@ __all__ = [
     "Qwen3_14b_SglangRecipe",
     "Qwen3_30b_SglangRecipe",
     "Qwen3_32b_SglangRecipe",
-    "Qwen3_6_27b_SglangRecipe",
     "Qwen3_6_35b_SglangRecipe",
 ]

--- a/modal_training_gym/deploy_recipes/vllm_recipe/__init__.py
+++ b/modal_training_gym/deploy_recipes/vllm_recipe/__init__.py
@@ -10,9 +10,7 @@ from modal_training_gym.deploy_recipes.vllm_recipe.qwen3_8b import Qwen3_8b_Vllm
 from modal_training_gym.deploy_recipes.vllm_recipe.qwen3_14b import Qwen3_14b_VllmRecipe
 from modal_training_gym.deploy_recipes.vllm_recipe.qwen3_30b import Qwen3_30b_VllmRecipe
 from modal_training_gym.deploy_recipes.vllm_recipe.qwen3_32b import Qwen3_32b_VllmRecipe
-from modal_training_gym.deploy_recipes.vllm_recipe.qwen3_6_27b import (
-    Qwen3_6_27b_VllmRecipe,
-)
+
 from modal_training_gym.deploy_recipes.vllm_recipe.qwen3_6_35b import (
     Qwen3_6_35b_VllmRecipe,
 )
@@ -26,6 +24,5 @@ __all__ = [
     "Qwen3_14b_VllmRecipe",
     "Qwen3_30b_VllmRecipe",
     "Qwen3_32b_VllmRecipe",
-    "Qwen3_6_27b_VllmRecipe",
     "Qwen3_6_35b_VllmRecipe",
 ]

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -107,7 +107,6 @@ _PATCH_ROLLOUT_STATUS_B64 = encode_patch(
     "patch_rollout_status_reporting", _SLIME_PATCHES
 )
 _PATCH_LOG_ELIDE_B64 = encode_patch("patch_log_elide", _SLIME_PATCHES)
-_PATCH_CP_LOG_ROLLOUT_B64 = encode_patch("patch_cp_log_rollout", _SLIME_PATCHES)
 
 
 def _build_slime_base_image() -> "Image":
@@ -123,7 +122,6 @@ def _build_slime_base_image() -> "Image":
             f"echo {_PATCH_QWEN3_ASR_EXPORT_B64} | base64 -d | python3",
             f"echo {_PATCH_ROLLOUT_STATUS_B64} | base64 -d | python3",
             f"echo {_PATCH_LOG_ELIDE_B64} | base64 -d | python3",
-            f"echo {_PATCH_CP_LOG_ROLLOUT_B64} | base64 -d | python3",
         )
     )
 

--- a/modal_training_gym/frameworks/slime/modal_helpers/utils.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/utils.py
@@ -48,9 +48,8 @@ def get_checkpoint_conversion_policy(
         getattr(slime_cfg, "conversion_tensor_model_parallel_size", None)
         or slime_cfg.tensor_model_parallel_size
     )
-    pp = (
-        getattr(slime_cfg, "conversion_pipeline_model_parallel_size", None)
-        or getattr(slime_cfg, "pipeline_model_parallel_size", 1)
+    pp = getattr(slime_cfg, "conversion_pipeline_model_parallel_size", None) or getattr(
+        slime_cfg, "pipeline_model_parallel_size", 1
     )
 
     if tp == 1 and pp == 1 and getattr(slime_cfg, "mtp_num_layers", 0):

--- a/modal_training_gym/train_recipes/slime_recipe/__init__.py
+++ b/modal_training_gym/train_recipes/slime_recipe/__init__.py
@@ -9,9 +9,7 @@ from modal_training_gym.train_recipes.slime_recipe.qwen3_8b import Qwen3_8b_Reci
 from modal_training_gym.train_recipes.slime_recipe.qwen3_14b import Qwen3_14b_Recipe
 from modal_training_gym.train_recipes.slime_recipe.qwen3_32b import Qwen3_32b_Recipe
 from modal_training_gym.train_recipes.slime_recipe.qwen3_4b import Qwen3_4b_Recipe
-from modal_training_gym.train_recipes.slime_recipe.qwen3_6_27b import (
-    Qwen3_6_27b_Recipe,
-)
+
 from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b import (
     Qwen3_6_35b_Recipe,
 )
@@ -29,7 +27,6 @@ __all__ = [
     "Qwen3_8b_Recipe",
     "Qwen3_14b_Recipe",
     "Qwen3_32b_Recipe",
-    "Qwen3_6_27b_Recipe",
     "Qwen3_6_35b_Recipe",
     "Qwen3_ASR_1_7b_Recipe",
 ]

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -549,7 +549,7 @@ class SlimeRecipe(BaseTrainRecipe):
         from modal_training_gym.train_recipes.slime_recipe.qwen3_4b import (
             Qwen3_4b_Recipe,
         )
-        
+
         from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b import (
             Qwen3_6_35b_Recipe,
         )

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -549,9 +549,7 @@ class SlimeRecipe(BaseTrainRecipe):
         from modal_training_gym.train_recipes.slime_recipe.qwen3_4b import (
             Qwen3_4b_Recipe,
         )
-        from modal_training_gym.train_recipes.slime_recipe.qwen3_6_27b import (
-            Qwen3_6_27b_Recipe,
-        )
+        
         from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b import (
             Qwen3_6_35b_Recipe,
         )
@@ -573,8 +571,6 @@ class SlimeRecipe(BaseTrainRecipe):
             return Qwen3_14b_Recipe()
         if model_config.model_name == "Qwen/Qwen3-32B":
             return Qwen3_32b_Recipe()
-        if model_config.model_name == "Qwen/Qwen3.6-27B":
-            return Qwen3_6_27b_Recipe()
         if model_config.model_name == "Qwen/Qwen3.6-35B-A3B":
             return Qwen3_6_35b_Recipe()
         return None

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -29,6 +29,7 @@ class MetadataStore(Enum):
 SUMMARY_KEY = "summary"
 SUMMARY_ITEMS_KEY = "items"
 
+
 # Summary stores whose canonical per-item files share the summary's shape, so a
 # collapsed/stale summary can be rebuilt from the canonical files rather than
 # trusted blindly. Rollouts are intentionally excluded: their canonical files
@@ -247,7 +248,9 @@ def vol_count_items(store: MetadataStore | str) -> int:
     vol = _metadata_volume()
     _safe_reload(vol)
     try:
-        return sum(1 for e in vol.iterdir(_store_path(store)) if e.path.endswith(".json"))
+        return sum(
+            1 for e in vol.iterdir(_store_path(store)) if e.path.endswith(".json")
+        )
     except FileNotFoundError:
         return 0
 

--- a/scripts/api_reference_manifest.py
+++ b/scripts/api_reference_manifest.py
@@ -170,7 +170,6 @@ API_REFERENCE_MANIFEST = [
         "class_type": "config_data",
         "sidebar_label": "Qwen3-32B",
     },
-    
     {
         "class_name": "Qwen3_6_35B",
         "module": "modal_training_gym.common.models.qwen3_6_35b",
@@ -200,7 +199,6 @@ API_REFERENCE_MANIFEST = [
         "class_type": "config_data",
         "sidebar_label": "SlimeRecipe",
     },
-    
     {
         "class_name": "Qwen3_6_35b_Recipe",
         "module": "modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b",

--- a/scripts/api_reference_manifest.py
+++ b/scripts/api_reference_manifest.py
@@ -170,13 +170,7 @@ API_REFERENCE_MANIFEST = [
         "class_type": "config_data",
         "sidebar_label": "Qwen3-32B",
     },
-    {
-        "class_name": "Qwen3_6_27B",
-        "module": "modal_training_gym.common.models.qwen3_6_27b",
-        "group": "models",
-        "class_type": "config_data",
-        "sidebar_label": "Qwen3.6-27B",
-    },
+    
     {
         "class_name": "Qwen3_6_35B",
         "module": "modal_training_gym.common.models.qwen3_6_35b",
@@ -206,13 +200,7 @@ API_REFERENCE_MANIFEST = [
         "class_type": "config_data",
         "sidebar_label": "SlimeRecipe",
     },
-    {
-        "class_name": "Qwen3_6_27b_Recipe",
-        "module": "modal_training_gym.train_recipes.slime_recipe.qwen3_6_27b",
-        "group": "training",
-        "class_type": "config_data",
-        "sidebar_label": "Qwen3_6_27b_Recipe",
-    },
+    
     {
         "class_name": "Qwen3_6_35b_Recipe",
         "module": "modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b",


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Fixes import errors from f4312b3.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
