### PR TITLE
Ship custom_reward_post_process_function via _ship_callable

### DIFF
--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -69,16 +69,16 @@ def ship_callable(
 ) -> "Image":
     """Make a user-provided callable importable inside the remote container.
 
-    Package-internal callables need nothing (they ship with the package). A
-    callable defined in its own module is added as a local file and the slime/
-    miles arg is pointed at ``module.symbol``. Anything defined inline (e.g. in a
-    notebook or the caller script) is cloudpickled into a tiny loader module.
-    Returns the (possibly extended) image.
+    Package-internal callables need no shipping but still get ``set_path``.
+    A callable defined in its own module is added as a local file pointed at
+    ``module.symbol``. Inline callables are cloudpickled into a tiny loader
+    module. Returns the (possibly extended) image.
     """
     if fn is None:
         return image
     fn_mod = getattr(fn, "__module__", None) or ""
     if fn_mod.startswith("modal_training_gym"):
+        set_path(f"{fn_mod}.{getattr(fn, '__name__', fallback_name)}")
         return image
     try:
         fn_file = os.path.abspath(inspect.getfile(fn))
@@ -91,9 +91,6 @@ def ship_callable(
             remote_path=f"/root/{fn_module_name}.py",
             copy=True,
         )
-        # Point the slime arg at the shipped module's symbol. Without this the
-        # file is shipped but the path stays unset, so a custom_rm_function
-        # defined outside the entrypoint silently falls back to rule-based RM.
         set_path(f"{fn_module_name}.{getattr(fn, '__name__', fallback_name)}")
         return image
     fn_name = getattr(fn, "__name__", fallback_name)

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -440,6 +440,11 @@ def build_slime_app(
         set_path=_set_custom_generate_path,
     )
     _ship_callable(
+        slime.custom_reward_post_process_function,
+        fallback_name="custom_reward_post_process",
+        set_path=_set_extra_config_path("custom_reward_post_process_path"),
+    )
+    _ship_callable(
         slime.rollout_function if callable(slime.rollout_function) else None,
         fallback_name="rollout_function",
         set_path=lambda path: object.__setattr__(slime, "rollout_function", path),
@@ -479,6 +484,8 @@ def build_slime_app(
         object.__setattr__(slime, "custom_rm_function", None)
     if slime.custom_generate_function is not None and _get_custom_generate_path():
         object.__setattr__(slime, "custom_generate_function", None)
+    if slime.custom_reward_post_process_function is not None:
+        object.__setattr__(slime, "custom_reward_post_process_function", None)
 
     # ── SGLang request params auto-wiring ─────────────────────────────────
     if slime.sglang_request_params:

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -51,6 +51,7 @@ _SLIME_SKIP = {
     "checkpoint",
     "custom_rm_function",
     "custom_generate_function",
+    "custom_reward_post_process_function",
     "custom_rollout_log_function",
     "custom_eval_rollout_log_function",
     "rollout_function",
@@ -245,6 +246,15 @@ class SlimeRecipe(BaseTrainRecipe):
     # See https://github.com/THUDM/slime/blob/0988f0f4a0ab55d1bb3ce6285a597d912144fa80/docs/en/get_started/customization.md#1-rollout-function---rollout-function-path
     custom_rm_function: Callable | None = None
     custom_generate_function: Callable | None = None
+    # Ships a callable the same way `custom_rm_function`/`custom_generate_function`
+    # do (see `build_slime_app`'s `_ship_callable`), writing the resulting import
+    # path into `extra_config["custom_reward_post_process_path"]`. Prefer this over
+    # setting `custom_reward_post_process_path` directly with a raw dotted string:
+    # a function defined in a `__main__` tutorial script has no reliably importable
+    # module name (its file may not even be a valid Python identifier, e.g.
+    # `007_my_tutorial.py`), so slime's own `importlib.import_module(...)` on that
+    # raw path fails with `ModuleNotFoundError` inside the Ray actor that loads it.
+    custom_reward_post_process_function: Callable | None = None
     custom_rollout_log_function: Callable | str | None = None
     custom_eval_rollout_log_function: Callable | str | None = None
     rollout_function: Callable | str | None = None


### PR DESCRIPTION
## Summary
- Add `SlimeRecipe.custom_reward_post_process_function` and ship it via `_ship_callable` into `extra_config["custom_reward_post_process_path"]`, matching `custom_rm_function` — needed because `__main__` tutorial callables are not importable by a raw dotted path inside Ray.

Non-numeric / dict reward zero-std metrics hardening stays in #180.

## Test plan
- [ ] Pass a tutorial-local post-process callable and confirm slime loads it without `ModuleNotFoundError`
- [ ] Setting `custom_reward_post_process_path` via the new callable field works for OPD tutorials (e.g. 009)