### PR TITLE
Alex/complete recipe opt out

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -129,6 +129,20 @@ def _recipe_param_summary(
     return params
 
 
+def _resolve_slime_recipe(
+    model: ModelConfig,
+    recipe: SlimeRecipe,
+    *,
+    merge_model_recipe: bool,
+) -> tuple[SlimeRecipe, SlimeRecipe | None]:
+    if not merge_model_recipe:
+        return recipe, None
+    base_recipe = SlimeRecipe.get_base_recipe(model)
+    if base_recipe is None:
+        return recipe, None
+    return _merge_recipe(base_recipe, recipe), base_recipe
+
+
 _STAGE_LABELS: dict[str, str] = {
     "initializing": "Initializing",
     "download_model": "Downloading model",
@@ -329,6 +343,8 @@ class TrainConfig:
     model: ModelConfig
     recipe: BaseTrainRecipe
     checkpoint: Checkpoint | None = None
+    # Known-model recipes are presets by default; complete recipes can opt out.
+    merge_model_recipe: bool = True
     # Run the training app detached so it keeps running on Modal even if the
     # local client disconnects (terminal closed, laptop asleep). The CLI's
     # ``modal run --detach`` only detaches the entrypoint, not the nested
@@ -371,11 +387,11 @@ class TrainConfig:
                 raise TypeError(
                     f"Recipe type {recipe_type} requires SlimeRecipe, got {type(self.recipe).__name__}"
                 )
-            base_recipe = SlimeRecipe.get_base_recipe(self.model)
-            if base_recipe is not None:
-                combined = _merge_recipe(base_recipe, cast(SlimeRecipe, self.recipe))
-            else:
-                combined = cast(SlimeRecipe, self.recipe)
+            combined, _ = _resolve_slime_recipe(
+                self.model,
+                cast(SlimeRecipe, self.recipe),
+                merge_model_recipe=self.merge_model_recipe,
+            )
             return build_slime_app(
                 training_run_id=self.training_run_id,
                 slime=combined,
@@ -388,15 +404,13 @@ class TrainConfig:
     def recipe_param_summary(self) -> dict[str, dict[str, Any]]:
         if not isinstance(self.recipe, SlimeRecipe):
             return {}
-        base_recipe = SlimeRecipe.get_base_recipe(self.model)
-        combined = (
-            _merge_recipe(base_recipe, cast(SlimeRecipe, self.recipe))
-            if base_recipe is not None
-            else cast(SlimeRecipe, self.recipe)
+        recipe = cast(SlimeRecipe, self.recipe)
+        combined, base_recipe = _resolve_slime_recipe(
+            self.model,
+            recipe,
+            merge_model_recipe=self.merge_model_recipe,
         )
-        return _recipe_param_summary(
-            cast(SlimeRecipe, self.recipe), combined, base_recipe
-        )
+        return _recipe_param_summary(recipe, combined, base_recipe)
 
     # ── Run-record helpers ─────────────────────────────────────────────────
 
@@ -439,11 +453,10 @@ class TrainConfig:
                 _serialize_slime_params,
             )
 
-            base_recipe = SlimeRecipe.get_base_recipe(model)
-            combined = (
-                _merge_recipe(base_recipe, cast(SlimeRecipe, recipe))
-                if base_recipe is not None
-                else cast(SlimeRecipe, recipe)
+            combined, _ = _resolve_slime_recipe(
+                model,
+                cast(SlimeRecipe, recipe),
+                merge_model_recipe=self.merge_model_recipe,
             )
             summary["recipe"] = _serialize_slime_params(
                 combined, dataset=dataset, model=model

--- a/modal_training_gym/deploy_recipes/sglang_recipe/deepseek_v4_flash.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/deepseek_v4_flash.py
@@ -17,7 +17,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 _DEEPSEEK_V4_FLASH_DEFAULTS = {
     "gpu": "B200",
     "tp": 4,
-    "context_length": 32768,
+    "context_length": 262144,
     "mem_fraction_static": 0.80,
     "chunked_prefill_size": 4096,
     "max_running_requests": 16,

--- a/modal_training_gym/deploy_recipes/sglang_recipe/glm_4_7.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/glm_4_7.py
@@ -5,7 +5,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 _GLM_4_7_DEFAULTS = {
     "gpu": "H200",
     "tp": 8,
-    "context_length": 32768,
+    "context_length": 65536,
     "mem_fraction_static": 0.70,
     "chunked_prefill_size": 8192,
     "max_running_requests": 8,

--- a/modal_training_gym/deploy_recipes/sglang_recipe/qwen3_6_27b.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/qwen3_6_27b.py
@@ -5,7 +5,7 @@ from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 _QWEN3_6_27B_DEFAULTS = {
     "gpu": "H100",
     "tp": 4,
-    "context_length": 32768,
+    "context_length": 262144,
     "mem_fraction_static": 0.80,
     "chunked_prefill_size": 8192,
     "max_running_requests": 16,

--- a/tests/test_recipe_param_summary.py
+++ b/tests/test_recipe_param_summary.py
@@ -178,6 +178,35 @@ def test_train_config_recipe_param_summary(monkeypatch):
     assert params["weight_decay"]["source"] == "default"
 
 
+def test_train_config_can_skip_model_recipe_merge():
+    recipe = SlimeRecipe(
+        gpu_type="H100",
+        colocate=True,
+        tensor_model_parallel_size=1,
+        sequence_parallel=False,
+        rollout_num_gpus_per_engine=1,
+        num_rollout=1,
+        rollout_batch_size=16,
+        rollout_max_response_len=4096,
+        rollout_temperature=1.0,
+        save_interval=10,
+    )
+    config = TrainConfig(
+        model=_make_model("Qwen/Qwen3-4B"),
+        dataset=_make_dataset(),
+        recipe=recipe,
+        merge_model_recipe=False,
+    )
+
+    params = config.recipe_param_summary()
+    assert params["n_samples_per_prompt"] == {"value": 2, "source": "default"}
+    assert params["lr"] == {"value": 1e-6, "source": "default"}
+
+    summary = config._build_config_summary()
+    assert summary["recipe"]["n_samples_per_prompt"] == 2
+    assert summary["recipe"]["lr"] == 1e-6
+
+
 def test_serialized_recipe_fields():
     """_serialize_recipe_fields in the launcher produces JSON-safe values."""
     from modal_training_gym.frameworks.slime.launcher import _serialize_recipe_fields


### PR DESCRIPTION

`TrainConfig` currently always merges known-model Slime recipes with the model’s built-in preset, which works for partial overrides but can be wrong for recipes that are already complete. That forced callers with custom complete recipes to work around the merge behavior, for example by monkeypatching `SlimeRecipe.get_base_recipe` so custom fields would survive. This change adds an explicit opt-out so complete recipes can be used directly while preserving the existing preset-merge behavior by default.

Also, previous changes of context length are still live.


## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
