### PR TITLE
Add step/substep timing visualization to dashboard UI

### DIFF
--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -1,0 +1,429 @@
+<script>
+  import { Download } from "lucide-svelte";
+
+  let {
+    stepTimes = null,
+    substepTimes = null,
+    layout = "rows",
+    downloadName = "step_substep_times.json",
+  } = $props();
+
+  const SUBSTEP_LABELS = {
+    evaluate_rollouts: "Eval (before)",
+    generate_rollouts: "Generate rollouts",
+    offload_rollout: "Offload rollout",
+    compute_log_probs: "Compute log probs",
+    optimizer_step: "Optimizer step",
+    weight_sync: "Weight sync",
+    checkpoint_save: "Checkpoint save",
+    offload_train: "Offload train",
+    evaluate_rollouts_end: "Eval (after)",
+  };
+
+  const SUBSTEP_COLORS = {
+    evaluate_rollouts: "#60a5fa",
+    generate_rollouts: "#34d399",
+    offload_rollout: "#a78bfa",
+    compute_log_probs: "#fbbf24",
+    optimizer_step: "#f87171",
+    weight_sync: "#22d3ee",
+    checkpoint_save: "#f472b6",
+    offload_train: "#c084fc",
+    evaluate_rollouts_end: "#818cf8",
+  };
+
+  const ORDER = Object.keys(SUBSTEP_LABELS);
+
+  // Timeline horizontal scale (pixels per second) + fixed width for dropped substeps.
+  const PX_PER_SEC = 2;
+  const NULL_WIDTH = 8;
+
+  function labelFor(name) {
+    return SUBSTEP_LABELS[name] || name.replace(/_/g, " ");
+  }
+
+  function colorFor(name) {
+    return SUBSTEP_COLORS[name] || "var(--color-c-gray-40, #5e5e5e)";
+  }
+
+  // Durations are float seconds; keep up to 2 decimals (trailing zeros trimmed).
+  function fmtSecs(s) {
+    if (s == null) return "—";
+    const n = Number(s);
+    if (!Number.isFinite(n)) return "—";
+    const trim = (x) => x.toFixed(2).replace(/\.?0+$/, "");
+    if (n >= 60) {
+      const m = Math.floor(n / 60);
+      return `${m}m ${trim(n - m * 60)}s`;
+    }
+    return `${trim(n)}s`;
+  }
+
+  function downloadJson() {
+    const payload = { step_times: stepTimes || {}, substep_times: substepTimes || {} };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = downloadName;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function segWidth(sub) {
+    if (sub.duration == null) return NULL_WIDTH;
+    return Math.max(sub.duration * PX_PER_SEC, 2);
+  }
+
+  let steps = $derived.by(() => {
+    const stepKeys = Object.keys(stepTimes || {});
+    const subKeys = Object.keys(substepTimes || {});
+    const keys = Array.from(new Set([...stepKeys, ...subKeys]));
+    const out = keys.map((k) => {
+      const st = (stepTimes || {})[k] || null;
+      const subs = (substepTimes || {})[k] || {};
+      const substeps = Object.entries(subs)
+        .map(([name, v]) => ({
+          name,
+          start: v?.start ?? null,
+          duration: v?.duration_s ?? null,
+        }))
+        .sort((a, b) => (a.start ?? 0) - (b.start ?? 0));
+      return {
+        key: k,
+        n: Number.isFinite(Number(k)) ? Number(k) : k,
+        duration: st?.duration_s ?? null,
+        substeps,
+      };
+    });
+    out.sort((a, b) => (Number(a.key) || 0) - (Number(b.key) || 0));
+    return out;
+  });
+
+  let hasData = $derived(steps.length > 0);
+
+  let legend = $derived.by(() => {
+    const seen = new Set();
+    for (const s of steps) for (const sub of s.substeps) seen.add(sub.name);
+    return ORDER.filter((n) => seen.has(n));
+  });
+
+  let tip = $state(null);
+  let pinned = $state(false);
+
+  function isActive(step, sub) {
+    return tip && tip.step === step.n && tip.name === sub.name;
+  }
+
+  function showTip(e, step, sub) {
+    if (pinned) return;
+    tip = { x: e.clientX, y: e.clientY, step: step.n, name: sub.name, dur: sub.duration };
+  }
+
+  function moveTip(e) {
+    if (pinned || !tip) return;
+    tip = { ...tip, x: e.clientX, y: e.clientY };
+  }
+
+  function hideTip() {
+    if (pinned) return;
+    tip = null;
+  }
+
+  function pinTip(e, step, sub) {
+    e.stopPropagation();
+    if (pinned && isActive(step, sub)) {
+      pinned = false;
+      tip = null;
+      return;
+    }
+    pinned = true;
+    tip = { x: e.clientX, y: e.clientY, step: step.n, name: sub.name, dur: sub.duration };
+  }
+
+  function clearPin() {
+    if (!pinned) return;
+    pinned = false;
+    tip = null;
+  }
+</script>
+
+<svelte:window onclick={clearPin} />
+
+{#snippet segment(step, sub, timeline)}
+  <div
+    class="seg"
+    class:seg-null={sub.duration == null}
+    class:active={pinned && isActive(step, sub)}
+    style:flex-grow={timeline || sub.duration == null ? undefined : Math.max(sub.duration, 0.01)}
+    style:width={timeline ? `${segWidth(sub)}px` : undefined}
+    style:background={sub.duration == null ? undefined : colorFor(sub.name)}
+    role="button"
+    tabindex="0"
+    onmouseenter={(e) => showTip(e, step, sub)}
+    onmousemove={moveTip}
+    onmouseleave={hideTip}
+    onclick={(e) => pinTip(e, step, sub)}
+    onkeydown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        pinTip(e, step, sub);
+      }
+    }}
+  ></div>
+{/snippet}
+
+{#if hasData}
+  <div class="step-timings">
+    {#if legend.length || layout === "timeline"}
+      <div class="legend-row">
+        <div class="legend">
+          {#each legend as name (name)}
+            <span class="legend-item">
+              <span class="swatch" style:background={colorFor(name)}></span>
+              {labelFor(name)}
+            </span>
+          {/each}
+        </div>
+        {#if layout === "timeline"}
+          <button
+            class="dl-btn"
+            onclick={downloadJson}
+            title="Download step + substep times as JSON"
+          >
+            <Download size={13} />
+            Download JSON
+          </button>
+        {/if}
+      </div>
+    {/if}
+
+    {#if layout === "timeline"}
+      <div class="timeline-scroll">
+        <div class="bar tl-bar">
+          {#each steps as step, si (step.key)}
+            {#if si > 0}
+              <div class="tl-divider" title={`Step ${step.n}`}></div>
+            {/if}
+            {#each step.substeps as sub (sub.name)}
+              {@render segment(step, sub, true)}
+            {/each}
+          {/each}
+        </div>
+      </div>
+    {:else}
+      {#each steps as step (step.key)}
+        <div class="step-row">
+          <div class="step-head">
+            <span class="step-name">Step {step.n}</span>
+            <span class="step-dur">{fmtSecs(step.duration)}</span>
+          </div>
+          {#if step.substeps.length}
+            <div class="bar">
+              {#each step.substeps as sub (sub.name)}
+                {@render segment(step, sub, false)}
+              {/each}
+            </div>
+          {:else}
+            <div class="bar bar-empty"></div>
+          {/if}
+        </div>
+      {/each}
+    {/if}
+  </div>
+
+  {#if tip}
+    <div class="tg-tip" class:pinned style:left={`${tip.x}px`} style:top={`${tip.y}px`}>
+      <span class="tg-tip-step">Step {tip.step}</span>
+      <span class="tg-tip-name">{labelFor(tip.name)}</span>
+      <span class="tg-tip-dur">
+        {tip.dur == null ? "unknown (report dropped)" : fmtSecs(tip.dur)}
+      </span>
+    </div>
+  {/if}
+{/if}
+
+<style>
+  .step-timings {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .legend-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 4px;
+  }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    font-size: 11px;
+    color: var(--muted);
+  }
+
+  .dl-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    flex-shrink: 0;
+    background: none;
+    border: 1px solid var(--border, #2f2f2f);
+    border-radius: 4px;
+    color: var(--muted);
+    font-size: 11px;
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+
+  .dl-btn:hover {
+    color: var(--text);
+    border-color: var(--border-strong, #4a4a4a);
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .step-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .step-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    font-size: 12px;
+  }
+
+  .step-name {
+    color: var(--text-bright);
+    font-weight: 500;
+  }
+
+  .step-dur {
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .bar {
+    display: flex;
+    height: 14px;
+    border-radius: 3px;
+    overflow: hidden;
+    background: var(--color-c-gray-08, #1c1c1c);
+    gap: 1px;
+  }
+
+  .bar-empty {
+    background: var(--color-c-gray-10, #2f2f2f);
+  }
+
+  .seg {
+    min-width: 2px;
+    height: 100%;
+    cursor: pointer;
+    transition: filter 0.1s ease;
+  }
+
+  .seg:hover {
+    filter: brightness(1.25);
+  }
+
+  .seg.active {
+    outline: 1px solid var(--text-bright, #fff);
+    outline-offset: -1px;
+    filter: brightness(1.3);
+  }
+
+  /* Dropped substep: visible but doesn't distort the proportional widths. */
+  .seg-null {
+    flex: 0 0 16px;
+    background: repeating-linear-gradient(
+      45deg,
+      var(--color-c-gray-20, #3a3a3a),
+      var(--color-c-gray-20, #3a3a3a) 3px,
+      var(--color-c-gray-10, #2f2f2f) 3px,
+      var(--color-c-gray-10, #2f2f2f) 6px
+    );
+  }
+
+  /* ── Timeline (one long continuous bar across all steps) ─────────────── */
+  .timeline-scroll {
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 6px;
+  }
+
+  .tl-bar {
+    width: max-content;
+    min-width: 100%;
+    height: 18px;
+  }
+
+  .tl-bar .seg {
+    flex: 0 0 auto;
+  }
+
+  /* Thin marker between steps within the single continuous bar. */
+  .tl-divider {
+    flex: 0 0 2px;
+    height: 100%;
+    background: var(--color-c-gray-02, #0d0d0d);
+  }
+
+  /* ── Pinnable tooltip ────────────────────────────────────────────────── */
+  .tg-tip {
+    position: fixed;
+    z-index: 1000;
+    transform: translate(-50%, calc(-100% - 10px));
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 6px 9px;
+    border-radius: 6px;
+    background: var(--color-c-gray-02, #0d0d0d);
+    border: 1px solid var(--border, #3a3a3a);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  .tg-tip.pinned {
+    border-color: var(--accent, #60a5fa);
+  }
+
+  .tg-tip-step {
+    color: var(--muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .tg-tip-name {
+    color: var(--text-bright, #fff);
+    font-weight: 600;
+  }
+
+  .tg-tip-dur {
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Download } from "lucide-svelte";
+  import { Download, ZoomIn, ZoomOut } from "lucide-svelte";
 
   let {
     stepTimes = null,
@@ -34,9 +34,11 @@
 
   const ORDER = Object.keys(SUBSTEP_LABELS);
 
-  // Timeline horizontal scale (pixels per second) + fixed width for dropped substeps.
-  const PX_PER_SEC = 2;
-  const NULL_WIDTH = 8;
+  // Timeline zoom bounds: 1 = fit-to-width, MAX_ZOOM = deepest magnification.
+  const MIN_ZOOM = 1;
+  const MAX_ZOOM = 64;
+  const ZOOM_BTN_FACTOR = 1.5;
+  const WHEEL_SENSITIVITY = 0.0015;
 
   function labelFor(name) {
     return SUBSTEP_LABELS[name] || name.replace(/_/g, " ");
@@ -68,11 +70,6 @@
     a.download = downloadName;
     a.click();
     URL.revokeObjectURL(url);
-  }
-
-  function segWidth(sub) {
-    if (sub.duration == null) return NULL_WIDTH;
-    return Math.max(sub.duration * PX_PER_SEC, 2);
   }
 
   let steps = $derived.by(() => {
@@ -110,6 +107,51 @@
 
   let tip = $state(null);
   let pinned = $state(false);
+
+  // ── Timeline zoom / pan state ────────────────────────────────────────
+  let zoom = $state(1);
+  let viewport = $state(null);
+
+  function stepWeight(step) {
+    const subTotal = step.substeps.reduce((acc, s) => acc + (s.duration ?? 0), 0);
+    if (subTotal > 0) return subTotal;
+    if (step.duration != null && step.duration > 0) return step.duration;
+    return 1;
+  }
+
+  function setZoom(next, anchorX = null) {
+    const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, next));
+    if (clamped === zoom) return;
+    if (viewport) {
+      const rect = viewport.getBoundingClientRect();
+      const cursorX = anchorX == null ? rect.width / 2 : anchorX - rect.left;
+      const contentX = viewport.scrollLeft + cursorX;
+      const scale = clamped / zoom;
+      zoom = clamped;
+      requestAnimationFrame(() => {
+        viewport.scrollLeft = contentX * scale - cursorX;
+      });
+    } else {
+      zoom = clamped;
+    }
+  }
+
+  function handleWheel(e) {
+    // Let horizontal trackpad gestures pan natively; vertical wheel zooms.
+    if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+    e.preventDefault();
+    setZoom(zoom * Math.exp(-e.deltaY * WHEEL_SENSITIVITY), e.clientX);
+  }
+
+  // Wheel listeners are passive by default; zooming needs preventDefault.
+  function wheelZoom(node) {
+    node.addEventListener("wheel", handleWheel, { passive: false });
+    return {
+      destroy() {
+        node.removeEventListener("wheel", handleWheel);
+      },
+    };
+  }
 
   function isActive(step, sub) {
     return tip && tip.step === step.n && tip.name === sub.name;
@@ -150,13 +192,12 @@
 
 <svelte:window onclick={clearPin} />
 
-{#snippet segment(step, sub, timeline)}
+{#snippet segment(step, sub)}
   <div
     class="seg"
     class:seg-null={sub.duration == null}
     class:active={pinned && isActive(step, sub)}
-    style:flex-grow={timeline || sub.duration == null ? undefined : Math.max(sub.duration, 0.01)}
-    style:width={timeline ? `${segWidth(sub)}px` : undefined}
+    style:flex-grow={sub.duration == null ? undefined : Math.max(sub.duration, 0.01)}
     style:background={sub.duration == null ? undefined : colorFor(sub.name)}
     role="button"
     tabindex="0"
@@ -186,31 +227,69 @@
           {/each}
         </div>
         {#if layout === "timeline"}
-          <button
-            class="dl-btn"
-            onclick={downloadJson}
-            title="Download step + substep times as JSON"
-          >
-            <Download size={13} />
-            Download JSON
-          </button>
+          <div class="tl-toolbar">
+            <div class="zoom-controls">
+              <button
+                class="zoom-btn"
+                onclick={() => setZoom(zoom / ZOOM_BTN_FACTOR)}
+                disabled={zoom <= MIN_ZOOM}
+                title="Zoom out"
+              >
+                <ZoomOut size={13} />
+              </button>
+              <button
+                class="zoom-level"
+                onclick={() => setZoom(MIN_ZOOM)}
+                disabled={zoom <= MIN_ZOOM}
+                title="Reset zoom to fit"
+              >
+                {zoom >= 10 ? Math.round(zoom) : zoom.toFixed(1).replace(/\.0$/, "")}×
+              </button>
+              <button
+                class="zoom-btn"
+                onclick={() => setZoom(zoom * ZOOM_BTN_FACTOR)}
+                disabled={zoom >= MAX_ZOOM}
+                title="Zoom in"
+              >
+                <ZoomIn size={13} />
+              </button>
+            </div>
+            <button
+              class="dl-btn"
+              onclick={downloadJson}
+              title="Download step + substep times as JSON"
+            >
+              <Download size={13} />
+              Download JSON
+            </button>
+          </div>
         {/if}
       </div>
     {/if}
 
     {#if layout === "timeline"}
-      <div class="timeline-scroll">
-        <div class="bar tl-bar">
-          {#each steps as step, si (step.key)}
-            {#if si > 0}
-              <div class="tl-divider" title={`Step ${step.n}`}></div>
-            {/if}
-            {#each step.substeps as sub (sub.name)}
-              {@render segment(step, sub, true)}
-            {/each}
+      <div class="tl-viewport" bind:this={viewport} use:wheelZoom>
+        <div class="tl-track" style:width={`${zoom * 100}%`}>
+          {#each steps as step (step.key)}
+            <div class="tl-step" style:flex-grow={stepWeight(step)}>
+              <div class="tl-step-head">
+                <span class="tl-step-name">Step {step.n}</span>
+                <span class="tl-step-dur">{fmtSecs(step.duration)}</span>
+              </div>
+              {#if step.substeps.length}
+                <div class="bar tl-bar">
+                  {#each step.substeps as sub (sub.name)}
+                    {@render segment(step, sub)}
+                  {/each}
+                </div>
+              {:else}
+                <div class="bar tl-bar bar-empty"></div>
+              {/if}
+            </div>
           {/each}
         </div>
       </div>
+      <div class="tl-hint">Scroll to zoom · shift-scroll or drag the scrollbar to pan</div>
     {:else}
       {#each steps as step (step.key)}
         <div class="step-row">
@@ -221,7 +300,7 @@
           {#if step.substeps.length}
             <div class="bar">
               {#each step.substeps as sub (sub.name)}
-                {@render segment(step, sub, false)}
+                {@render segment(step, sub)}
               {/each}
             </div>
           {:else}
@@ -364,28 +443,104 @@
     );
   }
 
-  /* ── Timeline (one long continuous bar across all steps) ─────────────── */
-  .timeline-scroll {
+  /* ── Timeline (full-width zoomable bar across all steps) ─────────────── */
+  .tl-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .zoom-controls {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--border, #2f2f2f);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .zoom-btn,
+  .zoom-level {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-size: 11px;
+    padding: 3px 7px;
+    cursor: pointer;
+  }
+
+  .zoom-level {
+    min-width: 38px;
+    border-left: 1px solid var(--border, #2f2f2f);
+    border-right: 1px solid var(--border, #2f2f2f);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .zoom-btn:hover:not(:disabled),
+  .zoom-level:hover:not(:disabled) {
+    color: var(--text);
+    background: var(--color-c-gray-08, #1c1c1c);
+  }
+
+  .zoom-btn:disabled,
+  .zoom-level:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .tl-viewport {
     overflow-x: auto;
     overflow-y: hidden;
     padding-bottom: 6px;
+    overscroll-behavior-x: contain;
+  }
+
+  .tl-track {
+    display: flex;
+    gap: 3px;
+    min-width: 100%;
+  }
+
+  .tl-step {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    flex-basis: 0;
+    min-width: 3px;
+    overflow: hidden;
+  }
+
+  .tl-step-head {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 10px;
+    line-height: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .tl-step-name {
+    color: var(--text-bright);
+    font-weight: 500;
+  }
+
+  .tl-step-dur {
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
   }
 
   .tl-bar {
-    width: max-content;
-    min-width: 100%;
     height: 18px;
   }
 
-  .tl-bar .seg {
-    flex: 0 0 auto;
-  }
-
-  /* Thin marker between steps within the single continuous bar. */
-  .tl-divider {
-    flex: 0 0 2px;
-    height: 100%;
-    background: var(--color-c-gray-02, #0d0d0d);
+  .tl-hint {
+    font-size: 10px;
+    color: var(--muted);
+    opacity: 0.7;
   }
 
   /* ── Pinnable tooltip ────────────────────────────────────────────────── */

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -14,9 +14,9 @@
     offload_rollout: "Offload rollout",
     compute_log_probs: "Compute log probs",
     optimizer_step: "Optimizer step",
-    weight_sync: "Weight sync",
     checkpoint_save: "Checkpoint save",
     offload_train: "Offload train",
+    weight_sync: "Weight sync",
     evaluate_rollouts_end: "Eval (after)",
   };
 

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -46,12 +46,12 @@
     return SUBSTEP_COLORS[name] || "var(--color-c-gray-40, #5e5e5e)";
   }
 
-  // Durations are float seconds; keep up to 2 decimals (trailing zeros trimmed).
+  // Durations are float seconds; keep up to 3 decimals (trailing zeros trimmed).
   function fmtSecs(s) {
     if (s == null) return "—";
     const n = Number(s);
     if (!Number.isFinite(n)) return "—";
-    const trim = (x) => x.toFixed(2).replace(/\.?0+$/, "");
+    const trim = (x) => x.toFixed(3).replace(/\.?0+$/, "");
     if (n >= 60) {
       const m = Math.floor(n / 60);
       return `${m}m ${trim(n - m * 60)}s`;

--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -279,6 +279,8 @@ export async function fetchRuns({ signal } = {}) {
       updated_at: updatedAt,
       duration_seconds: durationSeconds,
       error_message: safeStr(run.error_message || ""),
+      step_times: run.step_times || null,
+      substep_times: run.substep_times || null,
       metadata,
       resume_state: summarizeResumeState(metadata),
       wandb_links: wandbLinks,
@@ -363,22 +365,6 @@ export async function fetchRunRollouts(trainingRunId, { signal } = {}) {
       error_summary: item.error_summary || null,
     }))
     .sort((a, b) => a.rollout_id - b.rollout_id);
-}
-
-// Step/substep timings are excluded from the /api/runs list payload (they
-// grow with the number of training steps) and fetched lazily per run here.
-export async function fetchRunStepTimes(trainingRunId, { signal } = {}) {
-  const res = await fetch(
-    `${SERVER}/runs/${encodeURIComponent(trainingRunId)}/step-times`,
-    { signal },
-  );
-  if (!res.ok) return null;
-  const data = await res.json();
-  if (!data || typeof data !== "object") return null;
-  return {
-    step_times: data.step_times || null,
-    substep_times: data.substep_times || null,
-  };
 }
 
 export async function fetchRollout(trainingRunId, rolloutId) {

--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -279,6 +279,8 @@ export async function fetchRuns({ signal } = {}) {
       updated_at: updatedAt,
       duration_seconds: durationSeconds,
       error_message: safeStr(run.error_message || ""),
+      step_times: run.step_times || null,
+      substep_times: run.substep_times || null,
       metadata,
       resume_state: summarizeResumeState(metadata),
       wandb_links: wandbLinks,

--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -279,8 +279,6 @@ export async function fetchRuns({ signal } = {}) {
       updated_at: updatedAt,
       duration_seconds: durationSeconds,
       error_message: safeStr(run.error_message || ""),
-      step_times: run.step_times || null,
-      substep_times: run.substep_times || null,
       metadata,
       resume_state: summarizeResumeState(metadata),
       wandb_links: wandbLinks,
@@ -365,6 +363,22 @@ export async function fetchRunRollouts(trainingRunId, { signal } = {}) {
       error_summary: item.error_summary || null,
     }))
     .sort((a, b) => a.rollout_id - b.rollout_id);
+}
+
+// Step/substep timings are excluded from the /api/runs list payload (they
+// grow with the number of training steps) and fetched lazily per run here.
+export async function fetchRunStepTimes(trainingRunId, { signal } = {}) {
+  const res = await fetch(
+    `${SERVER}/runs/${encodeURIComponent(trainingRunId)}/step-times`,
+    { signal },
+  );
+  if (!res.ok) return null;
+  const data = await res.json();
+  if (!data || typeof data !== "object") return null;
+  return {
+    step_times: data.step_times || null,
+    substep_times: data.substep_times || null,
+  };
 }
 
 export async function fetchRollout(trainingRunId, rolloutId) {

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -66,7 +66,7 @@
 
   function formatMean(value) {
     if (typeof value !== "number" || !Number.isFinite(value)) return "—";
-    return value.toFixed(2);
+    return value.toFixed(3);
   }
 
   // Map a rollout to its step timing. Step keys are 1-indexed; rollout ids are

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -18,6 +18,7 @@
     fetchRollout,
     fetchRunAdvantages,
     fetchRunAdvantageStep,
+    fetchRunStepTimes,
   } from "../lib/api.js";
 
   let {
@@ -72,8 +73,8 @@
   // Map a rollout to its step timing. Step keys are 1-indexed; rollout ids are
   // 0-indexed, so step N corresponds to rollout N-1 (fall back to a direct match).
   function stepTimingForRollout(rolloutId) {
-    const st = run?.step_times || null;
-    const sub = run?.substep_times || null;
+    const st = stepTimesData?.step_times || null;
+    const sub = stepTimesData?.substep_times || null;
     if (!st && !sub) return null;
     const candidates = [String(Number(rolloutId) + 1), String(rolloutId)];
     const key = candidates.find((k) => (st && st[k]) || (sub && sub[k]));
@@ -116,6 +117,9 @@
   // Per-step advantage distribution summaries (one row per step, each with the
   // step's overall stats + quantiles) — drives the advantage fan chart.
   let advantageSteps = $state([]);
+  // Step/substep timings, fetched lazily (excluded from the runs list
+  // payload since they grow with the number of training steps).
+  let stepTimesData = $state(null);
   let hasAdvantages = $derived(advantageSteps.length > 0);
 
   // Per-step sample view: a histogram of sample scores. Clicking a bar opens
@@ -271,6 +275,18 @@
     }
   }
 
+  async function loadStepTimes(signal) {
+    if (!runId) return;
+    try {
+      const data = await fetchRunStepTimes(runId, { signal });
+      if (signal?.aborted) return;
+      // Keep what we have on a transient poll failure (null response).
+      if (data) stepTimesData = data;
+    } catch {
+      // Timing data is optional — keep whatever is already loaded.
+    }
+  }
+
   async function loadAdvantages(signal) {
     if (!runId) return;
     try {
@@ -292,6 +308,7 @@
     expandedRolloutId = null;
     expandedRollout = null;
     advantageSteps = [];
+    stepTimesData = null;
     closeBucket();
   });
 
@@ -303,10 +320,12 @@
 
     const controller = new AbortController();
     void loadAdvantages(controller.signal);
+    void loadStepTimes(controller.signal);
     const interval = window.setInterval(() => {
       const status = String(run?.status || "").toLowerCase();
       if (status && status !== "running") return;
       void loadAdvantages(controller.signal);
+      void loadStepTimes(controller.signal);
     }, 5000);
 
     return () => {
@@ -789,12 +808,12 @@
               <pre class="[border:1px_solid_color-mix(in_srgb,var(--red,#f87171)_45%,transparent)] rounded-[8px] bg-[color-mix(in_srgb,var(--red,#f87171)_12%,transparent)] text-(--red,#f87171) [font-family:var(--font-mono)] text-[12px] leading-[17px] m-0 max-h-[320px] overflow-auto p-[12px_14px] whitespace-pre-wrap [word-break:break-word]">{run.error_message}</pre>
             </div>
           {/if}
-          {#if run.step_times || run.substep_times}
+          {#if stepTimesData?.step_times || stepTimesData?.substep_times}
             <div class="rollout-chart">
               <div class="rollout-chart-title">Step &amp; substep timeline</div>
               <StepTimings
-                stepTimes={run.step_times}
-                substepTimes={run.substep_times}
+                stepTimes={stepTimesData?.step_times}
+                substepTimes={stepTimesData?.substep_times}
                 layout="timeline"
                 downloadName={`step_substep_times_${runId}.json`}
               />

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -2,6 +2,7 @@
   import { ArrowLeft, ChevronLeft, ChevronRight, Download, ExternalLink, Minimize2, X } from "lucide-svelte";
   import Tabs from "../components/Tabs.svelte";
   import RunSummary from "../components/RunSummary.svelte";
+  import StepTimings from "../components/StepTimings.svelte";
   import StatusPill from "../components/StatusPill.svelte";
   import TimeAgo from "../components/TimeAgo.svelte";
   import SampleTimeline from "../components/SampleTimeline.svelte";
@@ -65,7 +66,22 @@
 
   function formatMean(value) {
     if (typeof value !== "number" || !Number.isFinite(value)) return "—";
-    return value.toFixed(3);
+    return value.toFixed(2);
+  }
+
+  // Map a rollout to its step timing. Step keys are 1-indexed; rollout ids are
+  // 0-indexed, so step N corresponds to rollout N-1 (fall back to a direct match).
+  function stepTimingForRollout(rolloutId) {
+    const st = run?.step_times || null;
+    const sub = run?.substep_times || null;
+    if (!st && !sub) return null;
+    const candidates = [String(Number(rolloutId) + 1), String(rolloutId)];
+    const key = candidates.find((k) => (st && st[k]) || (sub && sub[k]));
+    if (!key) return null;
+    return {
+      stepTimes: st && st[key] ? { [key]: st[key] } : null,
+      substepTimes: sub && sub[key] ? { [key]: sub[key] } : null,
+    };
   }
 
   function resumeBadge(run) {
@@ -773,6 +789,17 @@
               <pre class="[border:1px_solid_color-mix(in_srgb,var(--red,#f87171)_45%,transparent)] rounded-[8px] bg-[color-mix(in_srgb,var(--red,#f87171)_12%,transparent)] text-(--red,#f87171) [font-family:var(--font-mono)] text-[12px] leading-[17px] m-0 max-h-[320px] overflow-auto p-[12px_14px] whitespace-pre-wrap [word-break:break-word]">{run.error_message}</pre>
             </div>
           {/if}
+          {#if run.step_times || run.substep_times}
+            <div class="rollout-chart">
+              <div class="rollout-chart-title">Step &amp; substep timeline</div>
+              <StepTimings
+                stepTimes={run.step_times}
+                substepTimes={run.substep_times}
+                layout="timeline"
+                downloadName={`step_substep_times_${runId}.json`}
+              />
+            </div>
+          {/if}
           {#if rolloutsLoading && !rolloutSummaries.length}
             <div class="rollout-chart">
               <ChartSkeleton variant="line" height={140} showTitle />
@@ -918,6 +945,17 @@
                     {:else if !expandedRollout || !sampleDist}
                       <div class="detail-empty">No samples recorded.</div>
                     {:else}
+                      {@const stepTiming = stepTimingForRollout(r.rollout_id)}
+                      {#if stepTiming}
+                        <div class="rollout-chart">
+                          <div class="rollout-chart-title">Step timing</div>
+                          <StepTimings
+                            stepTimes={stepTiming.stepTimes}
+                            substepTimes={stepTiming.substepTimes}
+                            layout="rows"
+                          />
+                        </div>
+                      {/if}
                       {#if expandedRollout.metrics && Object.keys(expandedRollout.metrics).length}
                         {@const m = expandedRollout.metrics}
                         {@const remoteErr = Number(m["agent/exit_status/remoteerror_sample_count"]) || 0}

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -18,7 +18,6 @@
     fetchRollout,
     fetchRunAdvantages,
     fetchRunAdvantageStep,
-    fetchRunStepTimes,
   } from "../lib/api.js";
 
   let {
@@ -73,8 +72,8 @@
   // Map a rollout to its step timing. Step keys are 1-indexed; rollout ids are
   // 0-indexed, so step N corresponds to rollout N-1 (fall back to a direct match).
   function stepTimingForRollout(rolloutId) {
-    const st = stepTimesData?.step_times || null;
-    const sub = stepTimesData?.substep_times || null;
+    const st = run?.step_times || null;
+    const sub = run?.substep_times || null;
     if (!st && !sub) return null;
     const candidates = [String(Number(rolloutId) + 1), String(rolloutId)];
     const key = candidates.find((k) => (st && st[k]) || (sub && sub[k]));
@@ -117,9 +116,6 @@
   // Per-step advantage distribution summaries (one row per step, each with the
   // step's overall stats + quantiles) — drives the advantage fan chart.
   let advantageSteps = $state([]);
-  // Step/substep timings, fetched lazily (excluded from the runs list
-  // payload since they grow with the number of training steps).
-  let stepTimesData = $state(null);
   let hasAdvantages = $derived(advantageSteps.length > 0);
 
   // Per-step sample view: a histogram of sample scores. Clicking a bar opens
@@ -275,18 +271,6 @@
     }
   }
 
-  async function loadStepTimes(signal) {
-    if (!runId) return;
-    try {
-      const data = await fetchRunStepTimes(runId, { signal });
-      if (signal?.aborted) return;
-      // Keep what we have on a transient poll failure (null response).
-      if (data) stepTimesData = data;
-    } catch {
-      // Timing data is optional — keep whatever is already loaded.
-    }
-  }
-
   async function loadAdvantages(signal) {
     if (!runId) return;
     try {
@@ -308,7 +292,6 @@
     expandedRolloutId = null;
     expandedRollout = null;
     advantageSteps = [];
-    stepTimesData = null;
     closeBucket();
   });
 
@@ -320,12 +303,10 @@
 
     const controller = new AbortController();
     void loadAdvantages(controller.signal);
-    void loadStepTimes(controller.signal);
     const interval = window.setInterval(() => {
       const status = String(run?.status || "").toLowerCase();
       if (status && status !== "running") return;
       void loadAdvantages(controller.signal);
-      void loadStepTimes(controller.signal);
     }, 5000);
 
     return () => {
@@ -808,12 +789,12 @@
               <pre class="[border:1px_solid_color-mix(in_srgb,var(--red,#f87171)_45%,transparent)] rounded-[8px] bg-[color-mix(in_srgb,var(--red,#f87171)_12%,transparent)] text-(--red,#f87171) [font-family:var(--font-mono)] text-[12px] leading-[17px] m-0 max-h-[320px] overflow-auto p-[12px_14px] whitespace-pre-wrap [word-break:break-word]">{run.error_message}</pre>
             </div>
           {/if}
-          {#if stepTimesData?.step_times || stepTimesData?.substep_times}
+          {#if run.step_times || run.substep_times}
             <div class="rollout-chart">
               <div class="rollout-chart-title">Step &amp; substep timeline</div>
               <StepTimings
-                stepTimes={stepTimesData?.step_times}
-                substepTimes={stepTimesData?.substep_times}
+                stepTimes={run.step_times}
+                substepTimes={run.substep_times}
                 layout="timeline"
                 downloadName={`step_substep_times_${runId}.json`}
               />

--- a/dashboards/frontend/vite.config.js
+++ b/dashboards/frontend/vite.config.js
@@ -6,7 +6,10 @@ export default defineConfig({
   plugins: [tailwindcss(), svelte()],
   server: {
     proxy: {
-      "/api": "http://localhost:8000",
+      "/api": {
+        target: process.env.DASHBOARD_API || "http://localhost:8000",
+        changeOrigin: true,
+      },
     },
   },
   build: {

--- a/dashboards/frontend/vite.config.js
+++ b/dashboards/frontend/vite.config.js
@@ -6,10 +6,7 @@ export default defineConfig({
   plugins: [tailwindcss(), svelte()],
   server: {
     proxy: {
-      "/api": {
-        target: process.env.DASHBOARD_API || "http://localhost:8000",
-        changeOrigin: true,
-      },
+      "/api": "http://localhost:8000",
     },
   },
   build: {


### PR DESCRIPTION
Render per-step and per-substep timings on the training run detail page: a StepTimings component (rows + scrollable timeline layouts) with pinnable tooltips and a downloadable JSON of the step/substep dicts. Reads the step_times/substep_times fields produced by the core substep-timing change.


<img width="1149" height="142" alt="Screenshot 2026-07-08 at 11 09 41 AM" src="https://github.com/user-attachments/assets/42e3d022-3442-4343-85a2-92ba89c4c3bb" />

<img width="1469" height="211" alt="Screenshot 2026-07-08 at 11 09 51 AM" src="https://github.com/user-attachments/assets/63c5e027-542e-457d-90a3-16bc5e5722c4" />


<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->