### PR TITLE
Raise eval ready_timeout for large MoE weight loads

### DIFF
--- a/modal_training_gym/common/eval.py
+++ b/modal_training_gym/common/eval.py
@@ -346,6 +346,7 @@ class EvalConfig:
         deployment: "ModelDeployment",
         debug: bool = False,
         max_concurrency: int = 1,
+        ready_timeout: int = 3000,
     ) -> EvalResult:
         from modal_training_gym.cli.setup import ensure_dashboard_deployed
 
@@ -378,7 +379,12 @@ class EvalConfig:
         result.save()
 
         try:
-            deployment.wait_until_ready()
+            # Large MoE checkpoints (e.g. Qwen3.6-35B-A3B) can take tens of
+            # minutes to load weights off the HF cache volume, well past the
+            # old 600s default. ``wait_until_ready`` still fails fast on a
+            # crashlooping deploy, so a generous timeout only extends waiting
+            # for genuinely slow loads, not broken deploys.
+            deployment.wait_until_ready(timeout=ready_timeout)
         except Exception:
             result.status = "failed"
             result.save()


### PR DESCRIPTION
## Summary
EvalConfig.evaluate ready_timeout defaults to 600s. Increased to 3000s for loading large MoE models like DSV4. 
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->