### PR TITLE
migrate vLLM serving to app.server

### DIFF
--- a/modal_training_gym/common/deployment.py
+++ b/modal_training_gym/common/deployment.py
@@ -246,16 +246,18 @@ class DeploymentConfig:
         )
 
         if recipe.recipe_type == DeployRecipeType.SGLANG:
-            server = getattr(app, "SGLangEndpoint", None)
-            if server is None and hasattr(app, "registered_functions"):
-                server = app.registered_functions.get("SGLangEndpoint")
-            if server is None:
-                raise RuntimeError(
-                    f"Deployed {self.app_name!r} but could not resolve SGLang endpoint server handle."
-                )
-            url = _run_coro(server.get_url())
+            server_attr = "SGLangEndpoint"
         else:
-            url = app.serve.get_web_url()
+            server_attr = "Server"
+        server = getattr(app, server_attr, None)
+        if server is None and hasattr(app, "registered_functions"):
+            server = app.registered_functions.get(server_attr)
+        if server is None:
+            raise RuntimeError(
+                f"Deployed {self.app_name!r} but could not resolve "
+                f"{server_attr} server handle."
+            )
+        url = _run_coro(server.get_url())
         modal_app_id = app.app_id
         modal_app_url = modal_app_dashboard_url(modal_app_id)
         if not url:

--- a/modal_training_gym/deploy_recipes/vllm_recipe/recipe.py
+++ b/modal_training_gym/deploy_recipes/vllm_recipe/recipe.py
@@ -22,6 +22,9 @@ class VllmRecipe(BaseDeployRecipe):
         Modal environment to deploy into. Default ``None``.
     deploy_strategy : str
         Modal deployment strategy. Default ``"rolling"``.
+    startup_timeout : int
+        Seconds the server container is allowed to spend in startup before
+        Modal kills it. Default ``1200`` (20 minutes).
     """
 
     recipe_type: DeployRecipeType = DeployRecipeType.VLLM
@@ -30,3 +33,4 @@ class VllmRecipe(BaseDeployRecipe):
     extra_vllm_args: list[str] | None = None
     environment_name: str | None = None
     deploy_strategy: str = "rolling"
+    startup_timeout: int = 20 * 60

--- a/modal_training_gym/deploy_recipes/vllm_recipe/serve_vllm.py
+++ b/modal_training_gym/deploy_recipes/vllm_recipe/serve_vllm.py
@@ -1,17 +1,16 @@
 """vLLM serving helper — builds a Modal app that hosts a model via vLLM.
 
-Thin wrapper around the canonical
-[Modal vLLM inference example](https://modal.com/docs/examples/vllm_inference):
-one `@modal.web_server`-decorated function that runs `vllm serve` and
-exposes the OpenAI-compatible chat-completions API at
-`https://<workspace>--<app_name>-serve.modal.run/v1/chat/completions`.
+The model is served by ``Server``, a Modal *server* class registered with
+``@app.server`` (Modal's low-latency routing service for inference workloads).
+The endpoint is the Modal class itself — its ``@modal.enter()`` starts the
+``vllm serve`` subprocess; its ``@modal.exit()`` updates deployment status.
 
-`model_path` accepts either:
-  - a **HuggingFace repo id** (e.g. `"Qwen/Qwen3-4B"`) — vLLM downloads
+``model_path`` accepts either:
+  - a **HuggingFace repo id** (e.g. ``"Qwen/Qwen3-4B"``) — vLLM downloads
     the weights from HF into the cache volume on first boot, or
   - an **absolute container path** to an HF-format checkpoint directory
-    (must contain `config.json`) — typically a subdirectory of a
-    training-checkpoints volume you pass via `checkpoints_volume`.
+    (must contain ``config.json``) — typically a subdirectory of a
+    training-checkpoints volume you pass via ``checkpoints_volume``.
 
 Deploy separately from the training app:
 
@@ -39,7 +38,6 @@ def build_vllm_serve_app(
     deployment_id: str | None = None,
 ) -> "App":
     import modal
-    import modal.experimental
     from modal import App, Image, Volume
 
     from modal_training_gym.common import hf_secrets
@@ -48,6 +46,7 @@ def build_vllm_serve_app(
     n_gpu = recipe.n_gpu or 1
     vllm_port = 8000
     vllm_version = "0.13.0"
+    startup_timeout = recipe.startup_timeout
 
     image = (
         Image.from_registry("nvidia/cuda:12.8.0-devel-ubuntu22.04", add_python="3.12")
@@ -85,22 +84,20 @@ def build_vllm_serve_app(
     _extra = list(recipe.extra_vllm_args or [])
     _deployment_id = deployment_id
 
-    @app.cls(
+    @app.server(
         image=image,
         gpu=f"{gpu}:{n_gpu}",
         scaledown_window=10 * 60,
-        timeout=24 * 60 * 60,
+        startup_timeout=startup_timeout,
         volumes=volumes,
         secrets=hf_secrets(),
         serialized=True,
         include_source=False,
-    )
-    @modal.experimental.http_server(
         port=vllm_port,
-        startup_timeout=10 * 60,
-        proxy_regions=["us-east"],
+        exit_grace_period=25,
+        routing_region="us-east",
+        target_concurrency=32,
     )
-    @modal.concurrent(target_inputs=32)
     class Server:
         @modal.enter()
         def startup(self):
@@ -152,4 +149,8 @@ def build_vllm_serve_app(
         setattr(app, tag, fn)
     for tag, cls in app.registered_classes.items():
         setattr(app, tag, cls)
+    # The decorator returns the `_Server` handle (carries `get_url()`); the
+    # entry in `registered_functions` is only its underlying Function. Bind the
+    # server itself so callers (e.g. deployment URL resolution) get `get_url`.
+    setattr(app, "Server", Server)
     return app


### PR DESCRIPTION
Tested via:

```bash
uv run python <<'PY'
import os

from modal_training_gym.common.config import load_proxy_auth
from modal_training_gym.common.deployment import DeploymentConfig
from modal_training_gym.common.modal_lifecycle import stop_app
from modal_training_gym.common.models import Qwen3_0_6B
from modal_training_gym.deploy_recipes.vllm_recipe import Qwen3_0_6b_VllmRecipe

assert load_proxy_auth(), "proxy auth missing"
os.environ["MODAL_ENVIRONMENT"] = "examples"

deployment = DeploymentConfig(
    model=Qwen3_0_6B(),
    recipe=Qwen3_0_6b_VllmRecipe(environment_name="examples"),
    app_name="tg-vllm-app-server-smoke",
    served_model_name=Qwen3_0_6B.model_name,
).serve()

deployment.wait_until_ready()

text = deployment.generate(
    "Reply with exactly OK.",
    ensure_ready=False,
    max_tokens=16,
    temperature=0,
    chat_template_kwargs={"enable_thinking": False},
)

stop_app(deployment.modal_app_id)
PY
```

Output:
```
Waiting for 'tg-vllm-app-server-smoke' — https://modal.com/id/ap-9S6Dbz6FN1SjMaqnHquWLP
[deployment] probe https://modal-labs-examples--tg-vllm-app-server-smoke-server.us-east.modal.direct/v1/models: HTTP 503
WARNING: could not auto-stop app ap-9S6Dbz6FN1SjMaqnHquWLP: 
```

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->