### PR TITLE
Fix scrolling, improve spacing on training run detail page

### DIFF
--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -845,7 +845,7 @@
   <div class="grid grid-cols-[232px_minmax(0,1fr)] min-h-0 bg-(--bg) max-[900px]:grid-cols-[1fr]">
     <Sidebar {navItems} {activePage} onNavigate={setActivePage} />
 
-    <main class="p-[16px_24px] max-[900px]:p-[24px]">
+    <main class="min-w-0">
       <DashboardHeader
         title={pageMeta[activePage].title}
         {statusText}

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -635,7 +635,7 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 16px;
+  padding: 10px 0;
   margin-bottom: -1px;
   border: 0;
   border-bottom: 2px solid transparent;
@@ -652,6 +652,7 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
 
 .tab:hover {
   color: var(--text-bright);
+  border-bottom-color: var(--muted);
 }
 
 .tab.tabs-active {
@@ -1694,12 +1695,11 @@ table.training-runs-table td.row-open-cell {
 
 /* ===== pages/TrainingRunDetailPage.svelte ===== */
 .detail {
-  padding: 0 0 24px;
   color: var(--text);
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 145px);
-  max-height: calc(100vh - 145px);
+  height: calc(100vh - 129px);
+  max-height: calc(100vh - 129px);
   min-height: 0;
   overflow: hidden;
 }
@@ -1741,30 +1741,28 @@ table.training-runs-table td.row-open-cell {
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding-top: 20px;
+  padding: 20px 24px 24px;
 }
 
 .summary-tab {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
-  gap: 32px;
-  align-items: start;
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
-  padding-top: 20px;
 }
 
 .summary-tab-main {
   min-height: 0;
+  max-height: 100%;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding-right: 4px;
+  padding: 20px 24px 24px;
 }
 
 .summary-tab-side {
   border-left: 1px solid var(--border, #2f2f2f);
-  padding-left: 24px;
+  padding: 20px 24px 24px;
   max-height: 100%;
   min-height: 0;
   overflow-y: auto;
@@ -1777,7 +1775,18 @@ table.training-runs-table td.row-open-cell {
   overflow-y: visible;
 }
 
+.detail.embedded .summary-tab {
+  gap: 32px;
+}
+
+.detail.embedded .tab-panel,
+.detail.embedded .summary-tab-main {
+  padding: 20px 0 0;
+  max-height: none;
+}
+
 .detail.embedded .summary-tab-side {
+  padding: 20px 0 0 24px;
   max-height: none;
   overflow-y: visible;
 }
@@ -1785,20 +1794,18 @@ table.training-runs-table td.row-open-cell {
 @media (max-width: 900px) {
   .summary-tab {
     grid-template-columns: 1fr;
-    gap: 20px;
     overflow-y: auto;
   }
 
   .summary-tab-main {
     overflow-y: visible;
-    padding-right: 0;
+    max-height: none;
+    padding-bottom: 20px;
   }
 
   .summary-tab-side {
     border-left: 0;
-    padding-left: 0;
     border-top: 1px solid var(--border, #2f2f2f);
-    padding-top: 16px;
     max-height: none;
     overflow-y: visible;
   }

--- a/dashboards/frontend/src/components/DashboardHeader.svelte
+++ b/dashboards/frontend/src/components/DashboardHeader.svelte
@@ -17,7 +17,7 @@
   });
 </script>
 
-<header class="flex justify-between items-center mb-[24px]">
+<header class="flex justify-between items-center p-[16px_24px_0] mb-[24px] max-[900px]:p-[24px_24px_0]">
   <h1 class="text-(--text) text-[24px] font-medium leading-[36px]">{title}</h1>
   <div class="flex items-center gap-[0.7rem]">
     {#if statusText}

--- a/dashboards/frontend/src/components/Tabs.svelte
+++ b/dashboards/frontend/src/components/Tabs.svelte
@@ -5,7 +5,7 @@
   let { tabs = [], active = $bindable() } = $props();
 </script>
 
-<div class="flex [border-bottom:1px_solid_var(--color-c-gray-10,#2f2f2f)]" role="tablist">
+<div class="flex shrink-0 p-[0_24px] [border-bottom:1px_solid_var(--color-c-gray-10,#2f2f2f)] gap-8" role="tablist">
   {#each tabs as tab (tab.value)}
     <button
       class="tab"

--- a/dashboards/frontend/src/pages/DeploymentsPage.svelte
+++ b/dashboards/frontend/src/pages/DeploymentsPage.svelte
@@ -312,7 +312,7 @@
 
 <svelte:window onclick={() => (statusMenuOpen = false)} />
 
-<section class="summary-sticky grid [grid-template-columns:repeat(3,minmax(0,1fr))] gap-[14px] mb-[24px] max-[1080px]:[grid-template-columns:repeat(2,minmax(0,1fr))] max-[760px]:[grid-template-columns:1fr]">
+<section class="summary-sticky grid [grid-template-columns:repeat(3,minmax(0,1fr))] gap-[14px] p-[0_24px] mb-[24px] max-[1080px]:[grid-template-columns:repeat(2,minmax(0,1fr))] max-[760px]:[grid-template-columns:1fr]">
   <article class="summary-card">
     <span class="summary-label">Total deployments</span>
     <strong>{allDeployments.length}</strong>
@@ -327,7 +327,7 @@
   </article>
 </section>
 
-<section class="[border:0] [background:transparent] grid [grid-template-columns:minmax(0,1fr)] min-h-[520px] p-0">
+<section class="[border:0] [background:transparent] grid [grid-template-columns:minmax(0,1fr)] min-h-[520px] p-[0_24px_16px] max-[900px]:pb-[24px]">
   <div class="min-w-0">
     <div class="[border-bottom:0] p-[0_0_24px] flex items-center gap-[0.4rem] max-[760px]:flex-col max-[760px]:items-stretch">
       <label class="inline-flex items-center gap-[8px] [border:1px_solid_var(--color-c-gray-10,#2f2f2f)] rounded-[6px] [background:transparent] w-[260px] p-[6px_8px] max-[760px]:w-full" aria-label="Search deployments">

--- a/dashboards/frontend/src/pages/EvalsPage.svelte
+++ b/dashboards/frontend/src/pages/EvalsPage.svelte
@@ -518,7 +518,7 @@
   }}
 />
 
-<section class="summary-sticky grid [grid-template-columns:repeat(3,minmax(0,1fr))] gap-[14px] mb-[24px] max-[1080px]:[grid-template-columns:repeat(2,minmax(0,1fr))] max-[900px]:[grid-template-columns:1fr]">
+<section class="summary-sticky grid [grid-template-columns:repeat(3,minmax(0,1fr))] gap-[14px] p-[0_24px] mb-[24px] max-[1080px]:[grid-template-columns:repeat(2,minmax(0,1fr))] max-[900px]:[grid-template-columns:1fr]">
   <article class="summary-card">
     <span class="summary-label">Total runs</span>
     <strong>{allEvals.length}</strong>
@@ -533,7 +533,7 @@
   </article>
 </section>
 
-<section class="[border:0] [background:transparent] p-0">
+<section class="[border:0] [background:transparent] p-[0_24px_16px] max-[900px]:pb-[24px]">
   <div class="mb-[24px] flex items-center gap-[0.4rem] max-[900px]:flex-col max-[900px]:[align-items:stretch]">
     <label class="inline-flex items-center gap-[0.42rem] [border:1px_solid_var(--border)] rounded-[7px] bg-(--panel) min-w-[220px] w-[min(320px,100%)] p-[0.24rem_0.55rem] max-[900px]:w-full" aria-label="Search eval runs">
       <span class="search-icon"><Search size={13} /></span>

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -152,7 +152,7 @@
   });
 </script>
 
-<section class="summary-sticky grid grid-cols-5 gap-[14px] mb-[24px] max-[900px]:grid-cols-2 max-[640px]:grid-cols-1">
+<section class="summary-sticky grid grid-cols-5 gap-[14px] p-[0_24px] mb-[24px] max-[900px]:grid-cols-2 max-[640px]:grid-cols-1">
   <article class="summary-card">
     <span class="summary-label">Total runs</span>
     <strong>{allRuns.length}</strong>
@@ -175,7 +175,7 @@
   </article>
 </section>
 
-<section class="[border:0] [background:transparent] flex flex-col gap-[24px] p-0">
+<section class="[border:0] [background:transparent] flex flex-col gap-[24px] p-[0_24px_16px] max-[900px]:pb-[24px]">
   <div class="m-0">
     <FilterBar
       {recipes}

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -721,7 +721,7 @@
 
 <section class="detail" class:embedded>
   {#if !embedded}
-    <header class="flex items-center justify-between mb-[16px]">
+    <header class="flex items-center justify-between p-[0_24px] mb-[16px]">
       <button class="inline-flex items-center gap-[6px] [background:none] [border:0] text-(--muted) cursor-pointer text-[13px] p-[4px_8px] rounded-[6px] hover:text-(--text) hover:bg-(--color-c-gray-10,#2f2f2f)" onclick={onBack}>
         <ArrowLeft size={14} strokeWidth={2.1} />
         <span>Back to runs</span>
@@ -760,10 +760,10 @@
   {/if}
 
   {#if !run}
-    <div class="detail-empty">Loading run {runId}…</div>
+    <div class="detail-empty px-[24px]">Loading run {runId}…</div>
   {:else}
     {#if !embedded}
-    <div class="flex items-center gap-[16px] mb-[16px]">
+    <div class="flex items-center gap-[16px] p-[0_24px] mb-[16px]">
       <h1 class="text-[22px] font-[600] text-(--text-bright) m-0 overflow-hidden text-ellipsis whitespace-nowrap" title={run.run_id}>{run.run_id}</h1>
       <StatusPill status={getStatus(run)} />
       {#if resumeBadge(run)}


### PR DESCRIPTION
Tweaks a few things on the training run detail page:
* Fixes scrolling the summary charts; previously, these simply overflowed off the page
* Makes the tab view appear full-bleed on the page, and adjusts the tab styling to better match tab bars on the Modal dashboard

<img width="1416" height="1028" alt="Screenshot 2026-07-10 at 13 47 32" src="https://github.com/user-attachments/assets/07283619-7cb0-4d9d-990e-78cca0870abd" />