### PR TITLE
Fix metadata persistence tests broken by f4312b3

### DIFF
--- a/modal_training_gym/frameworks/slime/modal_helpers/utils.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/utils.py
@@ -48,9 +48,8 @@ def get_checkpoint_conversion_policy(
         getattr(slime_cfg, "conversion_tensor_model_parallel_size", None)
         or slime_cfg.tensor_model_parallel_size
     )
-    pp = (
-        getattr(slime_cfg, "conversion_pipeline_model_parallel_size", None)
-        or getattr(slime_cfg, "pipeline_model_parallel_size", 1)
+    pp = getattr(slime_cfg, "conversion_pipeline_model_parallel_size", None) or getattr(
+        slime_cfg, "pipeline_model_parallel_size", 1
     )
 
     if tp == 1 and pp == 1 and getattr(slime_cfg, "mtp_num_layers", 0):

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -29,6 +29,7 @@ class MetadataStore(Enum):
 SUMMARY_KEY = "summary"
 SUMMARY_ITEMS_KEY = "items"
 
+
 # Summary stores whose canonical per-item files share the summary's shape, so a
 # collapsed/stale summary can be rebuilt from the canonical files rather than
 # trusted blindly. Rollouts are intentionally excluded: their canonical files
@@ -247,7 +248,9 @@ def vol_count_items(store: MetadataStore | str) -> int:
     vol = _metadata_volume()
     _safe_reload(vol)
     try:
-        return sum(1 for e in vol.iterdir(_store_path(store)) if e.path.endswith(".json"))
+        return sum(
+            1 for e in vol.iterdir(_store_path(store)) if e.path.endswith(".json")
+        )
     except FileNotFoundError:
         return 0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,12 @@ class FakeVolume:
     ``save()`` against this — reload is only a freshness hint.
     """
 
+    class _DirEntry:
+        """Simple stand-in for Modal Volume directory entries."""
+
+        def __init__(self, path: str):
+            self.path = path
+
     def __init__(self) -> None:
         self.files: dict[str, bytes] = {}
 
@@ -33,7 +39,13 @@ class FakeVolume:
             raise FileNotFoundError(path)
         del self.files[path]
 
-    def batch_upload(self):
+    def iterdir(self, path: str):
+        """Return list of files in the given path (stub for Modal Volume.iterdir)."""
+        prefix = path.rstrip("/") + "/"
+        matching_files = [f for f in self.files.keys() if f.startswith(prefix)]
+        return [self._DirEntry(f) for f in matching_files]
+
+    def batch_upload(self, force: bool = False):
         files = self.files
 
         class _Batch:


### PR DESCRIPTION
Commit f4312b3 broke the metadata persistence tests in contest.py by adding force=True to `vol.batch_upload` calls. This could have been by mistake, as it is unrelated to the Qwen-27B removal. Fixes failing test in CI. 

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.
