### PR TITLE
show plain response

### DIFF
--- a/dashboards/frontend/src/components/ConversationView.svelte
+++ b/dashboards/frontend/src/components/ConversationView.svelte
@@ -228,12 +228,19 @@
     return { assistant: "Assistant", user: "User", tool: "Tool Result", system: "System", developer: "Developer" }[role] || role;
   }
 
-  // Resolve turns: prefer structured messages, fall back to response parsing
+  // Resolve turns: prefer structured messages, then multi-turn response
+  // parsing, and finally render a plain single-turn response as one assistant
+  // turn.
   let parsed = $derived.by(() => {
     if (Array.isArray(messages) && messages.length > 0) {
       return messages.map(parseStructuredMessage);
     }
-    return parseFlatResponse(response);
+    const turns = parseFlatResponse(response);
+    if (turns.length) return turns;
+    if (response) {
+      return [parseStructuredMessage({ role: "assistant", content: response })];
+    }
+    return [];
   });
 
   let thinkingOpen = $state({});


### PR DESCRIPTION
so rollout responses show up in dashboard

<img width="1436" height="1162" alt="image" src="https://github.com/user-attachments/assets/8d1729bb-3d2f-442f-97e8-8d396ec0f1a0" />