### PR TITLE
Extract shaped reward from Slime when sample.reward is non-scalar.

### DIFF
--- a/modal_training_gym/frameworks/slime/phase_reporting.py
+++ b/modal_training_gym/frameworks/slime/phase_reporting.py
@@ -69,7 +69,7 @@ from .sample_extraction import (
     _TRAJECTORY_MSG_CHARS_MAX as _TRAJECTORY_MSG_CHARS_MAX,
     _TRAJECTORY_SAMPLE_LIMIT_DEFAULT as _TRAJECTORY_SAMPLE_LIMIT_DEFAULT,
     _coerce_float as _coerce_float,
-    _coerce_score as _coerce_score,
+    _sample_score as _sample_score,
     _coerce_text as _coerce_text,
     _compact_trajectory_messages as _compact_trajectory_messages,
     _extract_audio_from_prompt as _extract_audio_from_prompt,

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -15,6 +15,8 @@ import json
 import os
 from typing import Any
 
+from modal_training_gym.common.sample import Sample
+
 # Import path of the run model's response parser (a (str) -> ParsedResponse
 # callable). The launcher exports it; the recorder resolves and applies it.
 RESPONSE_PARSER_PATH_ENV = "TRAINING_GYM_RESPONSE_PARSER_PATH"
@@ -76,36 +78,27 @@ def _coerce_text(value: Any) -> str:
 #
 #   sample.metadata["shaped_reward"] = float(task_score)
 #
+# Extraction maps that onto gym ``Sample.score``; do not grow gym Sample with
+# slime/OPD fields like ``reward: dict``.
 _SHAPED_REWARD_KEY = "shaped_reward"
 
 
-def _sample_score(sample: Any, reward: Any = None) -> float:
-    """Dashboard score for a slime sample.
+def _sample_score(sample: Sample, reward: float | None = None) -> float:
+    """Resolve gym :class:`~modal_training_gym.common.sample.Sample.score`.
 
     Resolution order:
 
-    1. Numeric ``reward`` / ``sample.reward`` (normal GRPO / post-process).
+    1. Numeric ``reward`` (normal GRPO / post-process).
     2. ``sample.metadata["shaped_reward"]`` — set this in custom generate/RM
-       when ``sample.reward`` must stay non-scalar until later (OPD teachers).
+       when the framework reward must stay non-scalar until later (OPD).
     3. ``0.0``.
     """
-    if reward is None:
-        if isinstance(sample, dict):
-            reward = sample.get("reward")
-        else:
-            reward = getattr(sample, "reward", None)
-    if isinstance(reward, (int, float)) and not isinstance(reward, bool):
+    if reward is not None:
         return float(reward)
 
-    meta: Any = None
-    if isinstance(sample, dict):
-        meta = sample.get("metadata")
-    else:
-        meta = getattr(sample, "metadata", None)
-    if isinstance(meta, dict):
-        value = meta.get(_SHAPED_REWARD_KEY)
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            return float(value)
+    value = sample.metadata.get(_SHAPED_REWARD_KEY)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
 
     return 0.0
 
@@ -518,8 +511,15 @@ def _sample_to_dict(
         metadata["image"] = image_uri
 
     response_text = _coerce_text(response)
+    # Score via gym Sample: numeric reward, else metadata["shaped_reward"] (OPD).
+    numeric_reward = (
+        float(reward)
+        if isinstance(reward, (int, float)) and not isinstance(reward, bool)
+        else None
+    )
+    score = _sample_score(Sample(metadata=metadata), numeric_reward)
     out: dict[str, Any] = {
-        "score": _sample_score(sample, reward),
+        "score": score,
         "prompt": _coerce_text(prompt),
         "response": response_text,
         "metadata": metadata,

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -84,7 +84,7 @@ _SHAPED_REWARD_KEY = "shaped_reward"
 
 
 def _sample_score(sample: Sample, reward: float | None = None) -> float:
-    """Resolve gym :class:`~modal_training_gym.common.sample.Sample.score`.
+    """Resolve reward score from a training gym Sample.
 
     Resolution order:
 

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -70,11 +70,44 @@ def _coerce_text(value: Any) -> str:
     return str(value)
 
 
-def _coerce_score(value: Any) -> float:
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
+# Metadata key for the dashboard score when ``sample.reward`` is not a float
+# yet (common with OPD: reward holds the teacher ``/generate`` payload until
+# post-process). Custom generate / RM hooks should set:
+#
+#   sample.metadata["shaped_reward"] = float(task_score)
+#
+_SHAPED_REWARD_KEY = "shaped_reward"
+
+
+def _sample_score(sample: Any, reward: Any = None) -> float:
+    """Dashboard score for a slime sample.
+
+    Resolution order:
+
+    1. Numeric ``reward`` / ``sample.reward`` (normal GRPO / post-process).
+    2. ``sample.metadata["shaped_reward"]`` — set this in custom generate/RM
+       when ``sample.reward`` must stay non-scalar until later (OPD teachers).
+    3. ``0.0``.
+    """
+    if reward is None:
+        if isinstance(sample, dict):
+            reward = sample.get("reward")
+        else:
+            reward = getattr(sample, "reward", None)
+    if isinstance(reward, (int, float)) and not isinstance(reward, bool):
+        return float(reward)
+
+    meta: Any = None
+    if isinstance(sample, dict):
+        meta = sample.get("metadata")
+    else:
+        meta = getattr(sample, "metadata", None)
+    if isinstance(meta, dict):
+        value = meta.get(_SHAPED_REWARD_KEY)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+
+    return 0.0
 
 
 _RESPONSE_PARSER: Any = None
@@ -425,7 +458,7 @@ def _sample_to_dict(
 
     prompt = get("prompt") if attrs is not None else get("prompt", "")
     response = get("response") if attrs is not None else get("response", "")
-    reward = get("reward") if attrs is not None else get("reward", 0.0)
+    reward = get("reward") if attrs is not None else get("reward", None)
 
     metadata: dict[str, Any] = {}
     for key in ("response_length", "prompt_length", "rollout_id", "rollout_idx"):
@@ -443,6 +476,8 @@ def _sample_to_dict(
             "eval_detail",
             "training_response_source",
             "training_assistant_turns",
+            _SHAPED_REWARD_KEY,
+            "task_passed",
         ):
             if key in sample_meta and sample_meta[key] is not None:
                 metadata[key] = sample_meta[key]
@@ -484,7 +519,7 @@ def _sample_to_dict(
 
     response_text = _coerce_text(response)
     out: dict[str, Any] = {
-        "score": _coerce_score(reward),
+        "score": _sample_score(sample, reward),
         "prompt": _coerce_text(prompt),
         "response": response_text,
         "metadata": metadata,

--- a/tests/test_opd_rollout_score.py
+++ b/tests/test_opd_rollout_score.py
@@ -3,48 +3,48 @@
 ``custom_rm`` returns the teacher ``/generate`` JSON as ``sample.reward`` until
 post-process. Gym's rollout reporter snapshots samples in that window, so hooks
 must stash ``metadata["shaped_reward"] = float(...)`` and score extraction
-reads that instead of treating the dict as ``0.0``.
+maps that onto gym :class:`~modal_training_gym.common.sample.Sample.score`.
 """
 
-from types import SimpleNamespace
-
+from modal_training_gym.common.sample import Sample
 from modal_training_gym.frameworks.slime.sample_extraction import (
     _sample_score,
     _sample_to_dict,
 )
 
+_OPD_TEACHER_PAYLOAD = {"text": "", "meta_info": {"input_token_logprobs": []}}
+
 
 def test_sample_score_prefers_numeric_reward():
-    sample = SimpleNamespace(reward=0.91, metadata={"shaped_reward": 0.1})
-    assert _sample_score(sample) == 0.91
+    sample = Sample(metadata={"shaped_reward": 0.1})
+    assert _sample_score(sample, reward=0.91) == 0.91
 
 
-def test_sample_score_falls_back_to_shaped_reward_when_reward_is_opd_dict():
-    sample = SimpleNamespace(
-        reward={"text": "", "meta_info": {"input_token_logprobs": []}},
-        metadata={"shaped_reward": 0.825, "task_passed": True},
-    )
+def test_sample_score_falls_back_to_shaped_reward():
+    sample = Sample(metadata={"shaped_reward": 0.825, "task_passed": True})
     assert _sample_score(sample) == 0.825
 
 
-def test_sample_score_returns_zero_for_dict_without_shaped_reward():
-    sample = SimpleNamespace(
-        reward={"meta_info": {"input_token_logprobs": []}},
-        metadata={},
-    )
-    assert _sample_score(sample) == 0.0
-    assert _sample_score(SimpleNamespace(reward=None, metadata=None)) == 0.0
+def test_sample_score_returns_zero_without_shaped_reward():
+    assert _sample_score(Sample()) == 0.0
 
 
-def test_sample_to_dict_uses_shaped_reward_for_opd():
-    sample = SimpleNamespace(
-        prompt="p",
-        response="r",
-        reward={"meta_info": {"input_token_logprobs": []}},
-        metadata={"shaped_reward": 0.71, "task_passed": False, "response_length": 12},
-        response_length=12,
-    )
-    out = _sample_to_dict(sample)
-    assert out["score"] == 0.71
-    assert out["metadata"]["shaped_reward"] == 0.71
-    assert out["metadata"]["task_passed"] is False
+def test_sample_to_dict_maps_shaped_reward_onto_gym_sample():
+    raw = {
+        "prompt": "p",
+        "response": "r",
+        "reward": _OPD_TEACHER_PAYLOAD,
+        "metadata": {
+            "shaped_reward": 0.71,
+            "task_passed": False,
+            "response_length": 12,
+        },
+        "response_length": 12,
+    }
+    sample = Sample.model_validate(_sample_to_dict(raw))
+    assert sample.score == 0.71
+    assert sample.prompt == "p"
+    assert sample.response == "r"
+    assert sample.metadata["shaped_reward"] == 0.71
+    assert sample.metadata["task_passed"] is False
+    assert sample.metadata["response_length"] == 12

--- a/tests/test_opd_rollout_score.py
+++ b/tests/test_opd_rollout_score.py
@@ -1,0 +1,50 @@
+"""OPD / cross-tokenizer rewards must not render as 0.0 on the dashboard.
+
+``custom_rm`` returns the teacher ``/generate`` JSON as ``sample.reward`` until
+post-process. Gym's rollout reporter snapshots samples in that window, so hooks
+must stash ``metadata["shaped_reward"] = float(...)`` and score extraction
+reads that instead of treating the dict as ``0.0``.
+"""
+
+from types import SimpleNamespace
+
+from modal_training_gym.frameworks.slime.sample_extraction import (
+    _sample_score,
+    _sample_to_dict,
+)
+
+
+def test_sample_score_prefers_numeric_reward():
+    sample = SimpleNamespace(reward=0.91, metadata={"shaped_reward": 0.1})
+    assert _sample_score(sample) == 0.91
+
+
+def test_sample_score_falls_back_to_shaped_reward_when_reward_is_opd_dict():
+    sample = SimpleNamespace(
+        reward={"text": "", "meta_info": {"input_token_logprobs": []}},
+        metadata={"shaped_reward": 0.825, "task_passed": True},
+    )
+    assert _sample_score(sample) == 0.825
+
+
+def test_sample_score_returns_zero_for_dict_without_shaped_reward():
+    sample = SimpleNamespace(
+        reward={"meta_info": {"input_token_logprobs": []}},
+        metadata={},
+    )
+    assert _sample_score(sample) == 0.0
+    assert _sample_score(SimpleNamespace(reward=None, metadata=None)) == 0.0
+
+
+def test_sample_to_dict_uses_shaped_reward_for_opd():
+    sample = SimpleNamespace(
+        prompt="p",
+        response="r",
+        reward={"meta_info": {"input_token_logprobs": []}},
+        metadata={"shaped_reward": 0.71, "task_passed": False, "response_length": 12},
+        response_length=12,
+    )
+    out = _sample_to_dict(sample)
+    assert out["score"] == 0.71
+    assert out["metadata"]["shaped_reward"] == 0.71
+    assert out["metadata"]["task_passed"] is False


### PR DESCRIPTION
In On-policy Distillation (OPD), the per-token teacher logprobs are attached on sample.reward instead of a normal scalar reward. 

Handle non-scalar rewards by accessing the "shaped_reward" on sample.metadata. Fixes error in Gym dashboard where non-zero rewards appear zero.

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->