### PR TITLE
Fix logging for zero rewards or dict of rewards in Slime

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -136,6 +136,8 @@ _PATCH_LOG_ELIDE_B64 = encode_patch("patch_log_elide", _SLIME_PATCHES)
 _PATCH_DIST_CKPT_QUANTIZED_B64 = encode_patch(
     "patch_dist_ckpt_quantized", _SLIME_PATCHES
 )
+# OPD / multi-turn: zero-std metrics must skip non-numeric rewards (dict/None).
+_PATCH_ZERO_STD_METRICS_B64 = encode_patch("patch_zero_std_metrics", _SLIME_PATCHES)
 
 
 def _build_slime_base_image() -> "Image":
@@ -155,6 +157,7 @@ def _build_slime_base_image() -> "Image":
             f"echo {_PATCH_ADVANTAGE_DIST_B64} | base64 -d | python3",
             f"echo {_PATCH_LOG_ELIDE_B64} | base64 -d | python3",
             f"echo {_PATCH_DIST_CKPT_QUANTIZED_B64} | base64 -d | python3",
+            f"echo {_PATCH_ZERO_STD_METRICS_B64} | base64 -d | python3",
         )
     )
 

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_zero_std_metrics.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_zero_std_metrics.py
@@ -1,0 +1,73 @@
+"""Patch ``_compute_zero_std_metrics`` to ignore aborted (reward is None) samples.
+
+slime's rollout metric logging path
+(``RolloutManager.generate`` -> ``_log_rollout_data`` ->
+``compute_metrics_from_samples`` -> ``_compute_zero_std_metrics``) runs on the
+kept training batch *before* the reward post-process converts samples to train
+data.  Multi-turn / agentic rollouts can yield ``ABORTED`` samples whose
+``reward`` is still ``None``: in ``generate_and_rm`` a fan-out group where *any*
+member is aborted returns early with no reward computed for the whole group.
+
+Cross-tokenizer OPD goes further: its ``custom_rm_function`` returns the
+teacher's raw ``/generate`` response (a ``dict`` of logprobs) as ``sample.reward``
+during the rollout, and only the later ``post_process`` step reduces that to a
+scalar.  The zero-std metric runs *in between*, so ``get_reward_value`` hands
+back either a ``dict`` (normal sample) or ``None`` (aborted sample), and
+``round(...)`` crashes with::
+
+    TypeError: type NoneType doesn't define __round__
+    TypeError: type dict doesn't define __round__
+
+This patch makes the metric numeric-safe: samples/groups whose reward is not an
+``int``/``float`` are skipped.  It is behaviour-neutral for plain scalar-reward
+runs because those rewards are always numeric.
+
+Executed at image-build time via ``python3 <this file>``.
+"""
+
+import pathlib
+
+p = pathlib.Path("/root/slime/slime/ray/rollout.py")
+src = p.read_text()
+
+old_is_zero_std = """\
+        rewards = [sample.get_reward_value(args) for sample in samples]
+        return len(rewards) == 0 or all(rewards[0] == r for r in rewards)"""
+
+new_is_zero_std = """\
+        rewards = [
+            r
+            for sample in samples
+            if isinstance((r := sample.get_reward_value(args)), (int, float))
+        ]
+        return len(rewards) == 0 or all(rewards[0] == r for r in rewards)"""
+
+if old_is_zero_std in src:
+    src = src.replace(old_is_zero_std, new_is_zero_std, 1)
+    print("[patch_zero_std_metrics] patched _is_zero_std to ignore non-numeric rewards")
+else:
+    print("[patch_zero_std_metrics] WARNING: _is_zero_std target not found; skipped")
+
+old_interesting = (
+    "    interesting_rewards = [str(round(g[0].get_reward_value(args), 1)) "
+    "for g in interesting_sample_groups]"
+)
+
+new_interesting = """\
+    interesting_rewards = [
+        str(round(r, 1))
+        for g in interesting_sample_groups
+        if isinstance((r := g[0].get_reward_value(args)), (int, float))
+    ]"""
+
+if old_interesting in src:
+    src = src.replace(old_interesting, new_interesting, 1)
+    print(
+        "[patch_zero_std_metrics] patched interesting_rewards to ignore non-numeric rewards"
+    )
+else:
+    print(
+        "[patch_zero_std_metrics] WARNING: interesting_rewards target not found; skipped"
+    )
+
+p.write_text(src)


### PR DESCRIPTION
Guard against non-numeric rewards such as aborted samples where the reward is None or a custom reward model function that returns a dict reward (e.g. per-token logprobs from the teacher). 

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->