### PR TITLE
Add "group by" to training runs dashboard

### DIFF
--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -25,6 +25,7 @@
   let activeRecipes = $state(new Set());
   let activeStatuses = $state(new Set());
   let activeGroups = $state(new Set());
+  let trainingGroupBy = $state("none");
   // Recipe/status/group values we've seen across loads. New ones are
   // auto-enabled in the filters once; the user's selections are never reset by
   // a refresh.
@@ -432,6 +433,30 @@
       })
       .sort((a, b) => (b.created_at || 0) - (a.created_at || 0)),
   );
+
+  function trainingGroupKey(run, groupBy) {
+    if (groupBy === "group") return getGroup(run);
+    if (groupBy === "dataset") return safeText(run.config_summary?.dataset_name) || "(no dataset)";
+    if (groupBy === "model") return modelName(run);
+    return "";
+  }
+
+  // Buckets inherit filteredRuns' recency sort: groups come out ordered by
+  // newest member and runs stay sorted within each group.
+  let trainingRunGroups = $derived.by(() => {
+    if (trainingGroupBy === "none") return [];
+    const buckets = new Map();
+    for (const run of filteredRuns) {
+      const key = trainingGroupKey(run, trainingGroupBy);
+      if (!buckets.has(key)) buckets.set(key, []);
+      buckets.get(key).push(run);
+    }
+    return [...buckets].map(([key, runs]) => ({
+      key,
+      runs,
+      latestCreatedAt: runs[0]?.created_at || null,
+    }));
+  });
 
   let completedTotal = $derived(allRuns.filter((run) => run.train_result).length);
   let cancelledTotal = $derived(allRuns.filter((run) => getStatus(run) === "Cancelled").length);
@@ -882,6 +907,8 @@
         {groupCounts}
         {activeGroups}
         {filteredRuns}
+        runGroups={trainingRunGroups}
+        bind:groupBy={trainingGroupBy}
         {loading}
         {error}
         {modelName}

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -434,23 +434,19 @@
       .sort((a, b) => (b.created_at || 0) - (a.created_at || 0)),
   );
 
-  function trainingGroupKey(run, groupBy) {
-    if (groupBy === "group") return getGroup(run);
-    if (groupBy === "dataset") return safeText(run.config_summary?.dataset_name) || "(no dataset)";
-    if (groupBy === "model") return modelName(run);
-    return "";
-  }
+  const trainingGroupKeyFns = {
+    group: getGroup,
+    dataset: (run) => safeText(run.config_summary?.dataset_name) || "(no dataset)",
+    model: modelName,
+  };
+
+  const trainingGroupKey = (run, groupBy) => trainingGroupKeyFns[groupBy]?.(run) ?? "";
 
   // Buckets inherit filteredRuns' recency sort: groups come out ordered by
   // newest member and runs stay sorted within each group.
   let trainingRunGroups = $derived.by(() => {
     if (trainingGroupBy === "none") return [];
-    const buckets = new Map();
-    for (const run of filteredRuns) {
-      const key = trainingGroupKey(run, trainingGroupBy);
-      if (!buckets.has(key)) buckets.set(key, []);
-      buckets.get(key).push(run);
-    }
+    const buckets = Map.groupBy(filteredRuns, (run) => trainingGroupKey(run, trainingGroupBy));
     return [...buckets].map(([key, runs]) => ({
       key,
       runs,

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -265,6 +265,11 @@ h6 {
   font-feature-settings: "ss01" on;
 }
 
+button,
+input {
+  font: inherit;
+}
+
 /* ============================================================
    Component styles (moved from per-component <style> blocks)
    ============================================================ */
@@ -606,7 +611,6 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   color: var(--text);
   text-decoration: none;
   text-align: left;
-  font: inherit;
   font-size: 14px;
   font-weight: 500;
   line-height: 20px;
@@ -641,7 +645,6 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   border-bottom: 2px solid transparent;
   background: none;
   color: var(--muted);
-  font: inherit;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -706,7 +709,6 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   border-radius: 6px;
   background: var(--bg);
   color: var(--text);
-  font: inherit;
   font-size: 14px;
   font-weight: 500;
   padding: 6px 8px;
@@ -772,7 +774,6 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   border: 0;
   background: transparent;
   color: var(--text);
-  font: inherit;
   font-size: 0.73rem;
   text-align: left;
   padding: 0.3rem 0.38rem;
@@ -1430,7 +1431,6 @@ tr.framework-run-row:last-child td {
   background: transparent;
   color: color-mix(in srgb, var(--text) 86%, white);
   padding: 0;
-  font: inherit;
   font-size: 0.74rem;
   cursor: pointer;
   text-align: left;
@@ -1477,7 +1477,6 @@ tr.framework-run-row:last-child td {
   margin: 0;
   background: transparent;
   color: var(--muted);
-  font: inherit;
   font-size: 0.68rem;
   cursor: pointer;
 }
@@ -1506,7 +1505,6 @@ tr.framework-run-row:last-child td {
   grid-template-columns: 16px minmax(0, 1fr) auto;
   align-items: center;
   gap: 0.42rem;
-  font: inherit;
   font-size: 0.74rem;
   text-align: left;
   cursor: pointer;
@@ -1534,7 +1532,6 @@ tr.framework-run-row:last-child td {
   color: var(--text);
   width: 100%;
   min-width: 0;
-  font: inherit;
   font-size: 14px;
 }
 
@@ -1640,7 +1637,6 @@ table.training-runs-table td.row-open-cell {
   border: 0;
   background: transparent;
   color: var(--text);
-  font: inherit;
   font-size: 14px;
   line-height: 20px;
   cursor: pointer;
@@ -2109,7 +2105,6 @@ table.rollout-table td {
     border-radius: 7px;
     background: var(--panel);
     color: var(--text);
-    font: inherit;
     font-size: 0.76rem;
     padding: 0.25rem 0.58rem;
     cursor: pointer;
@@ -2282,7 +2277,6 @@ table.rollout-table td {
   border-radius: 6px;
   background: var(--bg);
   color: var(--text);
-  font: inherit;
   font-size: 14px;
   font-weight: 500;
   padding: 6px 8px;
@@ -2369,7 +2363,6 @@ table.deployments-table tr.row-selected td {
   align-items: center;
   justify-content: space-between;
   padding: 6px 8px;
-  font: inherit;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -815,6 +815,37 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   font-variant-numeric: tabular-nums;
 }
 
+.menu.menu-right {
+  left: auto;
+  right: 0;
+}
+
+.group-by-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  padding: 6px 8px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.group-by-button:focus {
+  outline: none;
+}
+
+.group-by-button:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--border-strong) 55%, transparent);
+}
+
+.group-by-value {
+  color: var(--text-bright);
+}
+
 @media (max-width: 980px) {
   .menu {
     min-width: 180px;

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -851,6 +851,27 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   min-width: 100px;
 }
 
+.group-section {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  overflow: hidden;
+}
+
+.group-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+  width: 100%;
+  border: 0;
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
 @media (max-width: 980px) {
   .menu {
     min-width: 180px;

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -847,6 +847,10 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   color: var(--text-bright);
 }
 
+.group-by-menu {
+  min-width: 100px;
+}
+
 @media (max-width: 980px) {
   .menu {
     min-width: 180px;

--- a/dashboards/frontend/src/components/FilterBar.svelte
+++ b/dashboards/frontend/src/components/FilterBar.svelte
@@ -33,6 +33,17 @@
   function toggleMenu(menu) {
     openMenu = openMenu === menu ? null : menu;
   }
+
+  const groupByOptions = [
+    { value: "none", label: "None" },
+    { value: "group", label: "Group" },
+    { value: "dataset", label: "Dataset" },
+    { value: "model", label: "Model" },
+  ];
+
+  let groupByLabel = $derived(
+    groupByOptions.find((option) => option.value === groupBy)?.label ?? "None",
+  );
 </script>
 
 <svelte:window onclick={() => (openMenu = null)} />
@@ -190,13 +201,44 @@
     {/if}
   </div>
 
-  <label class="ml-auto inline-flex items-center gap-[6px] text-(--muted) text-[12px] whitespace-nowrap">
-    Group by:
-    <select class="filter-button ghost-hover" bind:value={groupBy}>
-      <option value="none">None</option>
-      <option value="group">Group</option>
-      <option value="dataset">Dataset</option>
-      <option value="model">Model</option>
-    </select>
-  </label>
+  <div class="filterbar-menu-wrap ml-auto">
+    <button
+      class="group-by-button ghost-hover"
+      class:filterbar-open={openMenu === "groupBy"}
+      aria-haspopup="listbox"
+      aria-expanded={openMenu === "groupBy"}
+      onclick={(event) => {
+        event.stopPropagation();
+        toggleMenu("groupBy");
+      }}
+    >
+      <span>Group by:</span>
+      <span class="group-by-value">{groupByLabel}</span>
+      <span class="chevron" class:rotated={openMenu === "groupBy"}>
+        <ChevronDown size={12} />
+      </span>
+    </button>
+    {#if openMenu === "groupBy"}
+      <div class="menu menu-right group-by-menu" role="listbox">
+        {#each groupByOptions as option (option.value)}
+          <button
+            class="menu-item"
+            role="option"
+            aria-selected={groupBy === option.value}
+            onclick={() => {
+              groupBy = option.value;
+              openMenu = null;
+            }}
+          >
+            <span class="w-[14px] h-[14px] flex justify-center items-center">
+              {#if groupBy === option.value}
+                <Check size={11} />
+              {/if}
+            </span>
+            <span class="item-label">{option.label}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
 </nav>

--- a/dashboards/frontend/src/components/FilterBar.svelte
+++ b/dashboards/frontend/src/components/FilterBar.svelte
@@ -16,6 +16,7 @@
     activeGroups,
     allGroupsActive,
     search = $bindable(),
+    groupBy = $bindable(),
     onToggleRecipe,
     onSelectAllRecipes,
     onClearRecipes,
@@ -188,4 +189,14 @@
       </div>
     {/if}
   </div>
+
+  <label class="ml-auto inline-flex items-center gap-[6px] text-(--muted) text-[12px] whitespace-nowrap">
+    Group by:
+    <select class="filter-button ghost-hover" bind:value={groupBy}>
+      <option value="none">None</option>
+      <option value="group">Group</option>
+      <option value="dataset">Dataset</option>
+      <option value="model">Model</option>
+    </select>
+  </label>
 </nav>

--- a/dashboards/frontend/src/components/GroupSection.svelte
+++ b/dashboards/frontend/src/components/GroupSection.svelte
@@ -4,8 +4,8 @@
   let { title, subtitle, expanded, onToggle, meta, children } = $props();
 </script>
 
-<section class="[border:1px_solid_var(--border)] rounded-[8px] [background:transparent] overflow-hidden">
-  <button class="[border:0] w-full text-left [background:transparent] text-inherit cursor-pointer flex justify-between items-center gap-[0.8rem] p-[0.75rem_0.9rem]" onclick={onToggle}>
+<section class="group-section">
+  <button class="group-section-header" onclick={onToggle}>
     <div class="min-w-0">
       <div class="text-(--text-bright) text-[0.86rem] [font-weight:600] overflow-hidden text-ellipsis whitespace-nowrap">{title}</div>
       <div class="text-(--muted) text-[0.74rem] overflow-hidden text-ellipsis whitespace-nowrap">{subtitle}</div>

--- a/dashboards/frontend/src/components/GroupSection.svelte
+++ b/dashboards/frontend/src/components/GroupSection.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { ChevronDown } from "lucide-svelte";
+
+  let { title, subtitle, expanded, onToggle, meta, children } = $props();
+</script>
+
+<section class="[border:1px_solid_var(--border)] rounded-[8px] [background:transparent] overflow-hidden">
+  <button class="[border:0] w-full text-left [background:transparent] text-inherit cursor-pointer flex justify-between items-center gap-[0.8rem] p-[0.75rem_0.9rem]" onclick={onToggle}>
+    <div class="min-w-0">
+      <div class="text-(--text-bright) text-[0.86rem] [font-weight:600] overflow-hidden text-ellipsis whitespace-nowrap">{title}</div>
+      <div class="text-(--muted) text-[0.74rem] overflow-hidden text-ellipsis whitespace-nowrap">{subtitle}</div>
+    </div>
+    <div class="flex items-center gap-[0.35rem] [flex-wrap:wrap] [justify-content:flex-end]">
+      {@render meta?.()}
+      <ChevronDown
+        size={14}
+        style={`color: var(--muted); transform: ${expanded ? "rotate(180deg)" : "rotate(0deg)"};`}
+      />
+    </div>
+  </button>
+
+  {#if expanded}
+    {@render children?.()}
+  {/if}
+</section>

--- a/dashboards/frontend/src/lib/set.js
+++ b/dashboards/frontend/src/lib/set.js
@@ -1,0 +1,8 @@
+// Returns a new Set with `key` toggled — added if absent, removed if present.
+// Reassign the result to a $state Set so Svelte picks up the change.
+export function toggleInSet(set, key) {
+  const next = new Set(set);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  return next;
+}

--- a/dashboards/frontend/src/pages/EvalsPage.svelte
+++ b/dashboards/frontend/src/pages/EvalsPage.svelte
@@ -16,6 +16,7 @@
   import ResizableTable from "../components/ResizableTable.svelte";
   import StatusPill from "../components/StatusPill.svelte";
   import TimeAgo from "../components/TimeAgo.svelte";
+  import { toggleInSet } from "../lib/set.js";
 
   let {
     allEvals,
@@ -258,10 +259,7 @@
   }
 
   function toggleGroup(evalConfigId) {
-    const next = new Set(expandedConfigIds);
-    if (next.has(evalConfigId)) next.delete(evalConfigId);
-    else next.add(evalConfigId);
-    expandedConfigIds = next;
+    expandedConfigIds = toggleInSet(expandedConfigIds, evalConfigId);
   }
 
   $effect(() => {
@@ -370,10 +368,7 @@
   });
 
   function toggleStatusFilter(status) {
-    const next = new Set(activeStatusFilters);
-    if (next.has(status)) next.delete(status);
-    else next.add(status);
-    activeStatusFilters = next;
+    activeStatusFilters = toggleInSet(activeStatusFilters, status);
   }
 
   function selectAllStatusFilters() {
@@ -385,10 +380,7 @@
   }
 
   function toggleDatasetFilter(dataset) {
-    const next = new Set(activeDatasetFilters);
-    if (next.has(dataset)) next.delete(dataset);
-    else next.add(dataset);
-    activeDatasetFilters = next;
+    activeDatasetFilters = toggleInSet(activeDatasetFilters, dataset);
   }
 
   function selectAllDatasetFilters() {
@@ -443,10 +435,7 @@
   }
 
   function toggleExample(index) {
-    const next = new Set(expandedExamples);
-    if (next.has(index)) next.delete(index);
-    else next.add(index);
-    expandedExamples = next;
+    expandedExamples = toggleInSet(expandedExamples, index);
   }
 
   let drawerRows = $derived.by(() => {

--- a/dashboards/frontend/src/pages/EvalsPage.svelte
+++ b/dashboards/frontend/src/pages/EvalsPage.svelte
@@ -11,6 +11,7 @@
   import ConversationView from "../components/ConversationView.svelte";
   import Drawer from "../components/Drawer.svelte";
   import FilterBulkActions from "../components/FilterBulkActions.svelte";
+  import GroupSection from "../components/GroupSection.svelte";
   import MinimalTableSkeleton from "../components/MinimalTableSkeleton.svelte";
   import ResizableTable from "../components/ResizableTable.svelte";
   import StatusPill from "../components/StatusPill.svelte";
@@ -685,93 +686,86 @@
           <div class="page-empty">No evals match the current filters.</div>
         {/if}
         {#each filteredGroups as group (group.evalConfigId)}
-          <section class="[border:1px_solid_var(--border)] rounded-[8px] [background:transparent] overflow-hidden">
-            <button class="[border:0] w-full text-left [background:transparent] text-inherit cursor-pointer flex justify-between items-center gap-[0.8rem] p-[0.75rem_0.9rem]" onclick={() => toggleGroup(group.evalConfigId)}>
-              <div class="min-w-0">
-                <div class="text-(--text-bright) text-[0.86rem] [font-weight:600] overflow-hidden text-ellipsis whitespace-nowrap">{group.evalConfigId || group.meta.dataset}</div>
-                <div class="text-(--muted) text-[0.74rem] overflow-hidden text-ellipsis whitespace-nowrap">{groupSubtitle(group)}</div>
-              </div>
-              <div class="flex items-center gap-[0.35rem] [flex-wrap:wrap] [justify-content:flex-end]">
-                {#if nonPlaceholderText(group.meta.model)}
-                  <span class="group-meta-pill">{group.meta.model}</span>
-                {/if}
-                {#if nonPlaceholderText(group.meta.split)}
-                  <span class="group-meta-pill">split: {group.meta.split}</span>
-                {/if}
-                <span class="group-meta-pill">total evals: {group.totalEvals}</span>
-                <span class="group-meta-pill">avg: {group.avgAccuracy.toFixed(4)}</span>
-                {#if group.latestCreatedAt}
-                  <span class="group-meta-pill [font-variant-numeric:tabular-nums]">
-                    <TimeAgo timestamp={group.latestCreatedAt} showJustNow falsyRepresentation="—" />
-                  </span>
-                {/if}
-                <ChevronDown
-                  size={14}
-                  style={`color: var(--muted); transform: ${expandedConfigIds.has(group.evalConfigId) ? "rotate(180deg)" : "rotate(0deg)"};`}
-                />
-              </div>
-            </button>
+          <GroupSection
+            title={group.evalConfigId || group.meta.dataset}
+            subtitle={groupSubtitle(group)}
+            expanded={expandedConfigIds.has(group.evalConfigId)}
+            onToggle={() => toggleGroup(group.evalConfigId)}
+          >
+            {#snippet meta()}
+              {#if nonPlaceholderText(group.meta.model)}
+                <span class="group-meta-pill">{group.meta.model}</span>
+              {/if}
+              {#if nonPlaceholderText(group.meta.split)}
+                <span class="group-meta-pill">split: {group.meta.split}</span>
+              {/if}
+              <span class="group-meta-pill">total evals: {group.totalEvals}</span>
+              <span class="group-meta-pill">avg: {group.avgAccuracy.toFixed(4)}</span>
+              {#if group.latestCreatedAt}
+                <span class="group-meta-pill [font-variant-numeric:tabular-nums]">
+                  <TimeAgo timestamp={group.latestCreatedAt} showJustNow falsyRepresentation="—" />
+                </span>
+              {/if}
+            {/snippet}
 
-            {#if expandedConfigIds.has(group.evalConfigId)}
-              <div class="table-wrap freeze-header" style="--frozen-table-offset: 360px;">
-                <ResizableTable class="evals-runs-table" columns={evalColumns} stickyFirstColumn>
-                  <tbody>
-                    {#each group.visibleRuns as run, runIndex (run.eval.eval_id || `${group.evalConfigId}-${run.eval.created_at || 0}-${runIndex}`)}
-                      {@const linkedDeployment = findDeploymentRow(run, group)}
-                      {@const deploymentName = evalDeploymentName(run, linkedDeployment)}
-                      {@const deploymentRef = deploymentRefValue(linkedDeployment)}
-                      {@const trainingRunId = linkedTrainingRunId(linkedDeployment)}
-                      {@const baseModel = evalBaseModel(run, group, linkedDeployment)}
-                      {@const dataset = groupDataset(group)}
-                      <tr
-                        class="eval-row-clickable"
-                        class:row-selected={selectedEval?.run?.eval?.eval_id === run.eval.eval_id}
-                        onclick={(event) => {
-                          if (event.target.closest(".cross-link")) return;
-                          openEvalDrawer(run, group);
-                        }}
-                      >
-                        <td class="evals-mono evals-name-cell" title={deploymentName}>
-                          <span class="truncate-text">{deploymentName}</span>
-                        </td>
-                        <td class="evals-dataset-cell" title={dataset}>
-                          <span class="truncate-text">{dataset}</span>
-                        </td>
-                        <td class="evals-mono evals-deployment-cell" title={deploymentRef || "—"}>
-                          <span class="truncate-text">{deploymentRef || "—"}</span>
-                        </td>
-                        <td class="max-w-0" title={trainingRunId || "—"}>
-                          {#if trainingRunId}
-                            <button
-                              class="cross-link"
-                              onclick={() => onOpenTrainingRun?.(trainingRunId)}
-                            >
-                              {trainingRunId}
-                            </button>
-                          {:else}
-                            —
-                          {/if}
-                        </td>
-                        <td class="base-model-cell" title={baseModel}>
-                          <span class="truncate-text">{baseModel}</span>
-                        </td>
-                        <td>
-                          <StatusPill status={run.pillStatus} label={run.statusLabel} />
-                        </td>
-                        <td class="text-(--text-bright) font-[600]">
-                          {run.status === "Failed" ? "—" : run.avgScore.toFixed(4)}
-                        </td>
-                        <td>{run.totalRows ? run.totalRows : "—"}</td>
-                        <td class="created-cell">
-                          <TimeAgo timestamp={run.createdAt} showJustNow falsyRepresentation="—" />
-                        </td>
-                      </tr>
-                    {/each}
-                  </tbody>
-                </ResizableTable>
-              </div>
-            {/if}
-          </section>
+            <div class="table-wrap freeze-header" style="--frozen-table-offset: 360px;">
+              <ResizableTable class="evals-runs-table" columns={evalColumns} stickyFirstColumn>
+                <tbody>
+                  {#each group.visibleRuns as run, runIndex (run.eval.eval_id || `${group.evalConfigId}-${run.eval.created_at || 0}-${runIndex}`)}
+                    {@const linkedDeployment = findDeploymentRow(run, group)}
+                    {@const deploymentName = evalDeploymentName(run, linkedDeployment)}
+                    {@const deploymentRef = deploymentRefValue(linkedDeployment)}
+                    {@const trainingRunId = linkedTrainingRunId(linkedDeployment)}
+                    {@const baseModel = evalBaseModel(run, group, linkedDeployment)}
+                    {@const dataset = groupDataset(group)}
+                    <tr
+                      class="eval-row-clickable"
+                      class:row-selected={selectedEval?.run?.eval?.eval_id === run.eval.eval_id}
+                      onclick={(event) => {
+                        if (event.target.closest(".cross-link")) return;
+                        openEvalDrawer(run, group);
+                      }}
+                    >
+                      <td class="evals-mono evals-name-cell" title={deploymentName}>
+                        <span class="truncate-text">{deploymentName}</span>
+                      </td>
+                      <td class="evals-dataset-cell" title={dataset}>
+                        <span class="truncate-text">{dataset}</span>
+                      </td>
+                      <td class="evals-mono evals-deployment-cell" title={deploymentRef || "—"}>
+                        <span class="truncate-text">{deploymentRef || "—"}</span>
+                      </td>
+                      <td class="max-w-0" title={trainingRunId || "—"}>
+                        {#if trainingRunId}
+                          <button
+                            class="cross-link"
+                            onclick={() => onOpenTrainingRun?.(trainingRunId)}
+                          >
+                            {trainingRunId}
+                          </button>
+                        {:else}
+                          —
+                        {/if}
+                      </td>
+                      <td class="base-model-cell" title={baseModel}>
+                        <span class="truncate-text">{baseModel}</span>
+                      </td>
+                      <td>
+                        <StatusPill status={run.pillStatus} label={run.statusLabel} />
+                      </td>
+                      <td class="text-(--text-bright) font-[600]">
+                        {run.status === "Failed" ? "—" : run.avgScore.toFixed(4)}
+                      </td>
+                      <td>{run.totalRows ? run.totalRows : "—"}</td>
+                      <td class="created-cell">
+                        <TimeAgo timestamp={run.createdAt} showJustNow falsyRepresentation="—" />
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </ResizableTable>
+            </div>
+          </GroupSection>
         {/each}
       </div>
     {/if}

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -154,8 +154,6 @@
     }
   });
 
-  const groupByLabels = { group: "Group", dataset: "Dataset", model: "Model" };
-
   // Inverted vs. evals' expanded set so groups default to expanded, including
   // ones that appear later via auto-refresh.
   let collapsedGroupKeys = $state(new Set());

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -3,6 +3,7 @@
   import Drawer from "../components/Drawer.svelte";
   import FilterBar from "../components/FilterBar.svelte";
   import FrameworkStageProgress from "../components/FrameworkStageProgress.svelte";
+  import GroupSection from "../components/GroupSection.svelte";
   import MinimalTableSkeleton from "../components/MinimalTableSkeleton.svelte";
   import ResizableTable from "../components/ResizableTable.svelte";
   import RunSummary from "../components/RunSummary.svelte";
@@ -27,6 +28,8 @@
     groupCounts,
     activeGroups,
     filteredRuns,
+    runGroups,
+    groupBy = $bindable(),
     loading,
     error,
     modelName,
@@ -150,6 +153,24 @@
       onCloseDrawer();
     }
   });
+
+  const groupByLabels = { group: "Group", dataset: "Dataset", model: "Model" };
+
+  // Inverted vs. evals' expanded set so groups default to expanded, including
+  // ones that appear later via auto-refresh.
+  let collapsedGroupKeys = $state(new Set());
+
+  function toggleGroupSection(key) {
+    const next = new Set(collapsedGroupKeys);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    collapsedGroupKeys = next;
+  }
+
+  $effect(() => {
+    void groupBy;
+    collapsedGroupKeys = new Set();
+  });
 </script>
 
 <section class="summary-sticky grid grid-cols-5 gap-[14px] mb-[24px] max-[900px]:grid-cols-2 max-[640px]:grid-cols-1">
@@ -191,6 +212,7 @@
       {activeGroups}
       allGroupsActive={activeGroups.size === groups.length}
       bind:search
+      bind:groupBy
       onToggleRecipe={onToggleRecipe}
       onSelectAllRecipes={onSelectAllRecipes}
       onClearRecipes={onClearRecipes}
@@ -219,159 +241,185 @@
     {:else if !filteredRuns.length}
       <div class="page-empty">No runs match the current filters.</div>
     {:else}
-      <div class="table-wrap freeze-header">
-        <ResizableTable class="training-runs-table" {columns} stickyFirstColumn>
-          <tbody>
-            {#each filteredRuns as run, runIndex (`${run.run_id || "run"}-${run.created_at || 0}-${runIndex}`)}
-              {@const runName = run.run_id || "—"}
-              {@const status = getStatus(run)}
-              {@const stageLabel = frameworkStatusLabel(run)}
-              {@const progress = frameworkProgress(run)}
-              {@const groupTags = getGroupTags(run)}
-              <tr class="run-row" class:row-selected={drawerRunId === run.run_id}>
-                <td class="min-w-0 row-open-cell">
-                  <a
-                    href={trainingRunDetailPath(run.run_id)}
-                    class="cell-open-button"
-                    title={runName}
-                    aria-label={`Open training run ${runName}`}
-                    onclick={(event) => selectRun(run.run_id, event)}
-                  >
-                    <div class="block text-(--text-bright) [font-family:var(--font-mono)] [font-weight:400] text-[14px] leading-[20px] overflow-hidden text-ellipsis whitespace-nowrap">{runName}</div>
-                  </a>
-                </td>
-                <td class="row-open-cell">
-                  <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
-                    <span class="flex flex-col items-start gap-[4px] min-w-0 max-w-full">
-                      <StatusPill status={status} />
-                      {#if resumeBadge(run)}
-                        <span class="[border:1px_solid_color-mix(in_srgb,var(--yellow,#fbbf24)_42%,transparent)] rounded-[999px] bg-[color-mix(in_srgb,var(--yellow,#fbbf24)_10%,transparent)] text-(--yellow,#fbbf24) text-[11px] leading-[14px] p-[1px_6px] whitespace-nowrap">{resumeBadge(run)}</span>
-                      {/if}
-                    </span>
-                  </a>
-                </td>
-                <td class="min-w-0 row-open-cell">
-                  <a
-                    href={trainingRunDetailPath(run.run_id)}
-                    class="cell-open-button whitespace-normal! leading-[16px]!"
-                    onclick={(event) => selectRun(run.run_id, event)}
-                  >
-                    {#if showFrameworkStatus(run) && stageLabel}
-                      <FrameworkStageProgress
-                        progress={progress}
-                        progressLabel={progressLabel(progress)}
-                        stageLabel={stageLabel}
-                        compact
-                        active={status.toLowerCase() === "pending"}
-                      />
-                    {:else}
-                      <span class="text-(--muted)">—</span>
-                    {/if}
-                  </a>
-                </td>
-                <td class="min-w-0 row-open-cell" title={modelName(run)}>
-                  <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
-                    {modelName(run)}
-                  </a>
-                </td>
-                <td class="min-w-0 row-open-cell" title={run.config_summary?.dataset_name || "—"}>
-                  <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
-                    {run.config_summary?.dataset_name || "—"}
-                  </a>
-                </td>
-                <td class="row-open-cell">
-                  <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
-                    {run.framework || "—"}
-                  </a>
-                </td>
-                <td class="group-cell row-open-cell" title={groupTags?.group_id || run.group_id || ""}>
-                  <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
-                    {#if groupTags?.group_id}
-                      <span class="inline-block max-w-full whitespace-normal [overflow-wrap:anywhere] align-bottom p-[2px_8px] rounded-[999px] text-[0.72rem] [font-variant-numeric:tabular-nums] text-(--muted) [border:1px_solid_var(--border,#2f2f2f)] bg-[color-mix(in_srgb,var(--panel-alt)_70%,transparent)]">{groupTags.group_id}</span>
-                    {:else}
-                      <span class="group-empty">—</span>
-                    {/if}
-                  </a>
-                </td>
-                <td class="h-auto align-top row-open-cell">
-                  <a
-                    href={trainingRunDetailPath(run.run_id)}
-                    class="cell-open-button overflow-visible! text-clip! whitespace-normal!"
-                    onclick={(event) => selectRun(run.run_id, event)}
-                  >
-                    {#if groupTags?.tags.length}
-                      <span class="flex flex-wrap gap-[4px] min-w-0 max-w-full">
-                        {#each groupTags.tags as tag (tag.key)}
-                          <span class="inline-flex items-baseline max-w-full min-w-0 overflow-hidden p-[2px_7px] [border:1px_solid_var(--border,#2f2f2f)] rounded-[999px] bg-[color-mix(in_srgb,var(--panel-alt)_70%,transparent)] text-(--text) [font-family:var(--font-mono)] text-[11px] leading-[14px]" title={`${tag.key}=${formatTagValue(tag.value)}`}>
-                            <span class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-(--muted)">{tag.key}</span><span>=</span><span class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{formatTagValue(tag.value)}</span>
-                          </span>
-                        {/each}
-                      </span>
-                    {:else}
-                      <span class="group-empty">—</span>
-                    {/if}
-                  </a>
-                </td>
-                <td class="whitespace-nowrap row-open-cell">
-                  <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
-                    <TimeAgo timestamp={run.started_at || run.created_at} showJustNow falsyRepresentation="—" />
-                  </a>
-                </td>
-                <td class="whitespace-nowrap row-open-cell">
-                  <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
-                    <TimeAgo timestamp={run.updated_at} showJustNow falsyRepresentation="—" />
-                  </a>
-                </td>
-                <td class="min-w-0 overflow-visible">
-                  <div class="flex items-center flex-wrap gap-[6px]">
-                    <button
-                      class="inline-flex items-center gap-[6px] whitespace-nowrap [border:1px_solid_var(--color-c-gray-10,#2f2f2f)] rounded-[6px] p-[4px_8px] [font:inherit] text-[12px] font-medium leading-[16px] text-(--muted) bg-transparent cursor-pointer ghost-hover"
-                      title="Open expanded view"
-                      aria-label={`Open expanded view for training run ${run.run_id}`}
-                      onclick={(event) => {
-                        event.stopPropagation();
-                        selectRun(run.run_id, event);
-                      }}
+      {#snippet runsTable(runs, frozenOffset)}
+        <div class="table-wrap freeze-header" style={frozenOffset ? `--frozen-table-offset: ${frozenOffset};` : ""}>
+          <ResizableTable class="training-runs-table" {columns} stickyFirstColumn>
+            <tbody>
+              {#each runs as run, runIndex (`${run.run_id || "run"}-${run.created_at || 0}-${runIndex}`)}
+                {@const runName = run.run_id || "—"}
+                {@const status = getStatus(run)}
+                {@const stageLabel = frameworkStatusLabel(run)}
+                {@const progress = frameworkProgress(run)}
+                {@const groupTags = getGroupTags(run)}
+                <tr class="run-row" class:row-selected={drawerRunId === run.run_id}>
+                  <td class="min-w-0 row-open-cell">
+                    <a
+                      href={trainingRunDetailPath(run.run_id)}
+                      class="cell-open-button"
+                      title={runName}
+                      aria-label={`Open training run ${runName}`}
+                      onclick={(event) => selectRun(run.run_id, event)}
                     >
-                      <Maximize2 size={12} strokeWidth={2.1} />
-                      <span class="expand-button-label">Expand</span>
-                    </button>
-                    {#if run.modal_app_url}
-                      <a
-                        class="training-open-modal-link"
-                        href={run.modal_app_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onclick={(event) => event.stopPropagation()}
-                      >
-                        <span class="open-modal-link-label">Open in Modal</span>
-                        <ExternalLink class="training-open-modal-link-icon" size={12} strokeWidth={2.1} />
-                      </a>
-                    {:else}
-                      <span class="training-open-modal-link open-modal-link-disabled">
-                        <span class="open-modal-link-label">Open in Modal</span>
-                        <ExternalLink class="training-open-modal-link-icon" size={12} strokeWidth={2.1} />
+                      <div class="block text-(--text-bright) [font-family:var(--font-mono)] [font-weight:400] text-[14px] leading-[20px] overflow-hidden text-ellipsis whitespace-nowrap">{runName}</div>
+                    </a>
+                  </td>
+                  <td class="row-open-cell">
+                    <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
+                      <span class="flex flex-col items-start gap-[4px] min-w-0 max-w-full">
+                        <StatusPill status={status} />
+                        {#if resumeBadge(run)}
+                          <span class="[border:1px_solid_color-mix(in_srgb,var(--yellow,#fbbf24)_42%,transparent)] rounded-[999px] bg-[color-mix(in_srgb,var(--yellow,#fbbf24)_10%,transparent)] text-(--yellow,#fbbf24) text-[11px] leading-[14px] p-[1px_6px] whitespace-nowrap">{resumeBadge(run)}</span>
+                        {/if}
                       </span>
-                    {/if}
-                    {#each run.wandb_links || [] as link (link.url)}
-                      <a
-                        class="training-open-modal-link training-open-wandb-link"
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onclick={(event) => event.stopPropagation()}
+                    </a>
+                  </td>
+                  <td class="min-w-0 row-open-cell">
+                    <a
+                      href={trainingRunDetailPath(run.run_id)}
+                      class="cell-open-button whitespace-normal! leading-[16px]!"
+                      onclick={(event) => selectRun(run.run_id, event)}
+                    >
+                      {#if showFrameworkStatus(run) && stageLabel}
+                        <FrameworkStageProgress
+                          progress={progress}
+                          progressLabel={progressLabel(progress)}
+                          stageLabel={stageLabel}
+                          compact
+                          active={status.toLowerCase() === "pending"}
+                        />
+                      {:else}
+                        <span class="text-(--muted)">—</span>
+                      {/if}
+                    </a>
+                  </td>
+                  <td class="min-w-0 row-open-cell" title={modelName(run)}>
+                    <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
+                      {modelName(run)}
+                    </a>
+                  </td>
+                  <td class="min-w-0 row-open-cell" title={run.config_summary?.dataset_name || "—"}>
+                    <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
+                      {run.config_summary?.dataset_name || "—"}
+                    </a>
+                  </td>
+                  <td class="row-open-cell">
+                    <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
+                      {run.framework || "—"}
+                    </a>
+                  </td>
+                  <td class="group-cell row-open-cell" title={groupTags?.group_id || run.group_id || ""}>
+                    <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
+                      {#if groupTags?.group_id}
+                        <span class="inline-block max-w-full whitespace-normal [overflow-wrap:anywhere] align-bottom p-[2px_8px] rounded-[999px] text-[0.72rem] [font-variant-numeric:tabular-nums] text-(--muted) [border:1px_solid_var(--border,#2f2f2f)] bg-[color-mix(in_srgb,var(--panel-alt)_70%,transparent)]">{groupTags.group_id}</span>
+                      {:else}
+                        <span class="group-empty">—</span>
+                      {/if}
+                    </a>
+                  </td>
+                  <td class="h-auto align-top row-open-cell">
+                    <a
+                      href={trainingRunDetailPath(run.run_id)}
+                      class="cell-open-button overflow-visible! text-clip! whitespace-normal!"
+                      onclick={(event) => selectRun(run.run_id, event)}
+                    >
+                      {#if groupTags?.tags.length}
+                        <span class="flex flex-wrap gap-[4px] min-w-0 max-w-full">
+                          {#each groupTags.tags as tag (tag.key)}
+                            <span class="inline-flex items-baseline max-w-full min-w-0 overflow-hidden p-[2px_7px] [border:1px_solid_var(--border,#2f2f2f)] rounded-[999px] bg-[color-mix(in_srgb,var(--panel-alt)_70%,transparent)] text-(--text) [font-family:var(--font-mono)] text-[11px] leading-[14px]" title={`${tag.key}=${formatTagValue(tag.value)}`}>
+                              <span class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-(--muted)">{tag.key}</span><span>=</span><span class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{formatTagValue(tag.value)}</span>
+                            </span>
+                          {/each}
+                        </span>
+                      {:else}
+                        <span class="group-empty">—</span>
+                      {/if}
+                    </a>
+                  </td>
+                  <td class="whitespace-nowrap row-open-cell">
+                    <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
+                      <TimeAgo timestamp={run.started_at || run.created_at} showJustNow falsyRepresentation="—" />
+                    </a>
+                  </td>
+                  <td class="whitespace-nowrap row-open-cell">
+                    <a href={trainingRunDetailPath(run.run_id)} class="cell-open-button" onclick={(event) => selectRun(run.run_id, event)}>
+                      <TimeAgo timestamp={run.updated_at} showJustNow falsyRepresentation="—" />
+                    </a>
+                  </td>
+                  <td class="min-w-0 overflow-visible">
+                    <div class="flex items-center flex-wrap gap-[6px]">
+                      <button
+                        class="inline-flex items-center gap-[6px] whitespace-nowrap [border:1px_solid_var(--color-c-gray-10,#2f2f2f)] rounded-[6px] p-[4px_8px] [font:inherit] text-[12px] font-medium leading-[16px] text-(--muted) bg-transparent cursor-pointer ghost-hover"
+                        title="Open expanded view"
+                        aria-label={`Open expanded view for training run ${run.run_id}`}
+                        onclick={(event) => {
+                          event.stopPropagation();
+                          selectRun(run.run_id, event);
+                        }}
                       >
-                        <span class="open-modal-link-label">{link.label}</span>
-                        <ExternalLink class="training-open-modal-link-icon" size={12} strokeWidth={2.1} />
-                      </a>
-                    {/each}
-                  </div>
-                </td>
-              </tr>
-            {/each}
-          </tbody>
-        </ResizableTable>
-      </div>
+                        <Maximize2 size={12} strokeWidth={2.1} />
+                        <span class="expand-button-label">Expand</span>
+                      </button>
+                      {#if run.modal_app_url}
+                        <a
+                          class="training-open-modal-link"
+                          href={run.modal_app_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onclick={(event) => event.stopPropagation()}
+                        >
+                          <span class="open-modal-link-label">Open in Modal</span>
+                          <ExternalLink class="training-open-modal-link-icon" size={12} strokeWidth={2.1} />
+                        </a>
+                      {:else}
+                        <span class="training-open-modal-link open-modal-link-disabled">
+                          <span class="open-modal-link-label">Open in Modal</span>
+                          <ExternalLink class="training-open-modal-link-icon" size={12} strokeWidth={2.1} />
+                        </span>
+                      {/if}
+                      {#each run.wandb_links || [] as link (link.url)}
+                        <a
+                          class="training-open-modal-link training-open-wandb-link"
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onclick={(event) => event.stopPropagation()}
+                        >
+                          <span class="open-modal-link-label">{link.label}</span>
+                          <ExternalLink class="training-open-modal-link-icon" size={12} strokeWidth={2.1} />
+                        </a>
+                      {/each}
+                    </div>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </ResizableTable>
+        </div>
+      {/snippet}
+
+      {#if groupBy === "none"}
+        {@render runsTable(filteredRuns)}
+      {:else}
+        <div class="flex flex-col gap-[24px] p-0">
+          {#each runGroups as group (group.key)}
+            <GroupSection
+              title={group.key}
+              subtitle={`${group.runs.length} run${group.runs.length === 1 ? "" : "s"}`}
+              expanded={!collapsedGroupKeys.has(group.key)}
+              onToggle={() => toggleGroupSection(group.key)}
+            >
+              {#snippet meta()}
+                {#if group.latestCreatedAt}
+                  <span class="group-meta-pill [font-variant-numeric:tabular-nums]">
+                    <TimeAgo timestamp={group.latestCreatedAt} showJustNow falsyRepresentation="—" />
+                  </span>
+                {/if}
+              {/snippet}
+              {@render runsTable(group.runs, "360px")}
+            </GroupSection>
+          {/each}
+        </div>
+      {/if}
     {/if}
   </div>
 </section>

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -10,6 +10,7 @@
   import StatusPill from "../components/StatusPill.svelte";
   import TimeAgo from "../components/TimeAgo.svelte";
   import { formatTagValue, getGroupTags, smoothedStageLabel } from "../lib/format.js";
+  import { toggleInSet } from "../lib/set.js";
 
   let {
     allRuns,
@@ -159,10 +160,7 @@
   let collapsedGroupKeys = $state(new Set());
 
   function toggleGroupSection(key) {
-    const next = new Set(collapsedGroupKeys);
-    if (next.has(key)) next.delete(key);
-    else next.add(key);
-    collapsedGroupKeys = next;
+    collapsedGroupKeys = toggleInSet(collapsedGroupKeys, key);
   }
 
   $effect(() => {


### PR DESCRIPTION
Adds the ability to group training runs by their group, dataset, and model:

<img width="1499" height="1075" alt="Screenshot 2026-07-10 at 17 06 33" src="https://github.com/user-attachments/assets/fb390337-d278-4d58-810e-d1b553a36e2c" />

For now, groups are sorted by recency. We may change this in the future.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->