### PR TITLE
Display dashboard URL as a hyperlink

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -155,6 +155,7 @@ class _TrainStatusDisplay:
 
     def print_banner(self) -> None:
         from rich.panel import Panel
+        from rich.style import Style
         from rich.table import Table
         from rich.text import Text
 
@@ -173,11 +174,12 @@ class _TrainStatusDisplay:
             base = self.framework_status_url.replace(
                 "/api/framework-status", ""
             ).rstrip("/")
+            run_url = f"{base}/training/{self.run_id}"
             body.add_row(
                 "Dashboard",
                 Text(
-                    f"{base}/training/{self.run_id}",
-                    style="underline blue",
+                    run_url,
+                    style=Style(color="blue", underline=True, link=run_url),
                 ),
             )
         else:

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -207,7 +207,7 @@ class _TrainStatusDisplay:
 
             from rich.style import Style
             from rich.text import Text
-            
+
             self._get_console().print(
                 Text.assemble(
                     ("Modal app:", "dim"),

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -204,8 +204,16 @@ class _TrainStatusDisplay:
     def set_modal_app_url(self, url: str) -> None:
         if url and url != self._modal_app_url:
             self._modal_app_url = url
+
+            from rich.style import Style
+            from rich.text import Text
+            
             self._get_console().print(
-                f"[dim]Modal app:[/dim] [blue underline]{url}[/blue underline]"
+                Text.assemble(
+                    ("Modal app:", "dim"),
+                    " ",
+                    (url, Style(color="blue", underline=True, link=url)),
+                )
             )
 
     def emit_stage(self, stage: str, detail: str = "") -> None:


### PR DESCRIPTION
Quick PR to update the train status display to render the dashboard URL as an [in-terminal hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda). This should make it easier to jump directly to the Training Gym dashboard from Jupyter or the terminal.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->