### PR TITLE
Match no_save_optim configuration flag with no_load_optim flag.

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -1054,6 +1054,15 @@ def build_slime_app(
                     "resuming training from last saved iteration."
                 )
                 object.__setattr__(slime, "load", save_root)
+                # Weights-only checkpoints (``no_save_optim``) have no Adam state;
+                # Megatron will KeyError on state_dict["optimizer"] unless we skip it.
+                if getattr(slime, "no_save_optim", False) and not getattr(
+                    slime, "no_load_optim", False
+                ):
+                    print(
+                        "WARNING: no_save_optim=True — enabling no_load_optim for resume."
+                    )
+                    object.__setattr__(slime, "no_load_optim", True)
             elif (
                 slime.megatron_to_hf_mode == "bridge" and not slime.ref_load and _hf_ref
             ):

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -1028,6 +1028,7 @@ def build_slime_app(
             original_save = slime.save
             original_load = slime.load
             original_ref_load = slime.ref_load
+            original_no_load_optim = slime.no_load_optim
             object.__setattr__(slime, "save", save_root)
 
             # Resolve the local HF snapshot dir (used for bridge-mode load below).
@@ -1076,6 +1077,7 @@ def build_slime_app(
                 object.__setattr__(slime, "save", original_save)
                 object.__setattr__(slime, "load", original_load)
                 object.__setattr__(slime, "ref_load", original_ref_load)
+                object.__setattr__(slime, "no_load_optim", original_no_load_optim)
 
             phase_report_url = (
                 os.environ.get("TRAINING_GYM_FRAMEWORK_STATUS_URL")

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -1056,9 +1056,7 @@ def build_slime_app(
                 object.__setattr__(slime, "load", save_root)
                 # Weights-only checkpoints (``no_save_optim``) have no Adam state;
                 # Megatron will KeyError on state_dict["optimizer"] unless we skip it.
-                if getattr(slime, "no_save_optim", False) and not getattr(
-                    slime, "no_load_optim", False
-                ):
+                if slime.no_save_optim and not slime.no_load_optim:
                     print(
                         "WARNING: no_save_optim=True — enabling no_load_optim for resume."
                     )

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -218,6 +218,7 @@ class SlimeRecipe(BaseTrainRecipe):
     save: str = "/checkpoints"
     load: str = ""
     no_save_optim: bool = False
+    no_load_optim: bool = False
     megatron_to_hf_mode: str = ""
     use_fault_tolerance: bool = True
 


### PR DESCRIPTION
`no_save_optim=True` can help prevent OOMs when dumping Adam optimizer states onto host RAM. `no_load_optim` is `False` by default and causes a Megatron error when `no_save_optim=True`.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->