### PR TITLE
Add goldenfile test for Slime substep patching

### DIFF
--- a/.github/workflows/validate-slime-patch-snapshots.yml
+++ b/.github/workflows/validate-slime-patch-snapshots.yml
@@ -1,0 +1,37 @@
+name: Validate Slime patch snapshots
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/validate-slime-patch-snapshots.yml"
+      - "modal_training_gym/frameworks/slime/launcher.py"
+      - "scripts/fetch_slime_patch_snapshots.py"
+      - "tests/testdata/*.input"
+
+jobs:
+  validate-snapshot:
+    runs-on: ubuntu-latest
+    environment: modal
+    permissions:
+      contents: read
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      MODAL_ENVIRONMENT: training-gym
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Fetch source from pinned Slime image
+        run: uv run modal run scripts/fetch_slime_patch_snapshots.py
+
+      - name: Verify committed snapshot is current
+        run: git diff --exit-code -- tests/testdata/*.input

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_rollout_status_reporting.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_rollout_status_reporting.py
@@ -438,5 +438,10 @@ def _patch_file(path: Path) -> None:
     print(f"Patched {path.name} with rollout status reporting")
 
 
-_patch_file(Path("/root/slime/train.py"))
-_patch_file(Path("/root/slime/train_async.py"))
+def main() -> None:
+    _patch_file(Path("/root/slime/train.py"))
+    _patch_file(Path("/root/slime/train_async.py"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_slime_patch_snapshots.py
+++ b/scripts/fetch_slime_patch_snapshots.py
@@ -1,0 +1,34 @@
+"""Fetch Slime source snapshots used by the local rollout-patcher golden test.
+
+The source files exist only inside the pinned Slime image, so this maintenance
+utility uses Modal to read that image. Normal pytest collection never imports or
+runs this module. It refreshes the committed ``*.input`` fixtures; CI checks the
+resulting Git diff to detect image-source drift.
+"""
+
+from pathlib import Path
+
+import modal
+
+from modal_training_gym.frameworks.slime.launcher import SLIME_IMAGE
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTDATA_DIR = REPO_ROOT / "tests" / "testdata"
+SLIME_SOURCE_PATHS = {
+    "train.py": "/root/slime/train.py",
+}
+
+app = modal.App("fetch-slime-snapshots")
+image = modal.Image.from_registry(SLIME_IMAGE).entrypoint([])
+
+
+@app.function(image=image, serialized=True)
+def read_sources() -> dict[str, str]:
+    return {name: Path(path).read_text() for name, path in SLIME_SOURCE_PATHS.items()}
+
+
+@app.local_entrypoint()
+def main() -> None:
+    TESTDATA_DIR.mkdir(exist_ok=True)
+    for name, source in read_sources.remote().items():
+        (TESTDATA_DIR / f"{name}.input").write_text(source)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,3 +98,12 @@ def fake_volume(monkeypatch) -> FakeVolume:
     vol = FakeVolume()
     monkeypatch.setattr(metadata, "_metadata_volume", lambda: vol)
     return vol
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--rewrite",
+        action="store_true",
+        default=False,
+        help="Rewrite golden .output files in tests/testdata/ instead of asserting",
+    )

--- a/tests/test_substep_times.py
+++ b/tests/test_substep_times.py
@@ -1,0 +1,51 @@
+"""Golden-file test for the Slime rollout-status patcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modal_training_gym.frameworks.slime.modal_helpers.patches import (
+    patch_rollout_status_reporting as patcher,
+)
+
+TESTDATA = Path(__file__).parent / "testdata"
+
+
+@pytest.fixture(scope="session")
+def slime_inputs() -> dict[str, str]:
+    inputs = sorted(TESTDATA.glob("*.input"))
+    assert inputs
+    return {path.name.removesuffix(".input"): path.read_text() for path in inputs}
+
+
+def test_missing_patch_target_is_skipped(tmp_path, capsys):
+    missing = tmp_path / "train_async.py"
+    patcher._patch_file(missing)
+    assert not missing.exists()
+    assert "not found, skipping rollout-status patch" in capsys.readouterr().out
+
+
+def test_patch_matches_golden(slime_inputs, tmp_path, request):
+    rewrite_goldens = request.config.getoption("--rewrite")
+    for name, source in slime_inputs.items():
+        golden_path = TESTDATA / f"{name}.output"
+        work = tmp_path / name
+        work.write_text(source)
+        patcher._patch_file(work)
+        actual = work.read_text()
+
+        if rewrite_goldens:
+            golden_path.write_text(actual)
+            continue
+
+        assert golden_path.exists(), (
+            f"Golden output file does not exist: {golden_path}. "
+            "Regenerate and review the expected patch output with "
+            "uv run pytest tests/test_substep_times.py --rewrite."
+        )
+        expected = golden_path.read_text()
+        assert actual == expected, (
+            f"golden mismatch for {name}; rerun with --rewrite to accept"
+        )

--- a/tests/testdata/train.py.input
+++ b/tests/testdata/train.py.input
@@ -1,0 +1,103 @@
+import ray
+
+from slime.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
+from slime.utils.arguments import parse_args
+from slime.utils.logging_utils import configure_logger, finish_tracking, init_tracking
+from slime.utils.misc import should_run_periodic_action
+
+
+def train(args):
+    configure_logger()
+    # allocate the GPUs
+    pgs = create_placement_groups(args)
+    init_tracking(args)
+
+    # create the rollout manager, with sglang engines inside.
+    # need to initialize rollout manager first to calculate num_rollout
+    rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"])
+
+    # create the actor and critic models
+    actor_model, critic_model = create_training_models(args, pgs, rollout_manager)
+
+    if args.offload_rollout:
+        ray.get(rollout_manager.onload_weights.remote())
+
+    # Always push actor weights to rollout once weights are loaded.
+    actor_model.update_weights()
+
+    if args.check_weight_update_equal:
+        ray.get(rollout_manager.check_weights.remote(action="compare"))
+
+    if args.offload_rollout:
+        ray.get(rollout_manager.onload_kv.remote())
+
+    # special case for eval-only
+    if args.num_rollout == 0 and args.eval_interval is not None:
+        ray.get(rollout_manager.eval.remote(rollout_id=0))
+
+    def offload_train(actor_trains_this_step):
+        # Each model auto-offloads after train() when offload_train is set,
+        # so we only need clear_memory for the non-offload case.
+        if not args.offload_train:
+            if not args.use_critic or actor_trains_this_step:
+                actor_model.clear_memory()
+            else:
+                critic_model.clear_memory()
+
+    def save(rollout_id):
+        actor_trains_this_step = (not args.use_critic) or rollout_id >= args.num_critic_only_steps
+        if actor_trains_this_step:
+            actor_model.save_model(
+                rollout_id,
+                force_sync=rollout_id == args.num_rollout - 1,
+            )
+        if args.use_critic:
+            critic_model.save_model(
+                rollout_id,
+                force_sync=rollout_id == args.num_rollout - 1,
+            )
+        if args.rollout_global_dataset:
+            ray.get(rollout_manager.save.remote(rollout_id))
+
+    # train loop.
+    for rollout_id in range(args.start_rollout_id, args.num_rollout):
+        if args.eval_interval is not None and rollout_id == 0 and not args.skip_eval_before_train:
+            ray.get(rollout_manager.eval.remote(rollout_id))
+
+        rollout_data_ref = ray.get(rollout_manager.generate.remote(rollout_id))
+
+        if args.offload_rollout:
+            ray.get(rollout_manager.offload.remote())
+
+        actor_trains_this_step = (not args.use_critic) or rollout_id >= args.num_critic_only_steps
+
+        if args.use_critic:
+            value_refs = critic_model.async_train(rollout_id, rollout_data_ref)
+            if actor_trains_this_step:
+                ray.get(actor_model.async_train(rollout_id, rollout_data_ref, external_data=value_refs))
+            else:
+                ray.get(value_refs)
+        else:
+            ray.get(actor_model.async_train(rollout_id, rollout_data_ref))
+
+        if should_run_periodic_action(rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout):
+            save(rollout_id)
+
+        offload_train(actor_trains_this_step)
+        if args.offload_rollout:
+            ray.get(rollout_manager.onload_weights.remote())
+        actor_model.update_weights()
+
+        if args.offload_rollout:
+            ray.get(rollout_manager.onload_kv.remote())
+
+        if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
+            ray.get(rollout_manager.eval.remote(rollout_id))
+
+    ray.get(rollout_manager.dispose.remote())
+    finish_tracking(args)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    train(args)

--- a/tests/testdata/train.py.output
+++ b/tests/testdata/train.py.output
@@ -1,0 +1,142 @@
+# PATCHED_TRAINING_GYM_PREAMBLE: bootstrap phase reporter (runs once per process)
+import sys as _tg_sys
+if '/root' not in _tg_sys.path:
+    _tg_sys.path.insert(0, '/root')
+try:
+    from modal_training_gym.frameworks.slime.phase_reporting import (
+        report_step_event as _tg_report,
+    )
+except ImportError:
+    def _tg_report(status, args=None, rollout_id=None, step_event=''): pass
+
+import ray
+
+from slime.ray.placement_group import create_placement_groups, create_rollout_manager, create_training_models
+from slime.utils.arguments import parse_args
+from slime.utils.logging_utils import configure_logger, finish_tracking, init_tracking
+from slime.utils.misc import should_run_periodic_action
+
+
+def train(args):
+    configure_logger()
+    # allocate the GPUs
+    pgs = create_placement_groups(args)
+    init_tracking(args)
+
+    # create the rollout manager, with sglang engines inside.
+    # need to initialize rollout manager first to calculate num_rollout
+    # PATCHED_TRAINING_GYM_ROLLOUT_STATUS: rollout engine startup state
+    _tg_report('initialize_rollouts', args)
+    rollout_manager, num_rollout_per_epoch = create_rollout_manager(args, pgs["rollout"])
+
+    # create the actor and critic models
+    actor_model, critic_model = create_training_models(args, pgs, rollout_manager)
+
+    if args.offload_rollout:
+        ray.get(rollout_manager.onload_weights.remote())
+
+    # Always push actor weights to rollout once weights are loaded.
+    actor_model.update_weights()
+
+    if args.check_weight_update_equal:
+        ray.get(rollout_manager.check_weights.remote(action="compare"))
+
+    if args.offload_rollout:
+        ray.get(rollout_manager.onload_kv.remote())
+
+    # special case for eval-only
+    if args.num_rollout == 0 and args.eval_interval is not None:
+        ray.get(rollout_manager.eval.remote(rollout_id=0))
+
+    def offload_train(actor_trains_this_step):
+        # Each model auto-offloads after train() when offload_train is set,
+        # so we only need clear_memory for the non-offload case.
+        if not args.offload_train:
+            if not args.use_critic or actor_trains_this_step:
+                actor_model.clear_memory()
+            else:
+                critic_model.clear_memory()
+
+    def save(rollout_id):
+        actor_trains_this_step = (not args.use_critic) or rollout_id >= args.num_critic_only_steps
+        if actor_trains_this_step:
+            actor_model.save_model(
+                rollout_id,
+                force_sync=rollout_id == args.num_rollout - 1,
+            )
+        if args.use_critic:
+            critic_model.save_model(
+                rollout_id,
+                force_sync=rollout_id == args.num_rollout - 1,
+            )
+        if args.rollout_global_dataset:
+            ray.get(rollout_manager.save.remote(rollout_id))
+
+    # train loop.
+    for rollout_id in range(args.start_rollout_id, args.num_rollout):
+        # PATCHED_TRAINING_GYM_SUBSTEP_START: substep window start (before eval)
+        _tg_report('generate_rollouts', args, rollout_id, 'substep_start')
+        if args.eval_interval is not None and rollout_id == 0 and not args.skip_eval_before_train:
+            # PATCHED_TRAINING_GYM_EVAL_BEGIN: eval-before-train substep start
+            _tg_report('evaluate_rollouts', args, rollout_id, 'eval_begin')
+            ray.get(rollout_manager.eval.remote(rollout_id))
+
+        # PATCHED_TRAINING_GYM_STEP_START: training step start
+        _tg_report('generate_rollouts', args, rollout_id, 'start')
+        # PATCHED_TRAINING_GYM_GENERATE_ROLLOUT_STATUS: rollout generation state
+        _tg_report('generate_rollouts', args, rollout_id)
+        rollout_data_ref = ray.get(rollout_manager.generate.remote(rollout_id))
+
+        if args.offload_rollout:
+            # PATCHED_TRAINING_GYM_OFFLOAD_ROLLOUT_STATUS: rollout offload state
+            _tg_report('offload_rollout', args, rollout_id)
+            ray.get(rollout_manager.offload.remote())
+
+        actor_trains_this_step = (not args.use_critic) or rollout_id >= args.num_critic_only_steps
+
+        if args.use_critic:
+            value_refs = critic_model.async_train(rollout_id, rollout_data_ref)
+            if actor_trains_this_step:
+                # PATCHED_TRAINING_GYM_COMPUTE_LOG_PROBS_STATUS: compute log probs state
+                _tg_report('compute_log_probs', args, rollout_id)
+                ray.get(actor_model.async_train(rollout_id, rollout_data_ref, external_data=value_refs))
+            else:
+                ray.get(value_refs)
+        else:
+            # PATCHED_TRAINING_GYM_COMPUTE_LOG_PROBS_STATUS: compute log probs state
+            _tg_report('compute_log_probs', args, rollout_id)
+            ray.get(actor_model.async_train(rollout_id, rollout_data_ref))
+
+        # PATCHED_TRAINING_GYM_STEP_FINISH: training step finish
+        _tg_report('weight_sync', args, rollout_id, 'finish')
+        if should_run_periodic_action(rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout):
+            # PATCHED_TRAINING_GYM_CHECKPOINT_SAVE_STATUS: checkpoint save state
+            _tg_report('checkpoint_save', args, rollout_id)
+            save(rollout_id)
+
+        # PATCHED_TRAINING_GYM_OFFLOAD_TRAIN_STATUS: train offload state
+        _tg_report('offload_train', args, rollout_id)
+        offload_train(actor_trains_this_step)
+        if args.offload_rollout:
+            ray.get(rollout_manager.onload_weights.remote())
+        # PATCHED_TRAINING_GYM_WEIGHT_SYNC_STATUS: weight sync state
+        _tg_report('weight_sync', args, rollout_id)
+        actor_model.update_weights()
+
+        if args.offload_rollout:
+            ray.get(rollout_manager.onload_kv.remote())
+
+        if should_run_periodic_action(rollout_id, args.eval_interval, num_rollout_per_epoch):
+            # PATCHED_TRAINING_GYM_EVAL_END: eval-after-train substep start
+            _tg_report('evaluate_rollouts', args, rollout_id, 'eval_end')
+            ray.get(rollout_manager.eval.remote(rollout_id))
+        # PATCHED_TRAINING_GYM_SUBSTEP_FINISH: end-of-iteration substep boundary
+        _tg_report('weight_sync', args, rollout_id, 'substep_finish')
+
+    ray.get(rollout_manager.dispose.remote())
+    finish_tracking(args)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    train(args)


### PR DESCRIPTION
Adds a goldenfile test that verifies patch_rollout_status_reporting.py inserts its step/substep timing hooks into Slime's train.py at the expected locations. Merge after [substep time PR](https://github.com/modal-projects/training-gym/pull/201). 

Currently no golden file for train_async.py since we do not support step/substep timing in async training yet.


---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->