### PR TITLE
Ignore empty sweep axes and forward W&B entity

### DIFF
--- a/modal_training_gym/common/training_group.py
+++ b/modal_training_gym/common/training_group.py
@@ -169,14 +169,18 @@ class TrainingGroup:
         self._validate_paths()
         keys = list(self.grid)
         combos: list[tuple[Any, ...]]
-        if keys and all(self.grid[k] for k in keys):
+        active_keys = [k for k in keys if self.grid[k]]
+        if active_keys:
             import itertools
 
-            combos = list(itertools.product(*(self.grid[k] for k in keys)))
+            combos = list(itertools.product(*(self.grid[k] for k in active_keys)))
         else:
             combos = [()]
         self._variants = [
-            (dict(zip(keys, combo)), self._build_variant(dict(zip(keys, combo))))
+            (
+                dict(zip(active_keys, combo)),
+                self._build_variant(dict(zip(active_keys, combo))),
+            )
             for combo in combos
         ]
         return list(self._variants)

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -269,6 +269,7 @@ class MilesConfig(BaseTrainRecipe):
         return {
             "use_wandb": True,
             "wandb_project": w.project,
+            "wandb_entity": w.entity,
             "wandb_group": w.group,
             "wandb_key": w.key,
             "disable_wandb_random_suffix": w.disable_random_suffix,

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -463,6 +463,7 @@ class SlimeRecipe(BaseTrainRecipe):
         return {
             "use_wandb": True,
             "wandb_project": w.project,
+            "wandb_entity": w.entity,
             "wandb_group": w.group,
             "wandb_key": w.key,
             "disable_wandb_random_suffix": w.disable_random_suffix,

--- a/tests/test_training_group.py
+++ b/tests/test_training_group.py
@@ -105,6 +105,24 @@ def test_empty_grid_axis_yields_single_blank_variant():
     assert cfg.training_run_id
 
 
+def test_empty_grid_axis_is_ignored_when_other_axes_have_values():
+    group = TrainingGroup(
+        base=_base(),
+        grid={
+            "recipe.lr": [1e-6, 5e-6],
+            "recipe.rollout_temperature": [],
+        },
+    )
+
+    variants = group.iter_variants()
+
+    assert len(variants) == 2
+    assert [overrides for overrides, _ in variants] == [
+        {"recipe.lr": 1e-6},
+        {"recipe.lr": 5e-6},
+    ]
+
+
 def test_empty_group_variant_records_blank_group_tags():
     group = TrainingGroup(base=_base(), grid={"recipe.lr": []}, name="Blank Sweep")
     cfg = group.get_train_configs()[0]

--- a/tests/test_wandb_preflight.py
+++ b/tests/test_wandb_preflight.py
@@ -11,6 +11,8 @@ from modal_training_gym.common.wandb import WandbConfig, preflight_wandb
 from modal_training_gym.frameworks.slime.launcher import (
     _preflight_wandb as _slime_preflight_wandb,
 )
+from modal_training_gym.train_recipes.miles_recipe.recipe import MilesConfig
+from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
 
 _CFG = WandbConfig(project="qwen3-asr-rl", modal_wandb_secret_name="wandb-secret")
 
@@ -98,3 +100,10 @@ def test_slime_preflight_delegates_to_common(monkeypatch):
     )
     entity = _slime_preflight_wandb(_CFG)
     assert entity == "slime-team"
+
+
+def test_wandb_entity_is_forwarded_to_framework_cli_fields():
+    wandb_cfg = WandbConfig(project="qwen3-asr-rl", entity="my-team")
+
+    assert SlimeRecipe._wandb_to_fields(wandb_cfg)["wandb_entity"] == "my-team"
+    assert MilesConfig._wandb_to_fields(wandb_cfg)["wandb_entity"] == "my-team"


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

Fixed two review issues from PR #198:
- `TrainingGroup.iter_variants()` now skips empty grid axes when other axes have values, so partially populated sweeps still expand the configured overrides instead of collapsing to a blank run.
- Both Slime and Miles recipe converters now forward `wandb.entity` as `wandb_entity`, matching preflight resolution and the metadata recorded by the launchers.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

Link to Devin session: https://modal.devinenterprise.com/sessions/e74f372f19d24a9fbdad8b350ff4f76e
Requested by: @joyliu-q