### PR TITLE
safe reload async

### DIFF
--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -127,6 +127,13 @@ def _safe_reload(vol) -> None:
         pass
 
 
+async def _safe_reload_async(vol) -> None:
+    try:
+        await vol.reload.aio()
+    except RuntimeError:
+        pass
+
+
 def _store_path(store: MetadataStore | str) -> str:
     if isinstance(store, MetadataStore):
         return store.value
@@ -192,7 +199,7 @@ async def vol_get_async(store: MetadataStore | str, key: str) -> dict[str, Any]:
         chunks = [chunk async for chunk in vol.read_file.aio(path)]
         return json.loads(b"".join(chunks))
     except FileNotFoundError:
-        await vol.reload.aio()
+        await _safe_reload_async(vol)
     try:
         chunks = [chunk async for chunk in vol.read_file.aio(path)]
         return json.loads(b"".join(chunks))
@@ -226,7 +233,7 @@ def vol_list(store: MetadataStore | str) -> list[dict[str, Any]]:
 
 async def vol_list_async(store: MetadataStore | str) -> list[dict[str, Any]]:
     vol = _metadata_volume()
-    await vol.reload.aio()
+    await _safe_reload_async(vol)
     results = []
     try:
         async for entry in vol.iterdir.aio(_store_path(store)):
@@ -321,10 +328,7 @@ async def vol_get_summary_items_async(
     payload_key: str = SUMMARY_ITEMS_KEY,
 ) -> list[dict[str, Any]] | None:
     vol = _metadata_volume()
-    try:
-        await vol.reload.aio()
-    except (RuntimeError, Exception):
-        pass
+    await _safe_reload_async(vol)
     try:
         payload = await vol_get_async(store, key)
     except KeyError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from modal_training_gym.utils import metadata
 
 
 class _Method:
-    """A Modal Volume method exposing a sync call and an ``.aio`` async form. """
+    """A Modal Volume method exposing a sync call and an ``.aio`` async form."""
 
     def __init__(self, sync_fn, async_fn):
         self._sync_fn = sync_fn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,24 @@ import pytest
 from modal_training_gym.utils import metadata
 
 
+class _Method:
+    """A Modal Volume method exposing a sync call and an ``.aio`` async form. """
+
+    def __init__(self, sync_fn, async_fn):
+        self._sync_fn = sync_fn
+        self.aio = async_fn
+
+    def __call__(self, *args, **kwargs):
+        return self._sync_fn(*args, **kwargs)
+
+
 class FakeVolume:
     """In-memory stand-in for a Modal Volume that is *not* attached.
 
-    ``reload()`` raises like a real unattached/local volume; reads and writes
-    operate on an in-memory dict. A correct metadata layer must still complete a
-    ``save()`` against this — reload is only a freshness hint.
+    ``reload()`` raises like a real unattached/local volume (both sync and via
+    ``.aio()``); reads and writes operate on an in-memory dict. A correct
+    metadata layer must still complete a ``save()`` / ``save_async()`` against
+    this — reload is only a freshness hint.
     """
 
     class _DirEntry:
@@ -25,25 +37,38 @@ class FakeVolume:
 
     def __init__(self) -> None:
         self.files: dict[str, bytes] = {}
+        self.reload = _Method(self._reload, self._reload_async)
+        self.read_file = _Method(self._read_file, self._read_file_async)
+        self.iterdir = _Method(self._iterdir, self._iterdir_async)
 
-    def reload(self) -> None:
+    def _reload(self) -> None:
         raise RuntimeError("reload() can only be called from within a running function")
 
-    def read_file(self, path: str):
+    async def _reload_async(self) -> None:
+        raise RuntimeError("reload() can only be called from within a running function")
+
+    def _read_file(self, path: str):
         if path not in self.files:
             raise FileNotFoundError(path)
         return [self.files[path]]
+
+    async def _read_file_async(self, path: str):
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        yield self.files[path]
 
     def remove_file(self, path: str) -> None:
         if path not in self.files:
             raise FileNotFoundError(path)
         del self.files[path]
 
-    def iterdir(self, path: str):
-        """Return list of files in the given path (stub for Modal Volume.iterdir)."""
+    def _iterdir(self, path: str):
         prefix = path.rstrip("/") + "/"
-        matching_files = [f for f in self.files.keys() if f.startswith(prefix)]
-        return [self._DirEntry(f) for f in matching_files]
+        return [self._DirEntry(f) for f in self.files if f.startswith(prefix)]
+
+    async def _iterdir_async(self, path: str):
+        for entry in self._iterdir(path):
+            yield entry
 
     def batch_upload(self, force: bool = False):
         files = self.files
@@ -53,6 +78,12 @@ class FakeVolume:
                 return self
 
             def __exit__(self, *_exc):
+                return False
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
                 return False
 
             def put_file(self, fileobj: io.BytesIO, path: str) -> None:

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -1,13 +1,15 @@
 """Drive the real ``save()`` chain to completion without Modal or a GPU.
 
-``TrainingRun.save()`` and ``TrainResult.save()`` are exercised against an
-in-memory ``FakeVolume`` (see ``conftest.py``) so the full serialize-and-write
-path is covered in CI: the payload must stay JSON-serializable, and ``save()``
-must complete even when ``Volume.reload()`` is unavailable.
+``TrainingRun.save()``, ``TrainResult.save()``, and
+``TrainingRolloutResult.save_async()`` are exercised against an in-memory
+``FakeVolume`` (see ``conftest.py``) so the full serialize-and-write path is
+covered in CI: the payload must stay JSON-serializable, and ``save()`` /
+``save_async()`` must complete even when ``Volume.reload()`` is unavailable.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 
@@ -16,6 +18,7 @@ import pytest
 from modal_training_gym.common import run as run_mod
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.train_result import TrainResult
+from modal_training_gym.common.training_rollout import TrainingRolloutResult
 from modal_training_gym.utils.metadata import MetadataStore
 
 
@@ -35,6 +38,26 @@ def test_train_result_save_survives_unmounted_volume(fake_volume, fw):
 
     blob = fake_volume.files[f"{MetadataStore.TRAIN_RESULTS.value}/t2.json"]
     assert json.loads(blob)["framework"] == fw.value
+
+
+def test_rollout_save_async_survives_unmounted_volume(fake_volume):
+    """TrainingRolloutResult.save_async() completes when reload() raises."""
+    asyncio.run(
+        TrainingRolloutResult(
+            training_run_id="t3",
+            rollout_id=0,
+            samples=[{"score": 1.0, "prompt": "p", "response": "r"}],
+        ).save_async()
+    )
+
+    blob = fake_volume.files[
+        f"{MetadataStore.TRAINING_ROLLOUTS.value}/t3__00000000.json"
+    ]
+    assert json.loads(blob)["rollout_id"] == 0
+    summary = fake_volume.files[
+        f"{MetadataStore.TRAINING_ROLLOUTS_SUMMARY.value}/summary.json"
+    ]
+    assert json.loads(summary)["items"][0]["summary_key"] == "t3__00000000"
 
 
 @pytest.mark.parametrize("fw", list(Framework))


### PR DESCRIPTION
Similar to https://github.com/modal-projects/training-gym/commit/1820790a5e066ff6b576a379529843a2c832d7a6 but for reload async

tldr it is preventing rollouts from being displayed on the dashboard

if you're running training run for the first time and it was after jun 12, you wouldnt have a summary.json in your volume, so the file is missing and hits an unsafe reload --> save_asyncgets aborted, and then no rollouts are found in the summary file to display in the dashboard

i fixed it by wrapping the async reload to catch the runtime error, just like how reload sync was done
