### PR TITLE
Add in-process BFCL v3/v4 multi-turn environment

### DIFF
--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -43,6 +43,11 @@ class DatasetConfig:
     label_key: str = ""
     apply_chat_template: bool = True
     always_prepare: bool = False
+    # When True (default), ``prepare()`` is expected to materialize every path in
+    # ``eval_paths`` and the launcher validates them strictly. Datasets that use
+    # a separate DatasetConfig instance for offline eval (Toolathlon, BFCL) set
+    # this False so resolvers don't invent a companion ``eval.*`` file.
+    writes_eval_paths: bool = True
 
     def __init__(self, **kwargs: Any) -> None:
         if not self.dataset_id:

--- a/modal_training_gym/common/environments/__init__.py
+++ b/modal_training_gym/common/environments/__init__.py
@@ -16,6 +16,7 @@ from modal_training_gym.common.environments.base import (
     ToolCall,
 )
 from modal_training_gym.common.environments.bfcl import (
+    BfclEpisodeResult,
     BfclMultiTurnConfig,
     BfclMultiTurnDataset,
     BfclTurnEnvironment,
@@ -23,6 +24,7 @@ from modal_training_gym.common.environments.bfcl import (
     build_prefix_messages as build_bfcl_prefix_messages,
     default_system_prompt as bfcl_default_system_prompt,
     prune_prefix as prune_bfcl_prefix,
+    run_bfcl_episode,
     to_json_schema,
     tool_schemas_to_openai as bfcl_tool_schemas_to_openai,
 )
@@ -74,9 +76,11 @@ __all__ = [
     "default_system_prompt",
     "tool_schemas_to_openai",
     # bfcl — config + env
+    "BfclEpisodeResult",
     "BfclMultiTurnConfig",
     "BfclTurnEnvironment",
     "build_bfcl_env",
+    "run_bfcl_episode",
     # bfcl — data + prompts
     "BfclMultiTurnDataset",
     "build_bfcl_prefix_messages",

--- a/modal_training_gym/common/environments/__init__.py
+++ b/modal_training_gym/common/environments/__init__.py
@@ -15,6 +15,17 @@ from modal_training_gym.common.environments.base import (
     StepResult,
     ToolCall,
 )
+from modal_training_gym.common.environments.bfcl import (
+    BfclMultiTurnConfig,
+    BfclMultiTurnDataset,
+    BfclTurnEnvironment,
+    build_env as build_bfcl_env,
+    build_prefix_messages as build_bfcl_prefix_messages,
+    default_system_prompt as bfcl_default_system_prompt,
+    prune_prefix as prune_bfcl_prefix,
+    to_json_schema,
+    tool_schemas_to_openai as bfcl_tool_schemas_to_openai,
+)
 from modal_training_gym.common.environments.toolathlon import (
     DEFAULT_CONFIG,
     TIER_A_MCPS,
@@ -31,44 +42,6 @@ from modal_training_gym.common.environments.toolathlon import (
     prune_prefix,
     render_tool_catalog,
     tool_schemas_to_openai,
-)
-from modal_training_gym.common.environments.bfcl import (
-    DEFAULT_CONFIG as BFCL_DEFAULT_CONFIG,
-)
-from modal_training_gym.common.environments.bfcl import (
-    BfclMultiTurnConfig,
-    BfclMultiTurnDataset,
-    BfclTurnEnvironment,
-)
-from modal_training_gym.common.environments.bfcl import build_env as build_bfcl_env
-from modal_training_gym.common.environments.bfcl import (
-    build_instances as build_bfcl_instances,
-)
-from modal_training_gym.common.environments.bfcl import (
-    build_prefix_messages as build_bfcl_prefix_messages,
-)
-from modal_training_gym.common.environments.bfcl import (
-    default_system_prompt as bfcl_default_system_prompt,
-)
-from modal_training_gym.common.environments.bfcl import (
-    execute_call as execute_bfcl_call,
-)
-from modal_training_gym.common.environments.bfcl import (
-    load_func_docs as load_bfcl_func_docs,
-)
-from modal_training_gym.common.environments.bfcl import (
-    parse_call_string as parse_bfcl_call_string,
-)
-from modal_training_gym.common.environments.bfcl import (
-    prune_prefix as prune_bfcl_prefix,
-)
-from modal_training_gym.common.environments.bfcl import (
-    render_tool_catalog as render_bfcl_tool_catalog,
-)
-from modal_training_gym.common.environments.bfcl import replay as replay_bfcl
-from modal_training_gym.common.environments.bfcl import to_json_schema
-from modal_training_gym.common.environments.bfcl import (
-    tool_schemas_to_openai as bfcl_tool_schemas_to_openai,
 )
 
 __all__ = [
@@ -102,20 +75,13 @@ __all__ = [
     "tool_schemas_to_openai",
     # bfcl — config + env
     "BfclMultiTurnConfig",
-    "BFCL_DEFAULT_CONFIG",
     "BfclTurnEnvironment",
     "build_bfcl_env",
-    "build_bfcl_instances",
-    "execute_bfcl_call",
-    "replay_bfcl",
-    "parse_bfcl_call_string",
     # bfcl — data + prompts
     "BfclMultiTurnDataset",
     "build_bfcl_prefix_messages",
     "prune_bfcl_prefix",
-    "render_bfcl_tool_catalog",
     "bfcl_default_system_prompt",
     "bfcl_tool_schemas_to_openai",
-    "load_bfcl_func_docs",
     "to_json_schema",
 ]

--- a/modal_training_gym/common/environments/__init__.py
+++ b/modal_training_gym/common/environments/__init__.py
@@ -23,6 +23,7 @@ from modal_training_gym.common.environments.bfcl import (
     build_env as build_bfcl_env,
     build_prefix_messages as build_bfcl_prefix_messages,
     default_system_prompt as bfcl_default_system_prompt,
+    prefix_turn_index as bfcl_prefix_turn_index,
     prune_prefix as prune_bfcl_prefix,
     run_bfcl_episode,
     to_json_schema,
@@ -84,6 +85,7 @@ __all__ = [
     # bfcl — data + prompts
     "BfclMultiTurnDataset",
     "build_bfcl_prefix_messages",
+    "bfcl_prefix_turn_index",
     "prune_bfcl_prefix",
     "bfcl_default_system_prompt",
     "bfcl_tool_schemas_to_openai",

--- a/modal_training_gym/common/environments/__init__.py
+++ b/modal_training_gym/common/environments/__init__.py
@@ -1,7 +1,8 @@
-"""Live, sandbox-backed RL environments.
+"""Live RL environments.
 
-``base`` holds the framework-agnostic abstractions (I/O shapes + lifecycle base
-classes); concrete benchmarks (e.g. ``toolathlon``) build on them.
+``base`` holds the framework-agnostic abstractions (I/O shapes + lifecycle base classes); concrete
+benchmarks build on them — ``toolathlon`` (Modal-sandbox-backed) and ``bfcl`` (in-process, no
+sandbox needed at all; see :mod:`.bfcl`'s module docstring for why).
 """
 
 from modal_training_gym.common.environments.base import (
@@ -30,6 +31,44 @@ from modal_training_gym.common.environments.toolathlon import (
     prune_prefix,
     render_tool_catalog,
     tool_schemas_to_openai,
+)
+from modal_training_gym.common.environments.bfcl import (
+    DEFAULT_CONFIG as BFCL_DEFAULT_CONFIG,
+)
+from modal_training_gym.common.environments.bfcl import (
+    BfclMultiTurnConfig,
+    BfclMultiTurnDataset,
+    BfclTurnEnvironment,
+)
+from modal_training_gym.common.environments.bfcl import build_env as build_bfcl_env
+from modal_training_gym.common.environments.bfcl import (
+    build_instances as build_bfcl_instances,
+)
+from modal_training_gym.common.environments.bfcl import (
+    build_prefix_messages as build_bfcl_prefix_messages,
+)
+from modal_training_gym.common.environments.bfcl import (
+    default_system_prompt as bfcl_default_system_prompt,
+)
+from modal_training_gym.common.environments.bfcl import (
+    execute_call as execute_bfcl_call,
+)
+from modal_training_gym.common.environments.bfcl import (
+    load_func_docs as load_bfcl_func_docs,
+)
+from modal_training_gym.common.environments.bfcl import (
+    parse_call_string as parse_bfcl_call_string,
+)
+from modal_training_gym.common.environments.bfcl import (
+    prune_prefix as prune_bfcl_prefix,
+)
+from modal_training_gym.common.environments.bfcl import (
+    render_tool_catalog as render_bfcl_tool_catalog,
+)
+from modal_training_gym.common.environments.bfcl import replay as replay_bfcl
+from modal_training_gym.common.environments.bfcl import to_json_schema
+from modal_training_gym.common.environments.bfcl import (
+    tool_schemas_to_openai as bfcl_tool_schemas_to_openai,
 )
 
 __all__ = [
@@ -61,4 +100,22 @@ __all__ = [
     "render_tool_catalog",
     "default_system_prompt",
     "tool_schemas_to_openai",
+    # bfcl — config + env
+    "BfclMultiTurnConfig",
+    "BFCL_DEFAULT_CONFIG",
+    "BfclTurnEnvironment",
+    "build_bfcl_env",
+    "build_bfcl_instances",
+    "execute_bfcl_call",
+    "replay_bfcl",
+    "parse_bfcl_call_string",
+    # bfcl — data + prompts
+    "BfclMultiTurnDataset",
+    "build_bfcl_prefix_messages",
+    "prune_bfcl_prefix",
+    "render_bfcl_tool_catalog",
+    "bfcl_default_system_prompt",
+    "bfcl_tool_schemas_to_openai",
+    "load_bfcl_func_docs",
+    "to_json_schema",
 ]

--- a/modal_training_gym/common/environments/base.py
+++ b/modal_training_gym/common/environments/base.py
@@ -91,6 +91,52 @@ class EvalVerdict:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+# ── Tool schemas ─────────────────────────────────────────────────────────────
+
+
+def render_tool_catalog(tool_schemas: dict, desc_chars: int = 160) -> str:
+    """Render tool schemas as compact ``name(arg, required*)`` lines."""
+    lines = []
+    for name in sorted(tool_schemas or {}):
+        spec = tool_schemas[name]
+        if isinstance(spec, dict) and ("parameters" in spec or "description" in spec):
+            desc, params = spec.get("description", ""), spec.get("parameters", {})
+        else:
+            desc, params = "", spec
+        props = (params or {}).get("properties", {}) if isinstance(params, dict) else {}
+        required = (
+            set((params or {}).get("required", []) or [])
+            if isinstance(params, dict)
+            else set()
+        )
+        sig = ", ".join(f"{key}*" if key in required else key for key in props)
+        desc = " ".join(str(desc).split())[:desc_chars]
+        lines.append(f"- {name}({sig})" + (f": {desc}" if desc else ""))
+    return "\n".join(lines)
+
+
+def tool_schemas_to_openai(tool_schemas: dict) -> list[dict]:
+    """Convert a tool-schema mapping into the OpenAI/HF ``tools=`` shape."""
+    tools = []
+    for name in sorted(tool_schemas or {}):
+        spec = tool_schemas[name]
+        if isinstance(spec, dict) and ("parameters" in spec or "description" in spec):
+            desc, params = spec.get("description", ""), spec.get("parameters", {})
+        else:
+            desc, params = "", spec
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": desc,
+                    "parameters": params or {"type": "object", "properties": {}},
+                },
+            }
+        )
+    return tools
+
+
 # ── Environment lifecycle ───────────────────────────────────────────────────
 
 

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -509,7 +509,7 @@ def run_bfcl_episode(
                         "type": "function",
                         "function": {
                             "name": action.name,
-                            "arguments": json.dumps(action.arguments or {}),
+                            "arguments": action.arguments or {},
                         },
                     }
                     for call_id, action in zip(call_ids, actions)

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -321,6 +321,19 @@ def build_prefix_messages(label: dict, K: int) -> list[dict]:
     return messages
 
 
+def prefix_turn_index(label: dict, K: int) -> int:
+    """Index of the latest user turn included in the step-``K`` prefix."""
+    latest_turn = -1
+    shown = 0
+    for turn_index, turn in enumerate(label.get("turns", [])):
+        latest_turn = turn_index
+        for _call in turn.get("calls", []):
+            if shown >= K:
+                return turn_index
+            shown += 1
+    return latest_turn
+
+
 def prune_prefix(messages: list[dict], max_messages: int) -> list[dict]:
     """Keep system + first user message and fill the rest with the most recent messages."""
     if max_messages <= 0:
@@ -436,6 +449,7 @@ def run_bfcl_episode(
     final_response = ""
     exit_reason = "max_turns"
     consecutive_errors = 0
+    current_turn = prefix_turn_index(label, start_step)
 
     for turn in range(max_turns):
         started_at = time.monotonic()
@@ -448,6 +462,19 @@ def run_bfcl_episode(
             f"calls={[action.name for action in actions]}"
         )
         if not actions:
+            next_turn = current_turn + 1
+            turns = label.get("turns", [])
+            if next_turn < len(turns):
+                messages.extend(
+                    [
+                        {"role": "assistant", "content": content},
+                        {"role": "user", "content": turns[next_turn]["user"]},
+                    ]
+                )
+                current_turn = next_turn
+                consecutive_errors = 0
+                emit(f"  advancing to user turn {current_turn}")
+                continue
             exit_reason = "no_further_calls"
             break
 

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -20,9 +20,10 @@ import ast
 import inspect
 import json
 import os
+import time
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 from modal_training_gym.common.dataset import DatasetConfig
 from modal_training_gym.common.environments.base import (
@@ -397,6 +398,147 @@ def build_env(label: dict, K: int) -> BfclTurnEnvironment:
     calls = deepcopy(label["flattened_calls"][:K])
     instances, _ = replay(label["involved_classes"], label["initial_config"], calls)
     return BfclTurnEnvironment(label=label, instances=instances, K=K)
+
+
+# ── Episode runner ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class BfclEpisodeResult:
+    """Structured output from :func:`run_bfcl_episode`."""
+
+    messages: list[dict]
+    calls: list[dict[str, Any]]
+    execution_successes: list[bool]
+    verdict: EvalVerdict
+    final_response: str = ""
+    exit_reason: str = "max_turns"
+
+    @property
+    def first_call(self) -> dict[str, Any] | None:
+        return self.calls[0] if self.calls else None
+
+
+def run_bfcl_episode(
+    label: dict,
+    *,
+    start_step: int,
+    generate: Callable[[list[dict], list[dict]], dict],
+    parse_response: Callable[[dict], tuple[str, list[ToolCall]]],
+    max_turns: int,
+    max_consecutive_errors: int = 3,
+    observation_limit: int = 2000,
+    log: Callable[[str], None] | None = None,
+) -> BfclEpisodeResult:
+    """Generate, execute, and grade one BFCL episode.
+
+    ``generate`` receives the current OpenAI-style messages and tool schemas.
+    ``parse_response`` converts its returned message into assistant text and
+    normalized :class:`ToolCall` objects. Keeping those model-specific details
+    in callbacks lets the BFCL lifecycle stay independent of a serving engine.
+    """
+
+    def emit(message: str) -> None:
+        if log is not None:
+            log(message)
+
+    messages = build_prefix_messages(label, start_step)
+    tools = tool_schemas_to_openai(label.get("tool_schemas", {}))
+    env = build_env(label, start_step)
+    calls: list[dict[str, Any]] = []
+    execution_successes: list[bool] = []
+    final_response = ""
+    exit_reason = "max_turns"
+    consecutive_errors = 0
+
+    for turn in range(max_turns):
+        started_at = time.monotonic()
+        message = generate(messages, tools)
+        generation_seconds = time.monotonic() - started_at
+        content, actions = parse_response(message)
+        final_response = content
+        emit(
+            f"turn {turn} gen={generation_seconds:.1f}s "
+            f"calls={[action.name for action in actions]}"
+        )
+        if not actions:
+            exit_reason = "no_further_calls"
+            break
+
+        observations: list[str] = []
+        stop = False
+        for action in actions:
+            calls.append({"name": action.name, "arguments": action.arguments or {}})
+            try:
+                step_result = env.step(action)
+            except Exception as exc:
+                emit(f"  execution error on {action.name}: {exc!r} — ending episode")
+                execution_successes.append(False)
+                exit_reason = "execution_error"
+                stop = True
+                break
+
+            observation = step_result.observation
+            execution_successes.append(not observation.is_error)
+            observations.append(observation.text)
+            emit(f"  exec {action.name} -> {'ERR' if observation.is_error else 'ok'}")
+            consecutive_errors = consecutive_errors + 1 if observation.is_error else 0
+            if step_result.done:
+                exit_reason = "environment_done"
+                stop = True
+                break
+            if (
+                max_consecutive_errors > 0
+                and consecutive_errors >= max_consecutive_errors
+            ):
+                exit_reason = "repeated_errors"
+                stop = True
+                break
+
+        if stop:
+            break
+
+        call_ids = [f"call_t{turn}_{index}" for index in range(len(actions))]
+        messages.append(
+            {
+                "role": "assistant",
+                "content": content,
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": action.name,
+                            "arguments": json.dumps(action.arguments or {}),
+                        },
+                    }
+                    for call_id, action in zip(call_ids, actions)
+                ],
+            }
+        )
+        messages.extend(
+            {
+                "role": "tool",
+                "tool_call_id": call_id,
+                "content": observation[:observation_limit],
+            }
+            for call_id, observation in zip(call_ids, observations)
+        )
+
+    try:
+        verdict = env.evaluate()
+    except Exception as exc:
+        emit(f"evaluate() failed: {exc!r} — marking failed")
+        verdict = EvalVerdict(passed=False, detail=str(exc), harness_error=True)
+
+    return BfclEpisodeResult(
+        messages=messages,
+        calls=calls,
+        execution_successes=execution_successes,
+        verdict=verdict,
+        final_response=final_response,
+        exit_reason=exit_reason,
+    )
 
 
 # ── Trajectory dataset ───────────────────────────────────────────────────────

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -31,10 +31,8 @@ from modal_training_gym.common.environments.base import (
     Observation,
     StepResult,
     ToolCall,
+    tool_schemas_to_openai as _tool_schemas_to_openai,
 )
-
-# Last N ids held out for eval (BFCL has no official train/eval split).
-DEFAULT_EVAL_TAIL = 30
 
 # Empty for interface parity with Toolathlon's DONE_TOOLS.
 DONE_TOOLS: frozenset[str] = frozenset()
@@ -219,18 +217,17 @@ def to_json_schema(node: Any) -> Any:
 
 
 def tool_schemas_to_openai(tool_schemas: dict) -> list[dict]:
-    """Render BFCL func-docs as an OpenAI ``tools=`` list."""
-    return [
-        {
-            "type": "function",
-            "function": {
-                "name": name,
-                "description": spec.get("description", ""),
+    """Convert BFCL function docs to OpenAI tools, normalizing BFCL type names."""
+    normalized = {}
+    for name, spec in (tool_schemas or {}).items():
+        if isinstance(spec, dict) and ("parameters" in spec or "description" in spec):
+            normalized[name] = {
+                **spec,
                 "parameters": to_json_schema(spec.get("parameters", {})),
-            },
-        }
-        for name, spec in (tool_schemas or {}).items()
-    ]
+            }
+        else:
+            normalized[name] = to_json_schema(spec)
+    return _tool_schemas_to_openai(normalized)
 
 
 def load_func_docs(
@@ -250,7 +247,7 @@ def load_func_docs(
                 continue
             schemas[doc["name"]] = {
                 "description": doc.get("description", ""),
-                "parameters": doc.get("parameters", {}),
+                "parameters": to_json_schema(doc.get("parameters", {})),
             }
     return schemas
 
@@ -282,30 +279,13 @@ temp
 Use the actual tool name, parameters, and full (untruncated) values required by your task; the call above is only an illustration of the wire format."""
 
 
-def render_tool_catalog(tool_schemas: dict, desc_chars: int = 160) -> str:
-    """Render available tools as ``name(arg, required*)`` lines + a short description."""
-    lines = []
-    for name in sorted(tool_schemas or {}):
-        spec = tool_schemas[name]
-        desc, params = spec.get("description", ""), spec.get("parameters", {})
-        props = (params or {}).get("properties", {}) if isinstance(params, dict) else {}
-        required = (
-            set((params or {}).get("required", []) or [])
-            if isinstance(params, dict)
-            else set()
-        )
-        sig = ", ".join(f"{k}*" if k in required else k for k in props)
-        lines.append(f"- {name}({sig}): {desc[:desc_chars]}")
-    return "\n".join(lines)
-
-
 def default_system_prompt(tool_schemas: dict) -> str:
     """Behavioral rules only — the tool catalog travels via the chat template's
     ``tools=`` parameter (see :func:`tool_schemas_to_openai`), not prompt text."""
     return DEFAULT_SYSTEM_PROMPT
 
 
-def build_prefix_messages(label: dict, K: int, *, obs_limit: int = 1500) -> list[dict]:
+def build_prefix_messages(label: dict, K: int) -> list[dict]:
     """Reconstruct the chat-message prefix after the first ``K`` ground-truth calls."""
     observations = label.get("observations")
     if observations is None:
@@ -347,7 +327,7 @@ def build_prefix_messages(label: dict, K: int, *, obs_limit: int = 1500) -> list
                 {
                     "role": "tool",
                     "tool_call_id": f"call_{shown}",
-                    "content": str(observations[shown])[:obs_limit],
+                    "content": str(observations[shown]),
                 }
             )
             shown += 1
@@ -438,11 +418,10 @@ class BfclMultiTurnConfig:
     """
 
     category: str = "multi_turn_base"
-    eval_tail: int = DEFAULT_EVAL_TAIL
+    # BFCL has no official split, so reserve the last N ids for eval.
+    eval_tail: int = 30
+    # Bound tool observations stored in each training prefix.
     obs_limit: int = 1500
-
-
-DEFAULT_CONFIG = BfclMultiTurnConfig()
 
 
 def _category_filename(category: str) -> str:
@@ -466,11 +445,11 @@ class BfclMultiTurnDataset(DatasetConfig):
     def __init__(
         self,
         split: str = "train",
-        config: BfclMultiTurnConfig = DEFAULT_CONFIG,
+        config: BfclMultiTurnConfig | None = None,
         **kwargs: Any,
     ) -> None:
         self._split = split
-        self.config = config
+        self.config = config if config is not None else BfclMultiTurnConfig()
         for k, v in kwargs.items():
             setattr(self, k, v)
 

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -595,6 +595,15 @@ class BfclMultiTurnDataset(DatasetConfig):
         return self._load_split()
 
     def prepare(self, path: str, eval_paths: dict | None = None) -> None:
+        """Write this instance's split to ``path``.
+
+        ``eval_paths`` is ignored on purpose: BFCL training and offline eval each
+        use their own ``BfclMultiTurnDataset(split=...)`` instance. Recipe
+        resolvers still invent an ``eval.*`` companion path; callers must not
+        require that file (see ``run_prepare_dataset`` / slime-miles ``exists``
+        guards).
+        """
+        del eval_paths  # train/eval are separate DatasetConfig instances
         rows = self._load_split()
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -1,34 +1,17 @@
 """In-process Berkeley Function Calling Leaderboard (BFCL) v3/v4 multi-turn environment.
 
-BFCL's multi-turn categories
-(https://gorilla.cs.berkeley.edu/blogs/13_bfcl_v3_multi_turn.html) grade agents against small,
-*in-process* Python state machines (``GorillaFileSystem``, ``TwitterAPI``, ``TicketAPI``,
-``TravelAPI``, ``VehicleControlAPI``, ...) rather than live sandboxes or MCP servers: a tool call is a
-Python expression (``mv(source='a', destination='b')``) evaluated against the live instance, and
-grading is an attribute-level state diff plus a response-subsequence check. This means the Modal
-sandbox / directory-snapshot apparatus in :mod:`.toolathlon` is unnecessary here — replaying ground
-truth and grading both happen in plain Python, in milliseconds, with no container or network involved.
+BFCL grades agents against in-process Python state machines (``GorillaFileSystem``,
+``TwitterAPI``, etc.): tool calls are Python expressions evaluated against live
+instances, and grading is a state diff plus a response-subsequence check. This
+module wraps ``bfcl_eval`` (imported lazily) into the same ``step``/``evaluate``
+shape as :mod:`.base`.
 
-This module is a thin, RL-rollout-friendly wrapper around the upstream ``bfcl_eval`` package
-(https://pypi.org/project/bfcl-eval/). It is *not* vendored — ``bfcl_eval`` is imported lazily (see
-:func:`_bfcl_eval`) so importing :mod:`modal_training_gym` doesn't pick up its large, mostly-unrelated
-dependency closure (sentence-transformers, faiss, several model-vendor SDKs, ...). Callers must
-``pip install bfcl-eval`` themselves (the tutorial's image/install cells do this).
-
-Three pieces, mirroring :mod:`.toolathlon`'s shape:
-
-- **Data** — :class:`BfclMultiTurnDataset` loads a BFCL multi-turn category (default:
-  ``BFCL_v4_multi_turn_base``) plus its ``possible_answer`` ground truth straight out of the installed
-  ``bfcl_eval`` package, flattens each task's per-turn ground-truth calls into one ordered sequence,
-  and replays it once (in-process) to capture the observation text for every step — the BFCL analogue
-  of Toolathlon's expert trajectory.
-- **Environment** — :class:`BfclTurnEnvironment` holds one fresh set of live class instances per
-  episode (no global/module-level caching, unlike upstream's own
-  ``execute_multi_turn_func_call`` — that caching is unsafe for concurrent online rollouts of the same
-  task) and exposes the same ``step``/``evaluate`` shape as :mod:`.base`. Grading reuses ``bfcl_eval``'s
-  own ``state_checker``/``response_checker`` rather than reimplementing them.
-- **Prompting** — :func:`build_prefix_messages` / :func:`tool_schemas_to_openai` mirror the Toolathlon
-  helpers of the same name, so a caller can swap one environment for the other with minimal churn.
+- **Data** — :class:`BfclMultiTurnDataset` loads a multi-turn category and flattens
+  per-turn ground-truth calls into an ordered sequence.
+- **Environment** — :class:`BfclTurnEnvironment` holds fresh class instances per
+  episode (no module-level caching) and reuses ``bfcl_eval``'s checkers.
+- **Prompting** — :func:`build_prefix_messages` / :func:`tool_schemas_to_openai`
+  mirror the Toolathlon helpers of the same name.
 """
 
 from __future__ import annotations
@@ -50,13 +33,10 @@ from modal_training_gym.common.environments.base import (
     ToolCall,
 )
 
-DEFAULT_CATEGORY = "BFCL_v4_multi_turn_base"
-# The leaderboard ships no train/eval split (it's a benchmark, not a training set), so we carve our
-# own: the last N ids of the category are held out for eval.
+# Last N ids held out for eval (BFCL has no official train/eval split).
 DEFAULT_EVAL_TAIL = 30
 
-# BFCL has no explicit "done" tool — a turn simply ends when the model stops emitting calls. Kept
-# (empty) for interface parity with callers that special-case Toolathlon's ``DONE_TOOLS``.
+# Empty for interface parity with Toolathlon's DONE_TOOLS.
 DONE_TOOLS: frozenset[str] = frozenset()
 
 _JSON_TYPE_MAP = {
@@ -71,7 +51,7 @@ _JSON_TYPE_MAP = {
 
 
 def _bfcl_eval():
-    """Import ``bfcl_eval`` lazily (see module docstring)."""
+    """Import ``bfcl_eval`` lazily so the package isn't a hard dep of modal_training_gym."""
     try:
         import bfcl_eval
     except ImportError as e:
@@ -106,12 +86,9 @@ def _load_jsonl(path: str) -> list[dict]:
 
 
 def parse_call_string(call: str) -> dict[str, Any]:
-    """Parse a BFCL ground-truth call string (e.g. ``"mv(source='a', destination='b')"`` or the
-    positional ``"cd('archives')"``) into ``{"name": str, "arguments": dict}``.
+    """Parse a BFCL call string into ``{"name": str, "arguments": dict}``.
 
-    Ground-truth call strings are always a single call with literal/keyword arguments, so
-    ``ast.literal_eval`` per-argument is sufficient — and, unlike upstream's ``eval()``-based
-    execution helpers, this never executes arbitrary code.
+    Uses ``ast.literal_eval`` — never executes arbitrary code.
     """
     node = ast.parse(call.strip(), mode="eval").body
     if not isinstance(node, ast.Call):
@@ -128,9 +105,7 @@ def parse_call_string(call: str) -> dict[str, Any]:
 def _normalize_arguments(
     owner: Any, name: str, arguments: dict[str, Any]
 ) -> dict[str, Any]:
-    """Resolve ``_posN`` placeholders (from positional ground-truth calls) to real keyword names
-    using ``owner``'s live method signature, so stored calls are always keyword-args (clean to show
-    a model in a tool-call message and to re-execute later)."""
+    """Resolve ``_posN`` placeholders to keyword names via ``owner``'s method signature."""
     positional = sorted(
         ((k, v) for k, v in arguments.items() if k.startswith("_pos")),
         key=lambda kv: int(kv[0][4:]),
@@ -169,13 +144,7 @@ def _instantiate(
 def build_instances(
     involved_classes: list[str], initial_config: dict
 ) -> dict[str, Any]:
-    """One fresh instance per involved class.
-
-    Unlike upstream's ``execute_multi_turn_func_call`` — which memoizes instances in module
-    ``globals()`` keyed by ``(model_name, test_entry_id, class_name)`` for its offline batch-eval
-    harness — this always builds fresh instances, which is the correct (and only safe) behavior for
-    concurrent online rollouts that may replay the same task at the same time.
-    """
+    """One fresh instance per involved class (safe for concurrent rollouts)."""
     return {name: _instantiate(name, initial_config) for name in involved_classes}
 
 
@@ -200,14 +169,9 @@ def _stringify(result: Any) -> str:
 
 
 def execute_call(instances: dict[str, Any], call: dict[str, Any]) -> tuple[str, bool]:
-    """Run one ``{"name", "arguments"}`` call against ``instances``. Returns ``(result_text,
-    is_error)``. ``arguments`` must already be a plain keyword dict (no ``_posN`` placeholders) —
-    student-generated calls always are; ground-truth calls are normalized once during :func:`replay`.
+    """Run one ``{"name", "arguments"}`` call. Returns ``(result_text, is_error)``.
 
-    Arguments are deep-copied before the call: some upstream BFCL methods store a list/dict argument
-    by reference into instance state (e.g. ``TwitterAPI.post_tweet``'s ``mentions=[]`` default), so a
-    caller that reuses the same argument object across multiple ``step()`` calls (or across two
-    environments) would otherwise silently corrupt unrelated state through that aliasing.
+    Arguments are deep-copied before the call to avoid aliasing into instance state.
     """
     owner = _method_owner(instances, call["name"])
     if owner is None:
@@ -222,11 +186,9 @@ def execute_call(instances: dict[str, Any], call: dict[str, Any]) -> tuple[str, 
 def replay(
     involved_classes: list[str], initial_config: dict, calls: list[dict[str, Any]]
 ) -> tuple[dict[str, Any], list[str]]:
-    """Fresh instances + the observation text for each of ``calls``, executed in order.
+    """Fresh instances + observation text for each of ``calls``, executed in order.
 
-    Mutates each ``call["arguments"]`` in place to resolve any ``_posN`` placeholders to real keyword
-    names (see :func:`_normalize_arguments`), so callers that pass in freshly-parsed ground-truth
-    calls get back clean, display-ready call dicts as a side effect.
+    Mutates each ``call["arguments"]`` in place to resolve any ``_posN`` placeholders.
     """
     instances = build_instances(involved_classes, initial_config)
     observations = []
@@ -245,8 +207,7 @@ def replay(
 
 
 def to_json_schema(node: Any) -> Any:
-    """Recursively convert a BFCL func-doc schema fragment (``dict``/``list`` typed) to JSON-Schema
-    typing (``object``/``array``), e.g. for use with the ``jsonschema`` package."""
+    """Convert a BFCL func-doc schema fragment to JSON-Schema typing."""
     if isinstance(node, dict):
         out = {k: to_json_schema(v) for k, v in node.items() if k != "default"}
         if out.get("type") in _JSON_TYPE_MAP:
@@ -258,9 +219,7 @@ def to_json_schema(node: Any) -> Any:
 
 
 def tool_schemas_to_openai(tool_schemas: dict) -> list[dict]:
-    """Render ``{name: {"description", "parameters"}}`` (BFCL's func-doc shape) as the OpenAI
-    ``tools=`` list a chat template expects, converting BFCL's ``dict``/``list`` JSON types to
-    JSON-Schema's ``object``/``array``."""
+    """Render BFCL func-docs as an OpenAI ``tools=`` list."""
     return [
         {
             "type": "function",
@@ -277,9 +236,7 @@ def tool_schemas_to_openai(tool_schemas: dict) -> list[dict]:
 def load_func_docs(
     involved_classes: list[str], excluded_function: list[str] | None = None
 ) -> dict:
-    """The BFCL function docs for ``involved_classes``, minus any ``excluded_function`` (BFCL omits
-    these from the offered catalog when an equivalent function already covers the same ground truth,
-    e.g. excluding ``cp`` when the task is solved with ``mv``)."""
+    """BFCL function docs for ``involved_classes``, minus any ``excluded_function``."""
     _, doc_file_mapping, _ = _backend_mappings()
     excluded = set(excluded_function or [])
     data_dir = _data_dir()
@@ -326,7 +283,7 @@ Use the actual tool name, parameters, and full (untruncated) values required by 
 
 
 def render_tool_catalog(tool_schemas: dict, desc_chars: int = 160) -> str:
-    """Render the available-tools catalog as ``name(arg, required*)`` lines + a short description."""
+    """Render available tools as ``name(arg, required*)`` lines + a short description."""
     lines = []
     for name in sorted(tool_schemas or {}):
         spec = tool_schemas[name]
@@ -343,17 +300,13 @@ def render_tool_catalog(tool_schemas: dict, desc_chars: int = 160) -> str:
 
 
 def default_system_prompt(tool_schemas: dict) -> str:
-    return f"{DEFAULT_SYSTEM_PROMPT}\n\nAvailable tools:\n{render_tool_catalog(tool_schemas)}"
+    """Behavioral rules only — the tool catalog travels via the chat template's
+    ``tools=`` parameter (see :func:`tool_schemas_to_openai`), not prompt text."""
+    return DEFAULT_SYSTEM_PROMPT
 
 
 def build_prefix_messages(label: dict, K: int, *, obs_limit: int = 1500) -> list[dict]:
-    """Reconstruct the chat-message prefix after the first ``K`` ground-truth calls have happened.
-
-    Walks BFCL's turns in order, emitting each turn's user message followed by an assistant
-    tool-call + tool-result pair for every ground-truth call in that turn that falls within the
-    first ``K`` calls overall. Stops as soon as ``K`` calls have been shown — which may land exactly
-    on a fresh, not-yet-acted-on user turn, or mid-turn.
-    """
+    """Reconstruct the chat-message prefix after the first ``K`` ground-truth calls."""
     observations = label.get("observations")
     if observations is None:
         _, observations = replay(
@@ -383,12 +336,7 @@ def build_prefix_messages(label: dict, K: int, *, obs_limit: int = 1500) -> list
                             "type": "function",
                             "function": {
                                 "name": call["name"],
-                                # A raw dict, not a JSON string: this prefix is fed straight to
-                                # ``tokenizer.apply_chat_template`` (not an OpenAI-compatible HTTP
-                                # API layer that would parse a JSON string first), and Qwen3.6's
-                                # chat template iterates arguments with Jinja's ``|items`` filter,
-                                # which requires an actual mapping (mirrors
-                                # ``.toolathlon.build_prefix_messages``'s convention).
+                                # Raw dict (not JSON string) for chat-template |items.
                                 "arguments": call["arguments"],
                             },
                         }
@@ -407,13 +355,16 @@ def build_prefix_messages(label: dict, K: int, *, obs_limit: int = 1500) -> list
 
 
 def prune_prefix(messages: list[dict], max_messages: int) -> list[dict]:
-    """Keep the system + first user message and the most recent ``max_messages`` exchanges —
-    mirrors :func:`.toolathlon.prune_prefix`'s role, for callers that need to budget context length."""
+    """Keep system + first user message and fill the rest with the most recent messages."""
+    if max_messages <= 0:
+        return []
     if len(messages) <= max_messages:
         return messages
     head = messages[:2]
-    tail = messages[-(max_messages - len(head)) :]
-    return head + tail
+    tail_n = max_messages - len(head)
+    if tail_n <= 0:
+        return messages[:max_messages]
+    return head + messages[-tail_n:]
 
 
 # ── Environment ──────────────────────────────────────────────────────────────
@@ -421,16 +372,12 @@ def prune_prefix(messages: list[dict], max_messages: int) -> list[dict]:
 
 @dataclass
 class BfclTurnEnvironment(Environment):
-    """One live multi-turn BFCL episode: a set of in-process class instances seeded by replaying the
-    first ``K`` ground-truth calls, then driven forward by an agent's own tool calls via :meth:`step`.
-    """
+    """One live multi-turn BFCL episode, seeded by replaying the first ``K`` ground-truth calls."""
 
     label: dict
     instances: dict[str, Any] = field(default_factory=dict)
     exec_results: list[str] = field(default_factory=list)
-    # How many ground-truth calls were already replayed to seed `instances` before this episode
-    # started (see `build_env`). Only the *remaining* ground-truth responses (from this index
-    # onward) need to show up in `exec_results` — the prefix was identical by construction.
+    # Ground-truth calls already replayed to seed `instances`.
     K: int = 0
 
     def step(self, action: ToolCall) -> StepResult:
@@ -442,9 +389,7 @@ class BfclTurnEnvironment(Environment):
         )
 
     def evaluate(self) -> EvalVerdict:
-        """Grade the episode: deep state diff (``state_checker``) + response-subsequence check
-        (``response_checker``) against a freshly-replayed copy of the *full* ground-truth trajectory —
-        reusing ``bfcl_eval``'s own checkers rather than reimplementing them."""
+        """Grade via ``state_checker`` + ``response_checker`` against the full ground-truth trajectory."""
         from bfcl_eval.eval_checker.multi_turn_eval.multi_turn_checker import (
             response_checker,
             state_checker,
@@ -458,8 +403,7 @@ class BfclTurnEnvironment(Environment):
         state_result = state_checker(self.instances, ground_truth_instances)
         if not state_result["valid"]:
             return EvalVerdict(passed=False, detail=state_result["error_message"])
-        # The prefix (calls [0:K]) is identical for the model and ground truth by construction
-        # (both replayed it to seed state) — only what the agent did from K onward needs checking.
+        # Only check agent responses from K onward (prefix is identical by construction).
         response_result = response_checker(
             self.exec_results, ground_truth_results[self.K :], 0
         )
@@ -469,8 +413,7 @@ class BfclTurnEnvironment(Environment):
 
 
 def build_env(label: dict, K: int) -> BfclTurnEnvironment:
-    """Build a fresh :class:`BfclTurnEnvironment` with state fast-forwarded through the first ``K``
-    ground-truth calls — the in-process analogue of restoring a Toolathlon directory snapshot."""
+    """Fresh environment with state fast-forwarded through the first ``K`` ground-truth calls."""
     calls = deepcopy(label["flattened_calls"][:K])
     instances, _ = replay(label["involved_classes"], label["initial_config"], calls)
     return BfclTurnEnvironment(label=label, instances=instances, K=K)
@@ -488,9 +431,13 @@ def _first_user_text(turn_messages: list[dict]) -> str:
 
 @dataclass(frozen=True)
 class BfclMultiTurnConfig:
-    """Which BFCL multi-turn category to load and how to carve a train/eval split out of it."""
+    """Which BFCL multi-turn category to load and how to carve a train/eval split.
 
-    category: str = DEFAULT_CATEGORY
+    ``category`` is the bfcl_eval name (e.g. ``multi_turn_base``); the installed
+    package's ``VERSION_PREFIX`` is prepended when resolving data files.
+    """
+
+    category: str = "multi_turn_base"
     eval_tail: int = DEFAULT_EVAL_TAIL
     obs_limit: int = 1500
 
@@ -498,24 +445,23 @@ class BfclMultiTurnConfig:
 DEFAULT_CONFIG = BfclMultiTurnConfig()
 
 
-class BfclMultiTurnDataset(DatasetConfig):
-    """Loads a BFCL multi-turn category straight out of the installed ``bfcl_eval`` package.
+def _category_filename(category: str) -> str:
+    from bfcl_eval.constants.category_mapping import VERSION_PREFIX
 
-    Each row's ``label`` carries everything the curriculum/rollout/reward code needs: the per-turn
-    user text, the (keyword-normalized) ground-truth calls flattened across all turns, the observation
-    text for each of those calls (so the K-step prefix never needs to re-execute anything), the tool
-    catalog for the task's involved classes, and the raw ``initial_config``/``involved_classes`` so an
-    episode can be rebuilt at any step. There is no train/eval split upstream (BFCL is a benchmark,
-    not a training set) — :attr:`config`.eval_tail ids are held out as eval.
+    return f"{VERSION_PREFIX}_{category}.json"
+
+
+class BfclMultiTurnDataset(DatasetConfig):
+    """Loads a BFCL multi-turn category from the installed ``bfcl_eval`` package.
+
+    Last :attr:`config`.eval_tail ids are held out as eval.
     """
 
     input_key: str = "messages"
     label_key: str = "label"
-    # `prepare()` writes JSON-lines (below); tell the launcher's data-path
-    # resolver (`SlimeRecipe._resolve_data_paths`, default: "parquet") to name
-    # the on-volume file `*.jsonl` accordingly — otherwise slime tries to read
-    # a JSON-lines file as Parquet and fails with "Parquet magic bytes not found".
+    # JSON-lines output (slime default is parquet).
     output_format: str = "jsonl"
+    writes_eval_paths: bool = False
 
     def __init__(
         self,
@@ -529,11 +475,15 @@ class BfclMultiTurnDataset(DatasetConfig):
             setattr(self, k, v)
 
     def _entries(self) -> list[dict]:
-        return _load_jsonl(os.path.join(_data_dir(), f"{self.config.category}.json"))
+        return _load_jsonl(
+            os.path.join(_data_dir(), _category_filename(self.config.category))
+        )
 
     def _ground_truths(self) -> dict[str, list[list[str]]]:
         path = os.path.join(
-            _data_dir(), "possible_answer", f"{self.config.category}.json"
+            _data_dir(),
+            "possible_answer",
+            _category_filename(self.config.category),
         )
         return {e["id"]: e["ground_truth"] for e in _load_jsonl(path)}
 
@@ -595,14 +545,7 @@ class BfclMultiTurnDataset(DatasetConfig):
         return self._load_split()
 
     def prepare(self, path: str, eval_paths: dict | None = None) -> None:
-        """Write this instance's split to ``path``.
-
-        ``eval_paths`` is ignored on purpose: BFCL training and offline eval each
-        use their own ``BfclMultiTurnDataset(split=...)`` instance. Recipe
-        resolvers still invent an ``eval.*`` companion path; callers must not
-        require that file (see ``run_prepare_dataset`` / slime-miles ``exists``
-        guards).
-        """
+        """Write this instance's split to ``path``. ``eval_paths`` is ignored."""
         del eval_paths  # train/eval are separate DatasetConfig instances
         rows = self._load_split()
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -1,0 +1,601 @@
+"""In-process Berkeley Function Calling Leaderboard (BFCL) v3/v4 multi-turn environment.
+
+BFCL's multi-turn categories
+(https://gorilla.cs.berkeley.edu/blogs/13_bfcl_v3_multi_turn.html) grade agents against small,
+*in-process* Python state machines (``GorillaFileSystem``, ``TwitterAPI``, ``TicketAPI``,
+``TravelAPI``, ``VehicleControlAPI``, ...) rather than live sandboxes or MCP servers: a tool call is a
+Python expression (``mv(source='a', destination='b')``) evaluated against the live instance, and
+grading is an attribute-level state diff plus a response-subsequence check. This means the Modal
+sandbox / directory-snapshot apparatus in :mod:`.toolathlon` is unnecessary here — replaying ground
+truth and grading both happen in plain Python, in milliseconds, with no container or network involved.
+
+This module is a thin, RL-rollout-friendly wrapper around the upstream ``bfcl_eval`` package
+(https://pypi.org/project/bfcl-eval/). It is *not* vendored — ``bfcl_eval`` is imported lazily (see
+:func:`_bfcl_eval`) so importing :mod:`modal_training_gym` doesn't pick up its large, mostly-unrelated
+dependency closure (sentence-transformers, faiss, several model-vendor SDKs, ...). Callers must
+``pip install bfcl-eval`` themselves (the tutorial's image/install cells do this).
+
+Three pieces, mirroring :mod:`.toolathlon`'s shape:
+
+- **Data** — :class:`BfclMultiTurnDataset` loads a BFCL multi-turn category (default:
+  ``BFCL_v4_multi_turn_base``) plus its ``possible_answer`` ground truth straight out of the installed
+  ``bfcl_eval`` package, flattens each task's per-turn ground-truth calls into one ordered sequence,
+  and replays it once (in-process) to capture the observation text for every step — the BFCL analogue
+  of Toolathlon's expert trajectory.
+- **Environment** — :class:`BfclTurnEnvironment` holds one fresh set of live class instances per
+  episode (no global/module-level caching, unlike upstream's own
+  ``execute_multi_turn_func_call`` — that caching is unsafe for concurrent online rollouts of the same
+  task) and exposes the same ``step``/``evaluate`` shape as :mod:`.base`. Grading reuses ``bfcl_eval``'s
+  own ``state_checker``/``response_checker`` rather than reimplementing them.
+- **Prompting** — :func:`build_prefix_messages` / :func:`tool_schemas_to_openai` mirror the Toolathlon
+  helpers of the same name, so a caller can swap one environment for the other with minimal churn.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import os
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+from modal_training_gym.common.dataset import DatasetConfig
+from modal_training_gym.common.environments.base import (
+    EvalVerdict,
+    Environment,
+    Observation,
+    StepResult,
+    ToolCall,
+)
+
+DEFAULT_CATEGORY = "BFCL_v4_multi_turn_base"
+# The leaderboard ships no train/eval split (it's a benchmark, not a training set), so we carve our
+# own: the last N ids of the category are held out for eval.
+DEFAULT_EVAL_TAIL = 30
+
+# BFCL has no explicit "done" tool — a turn simply ends when the model stops emitting calls. Kept
+# (empty) for interface parity with callers that special-case Toolathlon's ``DONE_TOOLS``.
+DONE_TOOLS: frozenset[str] = frozenset()
+
+_JSON_TYPE_MAP = {
+    "dict": "object",
+    "list": "array",
+    "tuple": "array",
+    "float": "number",
+    "integer": "integer",
+    "string": "string",
+    "boolean": "boolean",
+}
+
+
+def _bfcl_eval():
+    """Import ``bfcl_eval`` lazily (see module docstring)."""
+    try:
+        import bfcl_eval
+    except ImportError as e:
+        raise ImportError(
+            "This requires the `bfcl-eval` package (`uv pip install bfcl-eval`); "
+            "see https://pypi.org/project/bfcl-eval/."
+        ) from e
+    return bfcl_eval
+
+
+def _backend_mappings() -> tuple[dict[str, str], dict[str, str], list[str]]:
+    from bfcl_eval.constants.executable_backend_config import (
+        CLASS_FILE_PATH_MAPPING,
+        MULTI_TURN_FUNC_DOC_FILE_MAPPING,
+        STATELESS_CLASSES,
+    )
+
+    return CLASS_FILE_PATH_MAPPING, MULTI_TURN_FUNC_DOC_FILE_MAPPING, STATELESS_CLASSES
+
+
+def _data_dir() -> str:
+    bfcl_eval = _bfcl_eval()
+    return os.path.join(os.path.dirname(bfcl_eval.__file__), "data")
+
+
+def _load_jsonl(path: str) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# ── Call-string <-> dict ─────────────────────────────────────────────────────
+
+
+def parse_call_string(call: str) -> dict[str, Any]:
+    """Parse a BFCL ground-truth call string (e.g. ``"mv(source='a', destination='b')"`` or the
+    positional ``"cd('archives')"``) into ``{"name": str, "arguments": dict}``.
+
+    Ground-truth call strings are always a single call with literal/keyword arguments, so
+    ``ast.literal_eval`` per-argument is sufficient — and, unlike upstream's ``eval()``-based
+    execution helpers, this never executes arbitrary code.
+    """
+    node = ast.parse(call.strip(), mode="eval").body
+    if not isinstance(node, ast.Call):
+        raise ValueError(f"Not a call expression: {call!r}")
+    name = node.func.id if isinstance(node.func, ast.Name) else ast.unparse(node.func)
+    arguments: dict[str, Any] = {
+        f"_pos{i}": ast.literal_eval(arg) for i, arg in enumerate(node.args)
+    }
+    for kw in node.keywords:
+        arguments[kw.arg] = ast.literal_eval(kw.value)
+    return {"name": name, "arguments": arguments}
+
+
+def _normalize_arguments(
+    owner: Any, name: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Resolve ``_posN`` placeholders (from positional ground-truth calls) to real keyword names
+    using ``owner``'s live method signature, so stored calls are always keyword-args (clean to show
+    a model in a tool-call message and to re-execute later)."""
+    positional = sorted(
+        ((k, v) for k, v in arguments.items() if k.startswith("_pos")),
+        key=lambda kv: int(kv[0][4:]),
+    )
+    if not positional:
+        return arguments
+    try:
+        param_names = [
+            p for p in inspect.signature(getattr(owner, name)).parameters if p != "self"
+        ]
+    except (TypeError, ValueError):
+        param_names = []
+    normalized = dict(zip(param_names, (v for _, v in positional)))
+    normalized.update({k: v for k, v in arguments.items() if not k.startswith("_pos")})
+    return normalized
+
+
+# ── Execution ────────────────────────────────────────────────────────────────
+
+
+def _instantiate(
+    class_name: str, initial_config: dict, *, long_context: bool = False
+) -> Any:
+    import importlib
+
+    class_file_path_mapping, _, stateless_classes = _backend_mappings()
+    module = importlib.import_module(class_file_path_mapping[class_name])
+    instance = getattr(module, class_name)()
+    if class_name not in stateless_classes:
+        instance._load_scenario(
+            deepcopy(initial_config.get(class_name, {})), long_context=long_context
+        )
+    return instance
+
+
+def build_instances(
+    involved_classes: list[str], initial_config: dict
+) -> dict[str, Any]:
+    """One fresh instance per involved class.
+
+    Unlike upstream's ``execute_multi_turn_func_call`` — which memoizes instances in module
+    ``globals()`` keyed by ``(model_name, test_entry_id, class_name)`` for its offline batch-eval
+    harness — this always builds fresh instances, which is the correct (and only safe) behavior for
+    concurrent online rollouts that may replay the same task at the same time.
+    """
+    return {name: _instantiate(name, initial_config) for name in involved_classes}
+
+
+def _method_owner(instances: dict[str, Any], method_name: str) -> Any | None:
+    if method_name.startswith("_"):
+        return None
+    for instance in instances.values():
+        if hasattr(type(instance), method_name):
+            return instance
+    return None
+
+
+def _stringify(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    if isinstance(result, dict):
+        try:
+            return json.dumps(result)
+        except TypeError:
+            return str(result)
+    return str(result)
+
+
+def execute_call(instances: dict[str, Any], call: dict[str, Any]) -> tuple[str, bool]:
+    """Run one ``{"name", "arguments"}`` call against ``instances``. Returns ``(result_text,
+    is_error)``. ``arguments`` must already be a plain keyword dict (no ``_posN`` placeholders) —
+    student-generated calls always are; ground-truth calls are normalized once during :func:`replay`.
+
+    Arguments are deep-copied before the call: some upstream BFCL methods store a list/dict argument
+    by reference into instance state (e.g. ``TwitterAPI.post_tweet``'s ``mentions=[]`` default), so a
+    caller that reuses the same argument object across multiple ``step()`` calls (or across two
+    environments) would otherwise silently corrupt unrelated state through that aliasing.
+    """
+    owner = _method_owner(instances, call["name"])
+    if owner is None:
+        return f"Error during execution: unknown function {call['name']!r}", True
+    try:
+        result = getattr(owner, call["name"])(**deepcopy(call.get("arguments") or {}))
+        return _stringify(result), False
+    except Exception as e:  # mirrors upstream's eval()-based catch-all
+        return f"Error during execution: {e}", True
+
+
+def replay(
+    involved_classes: list[str], initial_config: dict, calls: list[dict[str, Any]]
+) -> tuple[dict[str, Any], list[str]]:
+    """Fresh instances + the observation text for each of ``calls``, executed in order.
+
+    Mutates each ``call["arguments"]`` in place to resolve any ``_posN`` placeholders to real keyword
+    names (see :func:`_normalize_arguments`), so callers that pass in freshly-parsed ground-truth
+    calls get back clean, display-ready call dicts as a side effect.
+    """
+    instances = build_instances(involved_classes, initial_config)
+    observations = []
+    for call in calls:
+        owner = _method_owner(instances, call["name"])
+        if owner is not None:
+            call["arguments"] = _normalize_arguments(
+                owner, call["name"], call.get("arguments") or {}
+            )
+        text, _is_error = execute_call(instances, call)
+        observations.append(text)
+    return instances, observations
+
+
+# ── Tool schemas ─────────────────────────────────────────────────────────────
+
+
+def to_json_schema(node: Any) -> Any:
+    """Recursively convert a BFCL func-doc schema fragment (``dict``/``list`` typed) to JSON-Schema
+    typing (``object``/``array``), e.g. for use with the ``jsonschema`` package."""
+    if isinstance(node, dict):
+        out = {k: to_json_schema(v) for k, v in node.items() if k != "default"}
+        if out.get("type") in _JSON_TYPE_MAP:
+            out["type"] = _JSON_TYPE_MAP[out["type"]]
+        return out
+    if isinstance(node, list):
+        return [to_json_schema(v) for v in node]
+    return node
+
+
+def tool_schemas_to_openai(tool_schemas: dict) -> list[dict]:
+    """Render ``{name: {"description", "parameters"}}`` (BFCL's func-doc shape) as the OpenAI
+    ``tools=`` list a chat template expects, converting BFCL's ``dict``/``list`` JSON types to
+    JSON-Schema's ``object``/``array``."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": spec.get("description", ""),
+                "parameters": to_json_schema(spec.get("parameters", {})),
+            },
+        }
+        for name, spec in (tool_schemas or {}).items()
+    ]
+
+
+def load_func_docs(
+    involved_classes: list[str], excluded_function: list[str] | None = None
+) -> dict:
+    """The BFCL function docs for ``involved_classes``, minus any ``excluded_function`` (BFCL omits
+    these from the offered catalog when an equivalent function already covers the same ground truth,
+    e.g. excluding ``cp`` when the task is solved with ``mv``)."""
+    _, doc_file_mapping, _ = _backend_mappings()
+    excluded = set(excluded_function or [])
+    data_dir = _data_dir()
+    schemas: dict[str, dict] = {}
+    for class_name in involved_classes:
+        doc_file = doc_file_mapping.get(class_name)
+        if not doc_file:
+            continue
+        for doc in _load_jsonl(os.path.join(data_dir, "multi_turn_func_doc", doc_file)):
+            if doc["name"] in excluded:
+                continue
+            schemas[doc["name"]] = {
+                "description": doc.get("description", ""),
+                "parameters": doc.get("parameters", {}),
+            }
+    return schemas
+
+
+# ── Prompt-prefix reconstruction ────────────────────────────────────────────
+
+DEFAULT_SYSTEM_PROMPT = """\
+You are a tool-using agent completing a user's request with the function tools provided to you. Work one step at a time.
+
+Rules:
+- Make EXACTLY ONE tool call per turn. Emit only the tool call — no extra prose, narration, or markdown fences around it.
+- Use only the tools provided to you, with their exact names. Do not invent tools, arguments, or file paths.
+- Each user message may require several tool calls before the request is satisfied; keep calling tools until the request is complete, then stop calling tools.
+- After each tool result, check whether it succeeded before continuing; do not blindly repeat a failed call with the same arguments.
+
+Emit every tool call in exactly this format — a single <function> block wrapped in <emoji>, with one <parameter> block per argument. For example, a real call that moves a file (values abbreviated with … here) looks like:
+
+<emoji>
+<function=mv>
+<parameter=source>
+final_report.pdf
+</parameter>
+<parameter=destination>
+temp
+</parameter>
+</function>
+</emoji>
+
+Use the actual tool name, parameters, and full (untruncated) values required by your task; the call above is only an illustration of the wire format."""
+
+
+def render_tool_catalog(tool_schemas: dict, desc_chars: int = 160) -> str:
+    """Render the available-tools catalog as ``name(arg, required*)`` lines + a short description."""
+    lines = []
+    for name in sorted(tool_schemas or {}):
+        spec = tool_schemas[name]
+        desc, params = spec.get("description", ""), spec.get("parameters", {})
+        props = (params or {}).get("properties", {}) if isinstance(params, dict) else {}
+        required = (
+            set((params or {}).get("required", []) or [])
+            if isinstance(params, dict)
+            else set()
+        )
+        sig = ", ".join(f"{k}*" if k in required else k for k in props)
+        lines.append(f"- {name}({sig}): {desc[:desc_chars]}")
+    return "\n".join(lines)
+
+
+def default_system_prompt(tool_schemas: dict) -> str:
+    return f"{DEFAULT_SYSTEM_PROMPT}\n\nAvailable tools:\n{render_tool_catalog(tool_schemas)}"
+
+
+def build_prefix_messages(label: dict, K: int, *, obs_limit: int = 1500) -> list[dict]:
+    """Reconstruct the chat-message prefix after the first ``K`` ground-truth calls have happened.
+
+    Walks BFCL's turns in order, emitting each turn's user message followed by an assistant
+    tool-call + tool-result pair for every ground-truth call in that turn that falls within the
+    first ``K`` calls overall. Stops as soon as ``K`` calls have been shown — which may land exactly
+    on a fresh, not-yet-acted-on user turn, or mid-turn.
+    """
+    observations = label.get("observations")
+    if observations is None:
+        _, observations = replay(
+            label["involved_classes"],
+            label["initial_config"],
+            deepcopy(label["flattened_calls"]),
+        )
+    messages = [
+        {
+            "role": "system",
+            "content": default_system_prompt(label.get("tool_schemas", {})),
+        }
+    ]
+    shown = 0
+    for turn in label["turns"]:
+        messages.append({"role": "user", "content": turn["user"]})
+        for call in turn["calls"]:
+            if shown >= K:
+                return messages
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": f"call_{shown}",
+                            "type": "function",
+                            "function": {
+                                "name": call["name"],
+                                # A raw dict, not a JSON string: this prefix is fed straight to
+                                # ``tokenizer.apply_chat_template`` (not an OpenAI-compatible HTTP
+                                # API layer that would parse a JSON string first), and Qwen3.6's
+                                # chat template iterates arguments with Jinja's ``|items`` filter,
+                                # which requires an actual mapping (mirrors
+                                # ``.toolathlon.build_prefix_messages``'s convention).
+                                "arguments": call["arguments"],
+                            },
+                        }
+                    ],
+                }
+            )
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": f"call_{shown}",
+                    "content": str(observations[shown])[:obs_limit],
+                }
+            )
+            shown += 1
+    return messages
+
+
+def prune_prefix(messages: list[dict], max_messages: int) -> list[dict]:
+    """Keep the system + first user message and the most recent ``max_messages`` exchanges —
+    mirrors :func:`.toolathlon.prune_prefix`'s role, for callers that need to budget context length."""
+    if len(messages) <= max_messages:
+        return messages
+    head = messages[:2]
+    tail = messages[-(max_messages - len(head)) :]
+    return head + tail
+
+
+# ── Environment ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class BfclTurnEnvironment(Environment):
+    """One live multi-turn BFCL episode: a set of in-process class instances seeded by replaying the
+    first ``K`` ground-truth calls, then driven forward by an agent's own tool calls via :meth:`step`.
+    """
+
+    label: dict
+    instances: dict[str, Any] = field(default_factory=dict)
+    exec_results: list[str] = field(default_factory=list)
+    # How many ground-truth calls were already replayed to seed `instances` before this episode
+    # started (see `build_env`). Only the *remaining* ground-truth responses (from this index
+    # onward) need to show up in `exec_results` — the prefix was identical by construction.
+    K: int = 0
+
+    def step(self, action: ToolCall) -> StepResult:
+        call = {"name": action.name, "arguments": action.arguments or {}}
+        text, is_error = execute_call(self.instances, call)
+        self.exec_results.append(text)
+        return StepResult(
+            observation=Observation(text=text, is_error=is_error), done=False
+        )
+
+    def evaluate(self) -> EvalVerdict:
+        """Grade the episode: deep state diff (``state_checker``) + response-subsequence check
+        (``response_checker``) against a freshly-replayed copy of the *full* ground-truth trajectory —
+        reusing ``bfcl_eval``'s own checkers rather than reimplementing them."""
+        from bfcl_eval.eval_checker.multi_turn_eval.multi_turn_checker import (
+            response_checker,
+            state_checker,
+        )
+
+        ground_truth_instances, ground_truth_results = replay(
+            self.label["involved_classes"],
+            self.label["initial_config"],
+            deepcopy(self.label["flattened_calls"]),
+        )
+        state_result = state_checker(self.instances, ground_truth_instances)
+        if not state_result["valid"]:
+            return EvalVerdict(passed=False, detail=state_result["error_message"])
+        # The prefix (calls [0:K]) is identical for the model and ground truth by construction
+        # (both replayed it to seed state) — only what the agent did from K onward needs checking.
+        response_result = response_checker(
+            self.exec_results, ground_truth_results[self.K :], 0
+        )
+        if not response_result["valid"]:
+            return EvalVerdict(passed=False, detail=response_result["error_message"])
+        return EvalVerdict(passed=True)
+
+
+def build_env(label: dict, K: int) -> BfclTurnEnvironment:
+    """Build a fresh :class:`BfclTurnEnvironment` with state fast-forwarded through the first ``K``
+    ground-truth calls — the in-process analogue of restoring a Toolathlon directory snapshot."""
+    calls = deepcopy(label["flattened_calls"][:K])
+    instances, _ = replay(label["involved_classes"], label["initial_config"], calls)
+    return BfclTurnEnvironment(label=label, instances=instances, K=K)
+
+
+# ── Trajectory dataset ───────────────────────────────────────────────────────
+
+
+def _first_user_text(turn_messages: list[dict]) -> str:
+    for m in turn_messages:
+        if m.get("role") == "user" and str(m.get("content", "")).strip():
+            return str(m["content"])
+    return ""
+
+
+@dataclass(frozen=True)
+class BfclMultiTurnConfig:
+    """Which BFCL multi-turn category to load and how to carve a train/eval split out of it."""
+
+    category: str = DEFAULT_CATEGORY
+    eval_tail: int = DEFAULT_EVAL_TAIL
+    obs_limit: int = 1500
+
+
+DEFAULT_CONFIG = BfclMultiTurnConfig()
+
+
+class BfclMultiTurnDataset(DatasetConfig):
+    """Loads a BFCL multi-turn category straight out of the installed ``bfcl_eval`` package.
+
+    Each row's ``label`` carries everything the curriculum/rollout/reward code needs: the per-turn
+    user text, the (keyword-normalized) ground-truth calls flattened across all turns, the observation
+    text for each of those calls (so the K-step prefix never needs to re-execute anything), the tool
+    catalog for the task's involved classes, and the raw ``initial_config``/``involved_classes`` so an
+    episode can be rebuilt at any step. There is no train/eval split upstream (BFCL is a benchmark,
+    not a training set) — :attr:`config`.eval_tail ids are held out as eval.
+    """
+
+    input_key: str = "messages"
+    label_key: str = "label"
+    # `prepare()` writes JSON-lines (below); tell the launcher's data-path
+    # resolver (`SlimeRecipe._resolve_data_paths`, default: "parquet") to name
+    # the on-volume file `*.jsonl` accordingly — otherwise slime tries to read
+    # a JSON-lines file as Parquet and fails with "Parquet magic bytes not found".
+    output_format: str = "jsonl"
+
+    def __init__(
+        self,
+        split: str = "train",
+        config: BfclMultiTurnConfig = DEFAULT_CONFIG,
+        **kwargs: Any,
+    ) -> None:
+        self._split = split
+        self.config = config
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def _entries(self) -> list[dict]:
+        return _load_jsonl(os.path.join(_data_dir(), f"{self.config.category}.json"))
+
+    def _ground_truths(self) -> dict[str, list[list[str]]]:
+        path = os.path.join(
+            _data_dir(), "possible_answer", f"{self.config.category}.json"
+        )
+        return {e["id"]: e["ground_truth"] for e in _load_jsonl(path)}
+
+    def _ids_for_split(self, ids: list[str]) -> list[str]:
+        tail = self.config.eval_tail
+        if self._split == "eval":
+            return ids[-tail:] if tail else []
+        if self._split == "train":
+            return ids[:-tail] if tail else list(ids)
+        return ids
+
+    def _make_row(self, entry: dict, ground_truth: list[list[str]]) -> dict:
+        turns = [
+            {
+                "user": _first_user_text(turn_messages),
+                "calls": [parse_call_string(c) for c in calls],
+            }
+            for turn_messages, calls in zip(entry["question"], ground_truth)
+        ]
+        flattened_calls = [c for turn in turns for c in turn["calls"]]
+        _, observations = replay(
+            entry["involved_classes"], entry["initial_config"], flattened_calls
+        )
+        label = {
+            "task_id": entry["id"],
+            "initial_config": entry["initial_config"],
+            "involved_classes": entry["involved_classes"],
+            "excluded_function": entry.get("excluded_function", []),
+            "turns": [{"user": t["user"], "calls": t["calls"]} for t in turns],
+            "flattened_calls": flattened_calls,
+            "observations": [str(o)[: self.config.obs_limit] for o in observations],
+            "tool_schemas": load_func_docs(
+                entry["involved_classes"], entry.get("excluded_function")
+            ),
+            "total_steps": len(flattened_calls),
+        }
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a tool-calling agent. Output a JSON tool call.",
+            },
+            {"role": "user", "content": turns[0]["user"] if turns else ""},
+        ]
+        return {"messages": messages, "label": json.dumps(label)}
+
+    def _load_split(self) -> list[dict]:
+        entries_by_id = {e["id"]: e for e in self._entries()}
+        gt_by_id = self._ground_truths()
+        ids = self._ids_for_split(list(entries_by_id.keys()))
+        return [
+            self._make_row(entries_by_id[i], gt_by_id[i])
+            for i in ids
+            if i in entries_by_id and i in gt_by_id and gt_by_id[i] and any(gt_by_id[i])
+        ]
+
+    def load(self, split: str = "all") -> list[dict]:
+        if split in ("train", "eval"):
+            self._split = split
+        return self._load_split()
+
+    def prepare(self, path: str, eval_paths: dict | None = None) -> None:
+        rows = self._load_split()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.writelines(json.dumps(r) + "\n" for r in rows)

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -263,21 +263,7 @@ Rules:
 - Use only the tools provided to you, with their exact names. Do not invent tools, arguments, or file paths.
 - Each user message may require several tool calls before the request is satisfied; keep calling tools until the request is complete, then stop calling tools.
 - After each tool result, check whether it succeeded before continuing; do not blindly repeat a failed call with the same arguments.
-
-Emit every tool call in exactly this format — a single <function> block wrapped in <emoji>, with one <parameter> block per argument. For example, a real call that moves a file (values abbreviated with … here) looks like:
-
-<emoji>
-<function=mv>
-<parameter=source>
-final_report.pdf
-</parameter>
-<parameter=destination>
-temp
-</parameter>
-</function>
-</emoji>
-
-Use the actual tool name, parameters, and full (untruncated) values required by your task; the call above is only an illustration of the wire format."""
+Use the model's provided tool-calling interface."""
 
 
 def default_system_prompt(tool_schemas: dict) -> str:
@@ -591,6 +577,7 @@ class BfclMultiTurnDataset(DatasetConfig):
         **kwargs: Any,
     ) -> None:
         self._split = split
+        self.hf_split = split
         self.config = config if config is not None else BfclMultiTurnConfig()
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -663,6 +650,7 @@ class BfclMultiTurnDataset(DatasetConfig):
     def load(self, split: str = "all") -> list[dict]:
         if split in ("train", "eval"):
             self._split = split
+            self.hf_split = split
         return self._load_split()
 
     def prepare(self, path: str, eval_paths: dict | None = None) -> None:

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -676,6 +676,7 @@ class ToolathlonTrajectoryDataset(DatasetConfig):
     label_key = "label"
     output_format = "jsonl"
     apply_chat_template = True
+    writes_eval_paths = False
 
     hf_repo: str = "hkust-nlp/Toolathlon-Trajectories"
     source_file: str = "deepseek-v3.2-exp_1.jsonl"
@@ -821,12 +822,7 @@ class ToolathlonTrajectoryDataset(DatasetConfig):
         }
 
     def prepare(self, path: str, eval_paths: dict | None = None) -> None:
-        """Write this instance's split to ``path``.
-
-        ``eval_paths`` is ignored: train vs eval are separate dataset instances,
-        not companion files from one ``prepare()``. Recipe resolvers still invent
-        an ``eval.*`` path; validation skips missing files.
-        """
+        """Write this instance's split to ``path``. ``eval_paths`` is ignored."""
         import os
 
         del eval_paths

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -41,6 +41,8 @@ from modal_training_gym.common.environments.base import (
     SandboxEnvironmentPool,
     StepResult,
     ToolCall,
+    render_tool_catalog as render_tool_catalog,
+    tool_schemas_to_openai as tool_schemas_to_openai,
 )
 
 # MCP servers whose state is confined to the agent workspace (snapshot-safe "Tier A").
@@ -860,67 +862,10 @@ train-ticket-plan.json
 Use the actual tool name, parameters, and full (untruncated) values required by your task; the call above is only an illustration of the wire format."""
 
 
-def render_tool_catalog(tool_schemas: dict, desc_chars: int = 160) -> str:
-    """Render the available-tools catalog the agent must choose from.
-
-    The agent can't query the MCP servers itself (that's the host loop's job via tools/list + the
-    OpenAI tools= param), so we surface the exact catalog the expert saw. Compact: one line per tool —
-    ``name(arg, required*)`` + a short description.
-    """
-    lines = []
-    for name in sorted(tool_schemas or {}):
-        spec = tool_schemas[name]
-        # tolerate both {description, parameters} and bare parameters (older cached rows)
-        if isinstance(spec, dict) and ("parameters" in spec or "description" in spec):
-            desc, params = spec.get("description", ""), spec.get("parameters", {})
-        else:
-            desc, params = "", spec
-        props = (params or {}).get("properties", {}) if isinstance(params, dict) else {}
-        required = (
-            set((params or {}).get("required", []) or [])
-            if isinstance(params, dict)
-            else set()
-        )
-        sig = ", ".join(f"{k}*" if k in required else k for k in props)
-        desc = " ".join(str(desc).split())[:desc_chars]
-        lines.append(f"- {name}({sig})" + (f": {desc}" if desc else ""))
-    return "\n".join(lines)
-
-
 def default_system_prompt(tool_schemas: dict) -> str:
     """Behavioral rules only — the tool catalog travels via the chat template's
     ``tools=`` parameter (see :func:`tool_schemas_to_openai`), not prompt text."""
     return DEFAULT_SYSTEM_PROMPT
-
-
-def tool_schemas_to_openai(tool_schemas: dict) -> list[dict]:
-    """Convert the dataset's ``{name: {description, parameters}}`` map into the
-    OpenAI/HF ``tools=`` list.
-
-    Pass the result to ``tokenizer.apply_chat_template(..., tools=...)`` (training
-    rollouts) or as the ``tools`` field of a chat-completions request (eval), so the
-    model sees the catalog in its NATIVE tool-calling format instead of a hand-rendered
-    text catalog, and emits calls in the wire format its template was trained on.
-    """
-    tools = []
-    for name in sorted(tool_schemas or {}):
-        spec = tool_schemas[name]
-        # tolerate both {description, parameters} and bare parameters (older cached rows)
-        if isinstance(spec, dict) and ("parameters" in spec or "description" in spec):
-            desc, params = spec.get("description", ""), spec.get("parameters", {})
-        else:
-            desc, params = "", spec
-        tools.append(
-            {
-                "type": "function",
-                "function": {
-                    "name": name,
-                    "description": desc,
-                    "parameters": params or {"type": "object", "properties": {}},
-                },
-            }
-        )
-    return tools
 
 
 def build_prefix_messages(

--- a/modal_training_gym/common/environments/toolathlon.py
+++ b/modal_training_gym/common/environments/toolathlon.py
@@ -821,8 +821,15 @@ class ToolathlonTrajectoryDataset(DatasetConfig):
         }
 
     def prepare(self, path: str, eval_paths: dict | None = None) -> None:
+        """Write this instance's split to ``path``.
+
+        ``eval_paths`` is ignored: train vs eval are separate dataset instances,
+        not companion files from one ``prepare()``. Recipe resolvers still invent
+        an ``eval.*`` path; validation skips missing files.
+        """
         import os
 
+        del eval_paths
         rows = self._load_split()
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -221,13 +221,8 @@ def run_prepare_dataset(
         shutil.rmtree(data_dir, ignore_errors=True)
     dataset.prepare(prompt_data, eval_paths)
     dataset.validate_prepared(prompt_data)
-    # Resolvers always invent an ``eval.*`` path; some datasets (Toolathlon,
-    # BFCL) only materialize the train split and use a separate DatasetConfig
-    # for offline eval. Match slime/miles train prepare: validate only what
-    # actually exists.
     for ep in (eval_paths or {}).values():
-        if os.path.exists(ep):
-            dataset.validate_prepared(ep)
+        dataset.validate_prepared(ep)
     data_volume.commit()
 
 

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -221,8 +221,13 @@ def run_prepare_dataset(
         shutil.rmtree(data_dir, ignore_errors=True)
     dataset.prepare(prompt_data, eval_paths)
     dataset.validate_prepared(prompt_data)
+    # Resolvers always invent an ``eval.*`` path; some datasets (Toolathlon,
+    # BFCL) only materialize the train split and use a separate DatasetConfig
+    # for offline eval. Match slime/miles train prepare: validate only what
+    # actually exists.
     for ep in (eval_paths or {}).values():
-        dataset.validate_prepared(ep)
+        if os.path.exists(ep):
+            dataset.validate_prepared(ep)
     data_volume.commit()
 
 

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -539,8 +539,7 @@ def build_miles_app(
                 await data_volume.commit.aio()
             dataset.validate_prepared(prompt_data)
             for ep in (eval_paths or {}).values():
-                if os.path.exists(ep):
-                    dataset.validate_prepared(ep)
+                dataset.validate_prepared(ep)
 
         if cluster.is_head:
             try:

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -1138,8 +1138,7 @@ def build_slime_app(
                     await data_volume.commit.aio()
                 dataset.validate_prepared(prompt_data)
                 for ep in (eval_paths or {}).values():
-                    if os.path.exists(ep):
-                        dataset.validate_prepared(ep)
+                    dataset.validate_prepared(ep)
 
             await _set_framework_status_async(SlimeStatus.CONVERT_MODEL)
             prepare_slime_config(slime, model, tempfile.mkdtemp())

--- a/modal_training_gym/train_recipes/base.py
+++ b/modal_training_gym/train_recipes/base.py
@@ -45,8 +45,9 @@ class BaseTrainRecipe(ABC):
         ext = "jsonl" if fmt == "jsonl" else "parquet"
         split = getattr(ds, "hf_split", "train")
         prompt_data = f"{DATA_PATH}/{name}/{split}.{ext}"
-        eval_prompt_data = {"eval": f"{DATA_PATH}/{name}/eval.{ext}"}
-        return prompt_data, eval_prompt_data
+        if getattr(ds, "writes_eval_paths", True):
+            return prompt_data, {"eval": f"{DATA_PATH}/{name}/eval.{ext}"}
+        return prompt_data, None
 
     @classmethod
     def _dataset_to_fields(cls, ds: "DatasetConfig") -> dict[str, Any]:

--- a/tests/test_bfcl_episode.py
+++ b/tests/test_bfcl_episode.py
@@ -1,7 +1,3 @@
-from types import SimpleNamespace
-
-from modal_training_gym.common import deployment as deployment_module
-from modal_training_gym.common.deployment import ModelDeployment
 from modal_training_gym.common.environments import bfcl
 from modal_training_gym.common.environments.base import (
     EvalVerdict,
@@ -70,52 +66,11 @@ def test_run_bfcl_episode_executes_calls_and_appends_observations(monkeypatch) -
     assert result.first_call == {"name": "lookup", "arguments": {"key": "value"}}
     assert result.execution_successes == [True]
     assert environment.actions[0].name == "lookup"
+    assert generated_messages[1][-2]["tool_calls"][0]["function"]["arguments"] == {
+        "key": "value"
+    }
     assert generated_messages[1][-1] == {
         "role": "tool",
         "tool_call_id": "call_t0_0",
         "content": "result:lookup",
     }
-
-
-def test_model_deployment_chat_preserves_structured_message(monkeypatch) -> None:
-    structured_message = {
-        "content": "",
-        "tool_calls": [{"function": {"name": "lookup", "arguments": "{}"}}],
-    }
-
-    class _Response:
-        status_code = 200
-
-        @staticmethod
-        def raise_for_status() -> None:
-            return None
-
-        @staticmethod
-        def json() -> dict:
-            return {"choices": [{"message": structured_message}]}
-
-    request_body = {}
-
-    def post(url, *, json, timeout, headers):
-        request_body.update(json)
-        return _Response()
-
-    import requests
-
-    monkeypatch.setattr(requests, "post", post)
-    monkeypatch.setattr(deployment_module, "_modal_proxy_auth_headers", lambda: {})
-    deployment = ModelDeployment.model_construct(
-        deployment_id="test",
-        deployment_config=SimpleNamespace(served_model_name="test-model"),
-        url="https://example.test",
-    )
-
-    message = deployment.chat(
-        [{"role": "user", "content": "look it up"}],
-        ensure_ready=False,
-        tools=[{"type": "function", "function": {"name": "lookup"}}],
-    )
-
-    assert message == structured_message
-    assert request_body["model"] == "test-model"
-    assert request_body["tools"][0]["function"]["name"] == "lookup"

--- a/tests/test_bfcl_episode.py
+++ b/tests/test_bfcl_episode.py
@@ -77,6 +77,56 @@ def test_run_bfcl_episode_executes_calls_and_appends_observations(monkeypatch) -
     }
 
 
+def test_run_bfcl_episode_advances_to_later_user_turns(monkeypatch) -> None:
+    environment = _FakeEnvironment()
+    label = {
+        "turns": [
+            {"user": "first request", "calls": [{"name": "first"}]},
+            {"user": "second request", "calls": [{"name": "second"}]},
+        ]
+    }
+    monkeypatch.setattr(bfcl, "build_env", lambda label, start_step: environment)
+    monkeypatch.setattr(
+        bfcl,
+        "build_prefix_messages",
+        lambda label, start_step: [{"role": "user", "content": "first request"}],
+    )
+    monkeypatch.setattr(bfcl, "tool_schemas_to_openai", lambda schemas: [])
+
+    responses = iter(
+        [
+            {"content": "", "actions": [ToolCall(name="first", arguments={})]},
+            {"content": "first complete", "actions": []},
+            {"content": "", "actions": [ToolCall(name="second", arguments={})]},
+            {"content": "all complete", "actions": []},
+        ]
+    )
+    generated_messages: list[list[dict]] = []
+
+    def generate(messages: list[dict], tools: list[dict]) -> dict:
+        generated_messages.append(list(messages))
+        return next(responses)
+
+    result = bfcl.run_bfcl_episode(
+        label,
+        start_step=0,
+        generate=generate,
+        parse_response=lambda message: (
+            message["content"],
+            message["actions"],
+        ),
+        max_turns=4,
+    )
+
+    assert [action.name for action in environment.actions] == ["first", "second"]
+    assert generated_messages[2][-2:] == [
+        {"role": "assistant", "content": "first complete"},
+        {"role": "user", "content": "second request"},
+    ]
+    assert result.final_response == "all complete"
+    assert result.exit_reason == "no_further_calls"
+
+
 def test_bfcl_prompt_defers_to_model_tool_format() -> None:
     assert "<emoji>" not in bfcl.DEFAULT_SYSTEM_PROMPT
     assert "provided tool-calling interface" in bfcl.DEFAULT_SYSTEM_PROMPT

--- a/tests/test_bfcl_episode.py
+++ b/tests/test_bfcl_episode.py
@@ -5,6 +5,7 @@ from modal_training_gym.common.environments.base import (
     StepResult,
     ToolCall,
 )
+from modal_training_gym.train_recipes.base import BaseTrainRecipe
 
 
 class _FakeEnvironment:
@@ -74,3 +75,19 @@ def test_run_bfcl_episode_executes_calls_and_appends_observations(monkeypatch) -
         "tool_call_id": "call_t0_0",
         "content": "result:lookup",
     }
+
+
+def test_bfcl_prompt_defers_to_model_tool_format() -> None:
+    assert "<emoji>" not in bfcl.DEFAULT_SYSTEM_PROMPT
+    assert "provided tool-calling interface" in bfcl.DEFAULT_SYSTEM_PROMPT
+
+
+def test_bfcl_dataset_paths_are_split_specific() -> None:
+    train = bfcl.BfclMultiTurnDataset(split="train")
+    evaluation = bfcl.BfclMultiTurnDataset(split="eval")
+
+    train_path, _ = BaseTrainRecipe._resolve_data_paths(train)
+    eval_path, _ = BaseTrainRecipe._resolve_data_paths(evaluation)
+
+    assert train_path == "/data/BfclMultiTurnDataset/train.jsonl"
+    assert eval_path == "/data/BfclMultiTurnDataset/eval.jsonl"

--- a/tests/test_bfcl_episode.py
+++ b/tests/test_bfcl_episode.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+
+from modal_training_gym.common import deployment as deployment_module
+from modal_training_gym.common.deployment import ModelDeployment
+from modal_training_gym.common.environments import bfcl
+from modal_training_gym.common.environments.base import (
+    EvalVerdict,
+    Observation,
+    StepResult,
+    ToolCall,
+)
+
+
+class _FakeEnvironment:
+    def __init__(self) -> None:
+        self.actions: list[ToolCall] = []
+
+    def step(self, action: ToolCall) -> StepResult:
+        self.actions.append(action)
+        return StepResult(observation=Observation(text=f"result:{action.name}"))
+
+    def evaluate(self) -> EvalVerdict:
+        return EvalVerdict(passed=True)
+
+
+def test_run_bfcl_episode_executes_calls_and_appends_observations(monkeypatch) -> None:
+    environment = _FakeEnvironment()
+    monkeypatch.setattr(bfcl, "build_env", lambda label, start_step: environment)
+    monkeypatch.setattr(
+        bfcl,
+        "build_prefix_messages",
+        lambda label, start_step: [{"role": "user", "content": "start"}],
+    )
+    monkeypatch.setattr(
+        bfcl,
+        "tool_schemas_to_openai",
+        lambda schemas: [{"type": "function", "function": {"name": "lookup"}}],
+    )
+
+    responses = iter(
+        [
+            {
+                "content": "",
+                "actions": [ToolCall(name="lookup", arguments={"key": "value"})],
+            },
+            {"content": "done", "actions": []},
+        ]
+    )
+    generated_messages: list[list[dict]] = []
+
+    def generate(messages: list[dict], tools: list[dict]) -> dict:
+        generated_messages.append(list(messages))
+        assert tools[0]["function"]["name"] == "lookup"
+        return next(responses)
+
+    result = bfcl.run_bfcl_episode(
+        {},
+        start_step=2,
+        generate=generate,
+        parse_response=lambda message: (
+            message["content"],
+            message["actions"],
+        ),
+        max_turns=3,
+    )
+
+    assert result.verdict.passed
+    assert result.exit_reason == "no_further_calls"
+    assert result.final_response == "done"
+    assert result.first_call == {"name": "lookup", "arguments": {"key": "value"}}
+    assert result.execution_successes == [True]
+    assert environment.actions[0].name == "lookup"
+    assert generated_messages[1][-1] == {
+        "role": "tool",
+        "tool_call_id": "call_t0_0",
+        "content": "result:lookup",
+    }
+
+
+def test_model_deployment_chat_preserves_structured_message(monkeypatch) -> None:
+    structured_message = {
+        "content": "",
+        "tool_calls": [{"function": {"name": "lookup", "arguments": "{}"}}],
+    }
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+        @staticmethod
+        def json() -> dict:
+            return {"choices": [{"message": structured_message}]}
+
+    request_body = {}
+
+    def post(url, *, json, timeout, headers):
+        request_body.update(json)
+        return _Response()
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setattr(deployment_module, "_modal_proxy_auth_headers", lambda: {})
+    deployment = ModelDeployment.model_construct(
+        deployment_id="test",
+        deployment_config=SimpleNamespace(served_model_name="test-model"),
+        url="https://example.test",
+    )
+
+    message = deployment.chat(
+        [{"role": "user", "content": "look it up"}],
+        ensure_ready=False,
+        tools=[{"type": "function", "function": {"name": "lookup"}}],
+    )
+
+    assert message == structured_message
+    assert request_body["model"] == "test-model"
+    assert request_body["tools"][0]["function"]["name"] == "lookup"


### PR DESCRIPTION
## Summary
Add the BFCL v3/v4 multi-turn tool-calling [dataset](https://gorilla.cs.berkeley.edu/blogs/13_bfcl_v3_multi_turn.html) as an environment.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->