### PR TITLE
Fix Qwen3-ASR crash: patch packed_seq_params in thinker forward

### DIFF
--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_asr/patch_qwen3_asr_packed_seq.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_asr/patch_qwen3_asr_packed_seq.py
@@ -1,0 +1,47 @@
+"""Patch Qwen3-ASR thinker model to gracefully handle packed_seq_params.
+
+The megatron-bridge Qwen3-ASR thinker forward raises
+``NotImplementedError("packed_seq_params is not supported")`` when
+``packed_seq_params`` is passed.  As of slime nightly-dev-20260701a, slime's
+``get_batch()`` always builds ``PackedSeqParams`` regardless of the
+``qkv_format`` setting, so the Qwen3-ASR forward hits this error on the
+``compute_log_prob`` step even with ``qkv_format="bshd"``.
+
+This patch replaces the ``raise NotImplementedError`` with
+``packed_seq_params = None``, which tells the model to process the input as
+a single contiguous (non-packed) sequence — safe because the ASR recipe
+trains with padded batches (``micro_batch_size=1``).
+
+Idempotent. Run at image build:  python patch_qwen3_asr_packed_seq.py
+"""
+
+import pathlib
+
+
+def main() -> None:
+    marker = "PATCHED_ASR_PACKED_SEQ"
+    old = 'raise NotImplementedError("packed_seq_params is not supported")'
+    new = f"packed_seq_params = None  # {marker}: disable packed seq for ASR compat"
+
+    for p in pathlib.Path("/usr/local/lib").glob(
+        "python3.*/dist-packages/megatron/bridge/models/qwen3_asr/"
+        "modeling_qwen3_asr/thinker_model.py"
+    ):
+        src = p.read_text()
+        if marker in src:
+            print("compat: thinker_model.py already patched for packed_seq_params:", p)
+            continue
+        if old in src:
+            new_src = src.replace(old, new, 1)
+            p.write_text(new_src)
+            print("compat: patched thinker_model.py packed_seq_params:", p)
+        else:
+            print(
+                "WARNING: Could not find packed_seq_params error string in "
+                "thinker_model.py (may already be fixed upstream):",
+                p,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
@@ -31,6 +31,7 @@ _ASR_PATCHES = (
     "patch_qwen3_asr_bridge_config",
     "patch_qwen3_asr_processor",
     "patch_qwen3_asr_pg_collection",
+    "patch_qwen3_asr_packed_seq",
 )
 
 
@@ -60,10 +61,11 @@ class Qwen3_ASR_1_7b_Recipe(SlimeRecipe):
       be driven through the slime audio-transcription rollout.
     * ``use_dynamic_batch_size=False`` + ``qkv_format="bshd"`` + ``micro_batch_size=1``
       — the native megatron-bridge Qwen3-ASR forward doesn't implement THD sequence
-      packing. slime only builds packed_seq_params when qkv_format="thd" (its
-      default), so padded "bshd" batches sidestep the unsupported path; bshd needs
-      dynamic batching off + an explicit micro_batch_size. The launcher enforces this
-      (``model.requires_bshd``).
+      packing. As of nightly-dev-20260701a, slime builds packed_seq_params
+      regardless of qkv_format, so a build-time patch
+      (``patch_qwen3_asr_packed_seq``) nullifies it in the thinker forward. bshd
+      still needs dynamic batching off + an explicit micro_batch_size. The launcher
+      enforces this (``model.requires_bshd``).
     * ``sglang_mem_fraction_static=0.45`` — audio conditioning lengthens prompts
       (expanded ``<audio_pad>``) and adds the frozen audio tower, so free SGLang
       memory for the colocated actor (text-only runs use ~0.78).


### PR DESCRIPTION
Fixes the `NotImplementedError: packed_seq_params is not supported` crash in Qwen3-ASR training after the slime image bump to `nightly-dev-20260701a` (#210).

**Root cause:** The new slime image builds `PackedSeqParams` in `get_batch()` regardless of `qkv_format` (previously only for THD). The Qwen3-ASR megatron-bridge thinker model's forward rejects it at line 209 of `thinker_model.py`:

```python
raise NotImplementedError("packed_seq_params is not supported")
```

**Fix:** A new build-time patch (`patch_qwen3_asr_packed_seq`) replaces the raise with `packed_seq_params = None`, mirroring the existing `patch_gdn_packed_seq` approach for GDN models. Safe because the ASR recipe trains with padded `micro_batch_size=1` batches.

```
# Traceback (from CI validate (Qwen3-ASR-1.7B)):
MegatronTrainRayActor.train() → train_actor() → compute_log_prob() → forward_only()
  → megatron/bridge/models/qwen3_asr/.../thinker_model.py:209
    raise NotImplementedError("packed_seq_params is not supported")
```

## Checklist

- [x] Example pins container images to a stable tag, not a dynamic tag like `latest`

Link to Devin session: https://modal.devinenterprise.com/sessions/e3f416f852f2416d8540a4b53a2a4d0f
Requested by: @joyliu-q