### PR TITLE
Tune DeepSeek-V4-Flash SGLang recipe for MegaMoE prefill

### DIFF
--- a/modal_training_gym/deploy_recipes/sglang_recipe/_sglang_endpoint.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/_sglang_endpoint.py
@@ -49,7 +49,10 @@ def build_server_cmd(
     if tp is not None:
         cmd.extend(["--tp", str(tp)])
     if dp is not None:
-        cmd.extend(["--dp", str(dp), "--enable-dp-attention"])
+        # SGLang's CLI flag is ``--dp-size`` (not ``--dp``); ``--enable-dp-attention``
+        # is required for DeepSeek-style MLA DP attention and is a no-op when
+        # ``dp_size == 1``.
+        cmd.extend(["--dp-size", str(dp), "--enable-dp-attention"])
 
     merged = {**DEFAULT_OPERATIONAL_ARGS, **(extra_server_args or {})}
     for key, value in merged.items():

--- a/modal_training_gym/deploy_recipes/sglang_recipe/deepseek_v4_flash.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/deepseek_v4_flash.py
@@ -2,31 +2,46 @@ from dataclasses import dataclass
 
 from modal_training_gym.deploy_recipes.sglang_recipe.recipe import SglangRecipe
 
-# Flags mirror the official SGLang cookbook for B200 · DeepSeek-V4-Flash · FP4:
-# https://lmsysorg.mintlify.app/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-#
-# Key points for this model on a single B200 node:
-#   - Flash is an FP4-MoE checkpoint → use --moe-runner-backend flashinfer_mxfp4
-#     (a tensor-parallel MoE kernel). Do NOT use --moe-a2a-backend deepep, which
-#     needs NVSHMEM/IBGDA RDMA networking and hangs at expert-location init on a
-#     single-node deployment without that fabric.
-#   - Pure TP=4, no DP attention (DP attention triggers a CUDA-graph "Hidden size
-#     mismatch" / short-circuit-allreduce assertion on a single node here).
-#   - --disable-flashinfer-autotune and --swa-full-tokens-ratio 0.1 are required
-#     by the cookbook for the hybrid (CSA/HCA + sliding-window) attention.
+# Production-tuned SGLang recipe for DeepSeek-V4-Flash on 4×B200 (FP4 MoE).
+# Mirrors the Modal LLM endpoint config (sglang v0.5.12.post1-cu130 + MegaMoE
+# DeepGEMM kernels + DP attention), minus EAGLE — speculative decoding only
+# helps the decode path, and this recipe's primary consumer is OPD teacher
+# logprob prefills (``max_new_tokens=0``). Relative to the earlier cookbook-
+# style defaults (pure TP=4, flashinfer_mxfp4, no DP), the prefill wins are:
+#   - ``--moe-a2a-backend megamoe`` + DeepGEMM FP4 env vars (Blackwell MoE)
+#   - ``dp=4`` / DP attention (4 independent prefill streams on one node)
+#   - ``--enable-mixed-chunk`` + chunked prefill (better prefill packing)
+#   - higher ``mem_fraction_static`` (more KV → more concurrent prefills)
 _DEEPSEEK_V4_FLASH_DEFAULTS = {
     "gpu": "B200",
     "tp": 4,
+    "dp": 4,
     "context_length": 262144,
-    "mem_fraction_static": 0.80,
+    "mem_fraction_static": 0.85,
     "chunked_prefill_size": 4096,
     "max_running_requests": 16,
-    "extra_server_args": {
-        "--trust-remote-code": "",
-        "--moe-runner-backend": "flashinfer_mxfp4",
-        "--disable-flashinfer-autotune": "",
-        "--swa-full-tokens-ratio": "0.1",
+    # Matches the production Modal LLM endpoint image (cu130 / Blackwell).
+    "sglang_image": "lmsysorg/sglang:v0.5.12.post1-cu130",
+    # That image already ships DeepSeek-V4-aware transformers; forcing a git
+    # install double-registers ``qwen3_asr`` and crashloops on import.
+    "install_transformers_from_git": False,
+    "env_vars": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK": "8320",
+        "SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS": "1",
+        "SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND": "1",
     },
+}
+
+_DEEPSEEK_V4_FLASH_SERVER_ARGS = {
+    "--trust-remote-code": "",
+    "--moe-a2a-backend": "megamoe",
+    "--enable-breakable-cuda-graph": "",
+    "--enable-mixed-chunk": "",
+    "--piecewise-cuda-graph-max-tokens": "4096",
+    # Parse DeepSeek-V4's native DSML tool-call markup + reasoning blocks.
+    "--tool-call-parser": "deepseekv4",
+    "--reasoning-parser": "deepseek-v4",
 }
 
 
@@ -35,9 +50,12 @@ _SGLANG_DEFAULTS = SglangRecipe()
 
 @dataclass
 class DeepSeek_V4_Flash_SglangRecipe(SglangRecipe):
-    """DeepSeek-V4-Flash (284B MoE, 13B active) on 4×B200 — sensible SGLang defaults."""
+    """DeepSeek-V4-Flash (284B MoE, 13B active) on 4×B200 — production SGLang defaults."""
 
     def __post_init__(self) -> None:
         for key, val in _DEEPSEEK_V4_FLASH_DEFAULTS.items():
             if getattr(self, key) == getattr(_SGLANG_DEFAULTS, key):
                 object.__setattr__(self, key, val)
+        merged = dict(_DEEPSEEK_V4_FLASH_SERVER_ARGS)
+        merged.update(self.extra_server_args or {})
+        object.__setattr__(self, "extra_server_args", merged)

--- a/modal_training_gym/deploy_recipes/sglang_recipe/recipe.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/recipe.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from modal_training_gym.common import GPUType
 from modal_training_gym.deploy_recipes.base import BaseDeployRecipe, DeployRecipeType
@@ -17,8 +17,8 @@ class SglangRecipe(BaseDeployRecipe):
     tp : int | None
         Tensor parallelism degree. Default ``None`` (SGLang infers from GPU count).
     dp : int | None
-        Data parallelism degree. Enables ``--enable-dp-attention`` when set.
-        Default ``None``.
+        Data parallelism degree. Emitted as ``--dp-size`` and enables
+        ``--enable-dp-attention`` when set. Default ``None``.
     context_length : int | None
         Maximum context length. Default ``None`` (model default).
     mem_fraction_static : float | None
@@ -33,6 +33,16 @@ class SglangRecipe(BaseDeployRecipe):
         Additional ``--flag value`` pairs passed to ``sglang.launch_server``.
         Use an empty string value for boolean flags (e.g. ``{"--trust-remote-code": ""}``).
         Default ``None``.
+    env_vars : dict[str, str]
+        Extra environment variables baked into the serving image (e.g. DeepGEMM
+        MegaMoE knobs). Merged on top of the base HF cache env. Default empty.
+    install_transformers_from_git : bool
+        If ``True`` (default), the serve image ``pip install``s transformers
+        from GitHub so brand-new architectures (historically DeepSeek-V4 on
+        older SGLang tags) are recognized by ``AutoConfig``. Set ``False``
+        when the chosen ``sglang_image`` already ships a compatible
+        transformers — otherwise the git install double-registers configs
+        (e.g. ``qwen3_asr``) and the server crashloops on import.
     environment_name : str | None
         Modal environment to deploy into. Default ``None``.
     deploy_strategy : str
@@ -56,6 +66,8 @@ class SglangRecipe(BaseDeployRecipe):
     max_running_requests: int | None = None
     sglang_image: str = "lmsysorg/sglang:v0.5.12"
     extra_server_args: dict[str, str] | None = None
+    env_vars: dict[str, str] = field(default_factory=dict)
+    install_transformers_from_git: bool = True
     environment_name: str | None = None
     deploy_strategy: str = "rolling"
     startup_timeout: int = 20 * 60

--- a/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
+++ b/modal_training_gym/deploy_recipes/sglang_recipe/serve_sglang.py
@@ -41,6 +41,12 @@ def build_sglang_serve_app(
 
     sglang_port = 8000
 
+    image_env = {
+        "HF_HUB_CACHE": "/root/.cache/huggingface",
+        "HF_XET_HIGH_PERFORMANCE": "1",
+        "HF_HUB_ENABLE_HF_TRANSFER": "1",
+        **(recipe.env_vars or {}),
+    }
     image = (
         Image.from_registry(recipe.sglang_image)
         .entrypoint([])
@@ -51,20 +57,19 @@ def build_sglang_serve_app(
         )
         # pydantic_core in the nightly image needs typing_extensions>=4.13 (Sentinel)
         .uv_pip_install("typing_extensions>=4.13")
-        # Brand-new model architectures (e.g. deepseek_v4) aren't in released
-        # transformers yet; install from git source so AutoConfig recognizes them.
-        .run_commands(
+    )
+    # Brand-new model architectures (e.g. deepseek_v4 on older SGLang tags)
+    # aren't in released transformers yet; install from git so AutoConfig
+    # recognizes them. Skip when the image already ships a compatible
+    # transformers — a second install double-registers configs like
+    # ``qwen3_asr`` and crashloops ``sglang.launch_server`` on import.
+    if recipe.install_transformers_from_git:
+        image = image.run_commands(
             "uv pip install --system --no-build-isolation "
             "'transformers @ git+https://github.com/huggingface/transformers.git'"
         )
-        .env(
-            {
-                "HF_HUB_CACHE": "/root/.cache/huggingface",
-                "HF_XET_HIGH_PERFORMANCE": "1",
-                "HF_HUB_ENABLE_HF_TRANSFER": "1",
-            }
-        )
-        .add_local_python_source("modal_training_gym", copy=True)
+    image = image.env(image_env).add_local_python_source(
+        "modal_training_gym", copy=True
     )
 
     hf_cache_vol = Volume.from_name("huggingface-cache", create_if_missing=True)


### PR DESCRIPTION
Calling `/generate` for teacher log-prob prefill on a long-context student trajectory can take anywhere from a couple seconds to 10-20 seconds on DeepSeekV4-Flash. This change adds DeepGEMM MegaMoE kernel optimizations and passes the right flag for enabling DP attention. 

Measured E2E speedup on ~5k token trajectories decreases from 3.701s to 3.289s on average.

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->