### PR TITLE
Make entire area of table cells in training runs dashboard clickable

### DIFF
--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -1617,7 +1617,6 @@ table.training-runs-table td.row-open-cell {
   text-align: left;
   width: 100%;
   min-height: 40px;
-  height: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -1603,7 +1603,9 @@ table.training-runs-table td.row-open-cell {
 }
 
 .cell-open-button {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   box-sizing: border-box;
   border: 0;
   background: transparent;
@@ -1616,6 +1618,7 @@ table.training-runs-table td.row-open-cell {
   text-align: left;
   width: 100%;
   min-height: 40px;
+  height: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -1599,13 +1599,12 @@ table.training-runs-table tr.run-row:hover:not(.row-selected) td:first-child {
 }
 
 table.training-runs-table td.row-open-cell {
+  position: relative;
   padding: 0;
 }
 
 .cell-open-button {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  display: block;
   box-sizing: border-box;
   border: 0;
   background: transparent;
@@ -1630,7 +1629,18 @@ table.training-runs-table td.row-open-cell {
   color: var(--text-bright);
 }
 
+/* Make the entire table cell clickable */
+.cell-open-button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
 .cell-open-button:focus-visible {
+  outline: none;
+}
+
+.cell-open-button:focus-visible::after {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }


### PR DESCRIPTION
Previously, there were some areas of the training runs table that weren't clickable. This PR expands the clickable area to most of the table (except for the column containing the Expand and Open in Modal) buttons, so that clicking anywhere on the table navigates to the run detail page.

Before (clickable area highlighted):
<img width="353" height="101" alt="Screenshot 2026-07-10 at 10 28 43" src="https://github.com/user-attachments/assets/41c05a2d-70e1-46fb-a10c-6f363d11df72" />

After:
<img width="354" height="92" alt="Screenshot 2026-07-10 at 10 28 17" src="https://github.com/user-attachments/assets/3ae56c6a-128d-4215-89ba-264161a5c827" />