### PR TITLE
allow complete slime recipes to skip model preset merge

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -117,6 +117,20 @@ def _field_default(field: _dc.Field) -> Any:
     return _dc.MISSING
 
 
+def _resolve_slime_recipe(
+    model: ModelConfig,
+    recipe: SlimeRecipe,
+    *,
+    merge_model_recipe: bool,
+) -> SlimeRecipe:
+    if not merge_model_recipe:
+        return recipe
+    base_recipe = SlimeRecipe.get_base_recipe(model)
+    if base_recipe is None:
+        return recipe
+    return _merge_recipe(base_recipe, recipe)
+
+
 class TrainStepStatus(Enum):
     INITIALIZING = "initializing"
     DOWNLOAD_MODEL = "download_model"
@@ -334,6 +348,8 @@ class TrainConfig:
     model: ModelConfig
     recipe: BaseTrainRecipe
     checkpoint: Checkpoint | None = None
+    # Known-model recipes are presets by default; complete recipes can opt out.
+    merge_model_recipe: bool = True
     # Run the training app detached so it keeps running on Modal even if the
     # local client disconnects (terminal closed, laptop asleep). The CLI's
     # ``modal run --detach`` only detaches the entrypoint, not the nested
@@ -377,11 +393,11 @@ class TrainConfig:
                 raise TypeError(
                     f"Recipe type {recipe_type} requires SlimeRecipe, got {type(self.recipe).__name__}"
                 )
-            base_recipe = SlimeRecipe.get_base_recipe(self.model)
-            if base_recipe is not None:
-                combined = _merge_recipe(base_recipe, cast(SlimeRecipe, self.recipe))
-            else:
-                combined = cast(SlimeRecipe, self.recipe)
+            combined = _resolve_slime_recipe(
+                self.model,
+                cast(SlimeRecipe, self.recipe),
+                merge_model_recipe=self.merge_model_recipe,
+            )
             return build_slime_app(
                 training_run_id=self.training_run_id,
                 slime=combined,
@@ -433,11 +449,10 @@ class TrainConfig:
                 _serialize_slime_params,
             )
 
-            base_recipe = SlimeRecipe.get_base_recipe(model)
-            combined = (
-                _merge_recipe(base_recipe, cast(SlimeRecipe, recipe))
-                if base_recipe is not None
-                else cast(SlimeRecipe, recipe)
+            combined = _resolve_slime_recipe(
+                model,
+                cast(SlimeRecipe, recipe),
+                merge_model_recipe=self.merge_model_recipe,
             )
             summary["recipe"] = _serialize_slime_params(
                 combined, dataset=dataset, model=model

--- a/tests/test_readable_ids.py
+++ b/tests/test_readable_ids.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from modal_training_gym.common import ids
-from modal_training_gym.common.dataset import DatasetConfig
-from modal_training_gym.common.models import ModelConfig
+from modal_training_gym.common.dataset import DatasetConfig, HuggingFaceDataset
+from modal_training_gym.common.models import ModelConfig, Qwen3_4B
 from modal_training_gym.common.train import TrainConfig
 from modal_training_gym.train_recipes.base import BaseTrainRecipe, RecipeType
+from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
 
 
 def test_create_hash_has_word_word_hash_shape() -> None:
@@ -64,3 +65,40 @@ def test_train_config_keeps_stable_training_run_id(monkeypatch) -> None:
     assert config.training_run_id == "brisk-river-deadbeef"
     assert config.training_run_id == "brisk-river-deadbeef"
     assert calls == 1
+
+
+def test_train_config_can_skip_model_recipe_merge() -> None:
+    recipe = SlimeRecipe(
+        gpu_type="H100",
+        colocate=True,
+        tensor_model_parallel_size=1,
+        sequence_parallel=False,
+        rollout_num_gpus_per_engine=1,
+        num_rollout=1,
+        rollout_batch_size=16,
+        rollout_max_response_len=4096,
+        rollout_temperature=1.0,
+        save_interval=10,
+    )
+    dataset = HuggingFaceDataset(
+        hf_repo="some/dataset",
+        input_column="prompt",
+        output_column="answer",
+    )
+
+    merged = TrainConfig(
+        dataset=dataset,
+        model=Qwen3_4B(),
+        recipe=recipe,
+    )._build_config_summary()
+    assert merged["recipe"]["n_samples_per_prompt"] == 8
+    assert merged["recipe"]["lr"] == 5e-7
+
+    unmerged = TrainConfig(
+        dataset=dataset,
+        model=Qwen3_4B(),
+        recipe=recipe,
+        merge_model_recipe=False,
+    )._build_config_summary()
+    assert unmerged["recipe"]["n_samples_per_prompt"] == 2
+    assert unmerged["recipe"]["lr"] == 1e-6


### PR DESCRIPTION

`TrainConfig` currently always merges known-model Slime recipes with the model’s built-in preset, which works for partial overrides but can be wrong for recipes that are already complete. That forced callers with custom complete recipes to work around the merge behavior, for example by monkeypatching `SlimeRecipe.get_base_recipe` so custom fields would survive. This change adds an explicit opt-out so complete recipes can be used directly while preserving the existing preset-merge behavior by default.

Also, previous changes of context length are still live.


## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
