### PR TITLE
fix stop_app implementation

### DIFF
--- a/modal_training_gym/common/modal_lifecycle.py
+++ b/modal_training_gym/common/modal_lifecycle.py
@@ -65,15 +65,19 @@ def stop_app(app_id: str) -> None:
     if not app_id:
         return
     try:
-        import modal
+        from modal._utils.async_utils import synchronizer
+        from modal.client import _Client
         from modal_proto import api_pb2
 
-        with modal.Client.from_env() as client:
-            client.stub.AppStop(
+        async def _stop() -> None:
+            client = await _Client.from_env()
+            await client.stub.AppStop(
                 api_pb2.AppStopRequest(
                     app_id=app_id,
                     source=api_pb2.APP_STOP_SOURCE_PYTHON_CLIENT,
                 )
             )
+
+        synchronizer.create_blocking(_stop)()
     except Exception as exc:  # noqa: BLE001 — auto-stop is best-effort
-        print(f"WARNING: could not auto-stop app {app_id}: {exc}")
+        print(f"WARNING: could not auto-stop app {app_id}: {exc!r}")


### PR DESCRIPTION
# Summary

Fixed an issue with `_stop_app`:
1) `modal.Client.from_env()` returns Modal's process-wide singleton, which is already open. Entering it as a context manager re-runs _open(), which trips `assert self._stub is None` at `modal/client.py:142` (modal 1.5.1). A bare `AssertionError` stringifies to '', and the best-effort except printed that empty string.
2) Even without the `with`, `client.stub.AppStop(...)` on that client returns an un-awaited coroutine, so the stop still would not have executed.
<!-- devin-review-badge-begin -->

# Testing

Script:

```bash
uv run python <<'PY'
import os

from modal_training_gym.common.config import load_proxy_auth
from modal_training_gym.common.deployment import DeploymentConfig
from modal_training_gym.common.modal_lifecycle import stop_app
from modal_training_gym.common.models import Qwen3_0_6B
from modal_training_gym.deploy_recipes.sglang_recipe import Qwen3_0_6b_SglangRecipe

assert load_proxy_auth(), "proxy auth missing"
os.environ["MODAL_ENVIRONMENT"] = "examples"

deployment = DeploymentConfig(
    model=Qwen3_0_6B(),
    recipe=Qwen3_0_6b_SglangRecipe(environment_name="examples"),
    app_name="tg-sglang-stop-app-smoke",
    served_model_name=Qwen3_0_6B.model_name,
).serve()

stop_app(deployment.modal_app_id)
PY
```

Before:
```
WARNING: could not auto-stop app ap-U0TNuXetA4liiX4FSEVUC3:
```

After:
```
```
---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->