### PR TITLE
Fix compute_advantages_and_returns patch for newer versions of slime

### DIFF
--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_advantages.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_advantages.py
@@ -46,16 +46,9 @@ new = """\
         else:
             _dev = loss_masks[0].device if loss_masks else torch.cuda.current_device()
             from slime.backends.megatron_utils.cp_utils import slice_log_prob_with_cp as _tg_cp_slice
-            _tg_msl = rollout_data.get("max_seq_lens", None)
             kl = [
-                _tg_cp_slice(
-                    torch.zeros(rl, dtype=torch.float32, device=_dev),
-                    tl,
-                    rl,
-                    args.qkv_format,
-                    (_tg_msl[_i] if _tg_msl is not None else None),
-                )
-                for _i, (rl, tl) in enumerate(zip(response_lengths, total_lengths))
+                _tg_cp_slice(torch.zeros(rl, dtype=torch.float32, device=_dev), tl, rl)
+                for rl, tl in zip(response_lengths, total_lengths)
             ]"""
 
 if old in src:


### PR DESCRIPTION
The [recent removal of bshd support from slime](https://github.com/THUDM/slime/commit/77037513d079b7ebfd0f070879cfd4de566aaac0) appears to have broken our patch for `compute_advantages_and_returns`. Specifically:
* `args.qkv_format` no longer exists
* `slice_log_prob_with_cp` no longer takes arguments for `qkv_format` and `max_seq_lens`

These changes caused the training step in our `rl/002_multiturn` tutorial to repeatedly fail with this error, as it triggers the patched code:

```
  File "/root/slime/slime/backends/megatron_utils/actor.py", line 509, in train_actor
    compute_advantages_and_returns(self.args, rollout_data)
  File "/root/slime/slime/backends/megatron_utils/loss.py", line 717, in compute_advantages_and_returns
    args.qkv_format,
    ^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'qkv_format'
```

This PR updates the patch to no longer pass in these arguments, which fixes the breakage.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->