### PR TITLE
Bump SLIME_IMAGE to nightly-dev-20260701a (GLM-5.2 / sglang v0.5.13)

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -84,8 +84,8 @@ from modal_training_gym.common.checkpoint import Checkpoint
 from modal_training_gym.common.framework import Framework
 
 SLIME_ROOT = "/root/slime"
-# Pin by digest to prevent mutable-tag drift.  Tag: nightly-dev-20260529a
-SLIME_IMAGE = "slimerl/slime@sha256:087a57732cf4fb271729df47530b01a9530144f4339247efc422f03e2b6988e1"
+# Pin by digest to prevent mutable-tag drift.  Tag: nightly-dev-20260701a
+SLIME_IMAGE = "slimerl/slime@sha256:512b6bed52d3ffd7b8d76c7238ed2bf43446cfadd8aa03a1ea4a39646c92ebf3"
 # v0.8.0+ makes per-task CPU/memory requests configurable via enforcement
 # policies ("limit"/"ignore"), letting sandboxes burst on Modal and bill by
 # actual CPU-/RAM-second usage instead of over-provisioning a static reservation.


### PR DESCRIPTION
Updates the pinned `SLIME_IMAGE` digest from `nightly-dev-20260529a` to `nightly-dev-20260701a` (`sha256:512b6bed52d3…`).

The previous nightly predates GLM-5.2 support (upstream #2093, 2026-06-16) and its required sglang v0.5.13. This bump is needed by every slime recipe that targets GLM-5.2.

```diff
-SLIME_IMAGE = "slimerl/slime@sha256:087a5773..."  # nightly-dev-20260529a
+SLIME_IMAGE = "slimerl/slime@sha256:512b6bed..."  # nightly-dev-20260701a
```

## Checklist

- [x] Example pins container images to a stable tag, not a dynamic tag like `latest`

Link to Devin session: https://modal.devinenterprise.com/sessions/e3f416f852f2416d8540a4b53a2a4d0f
Requested by: @joyliu-q