### PR TITLE
update skill files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-`modal-training-gym` is a pip-installable Python package that provides framework-aware launchers for distributed training on Modal's multi-node GPU clusters. Users import framework configs, attach a model + dataset, and `modal run` — the package handles image construction, cluster topology, Ray/NCCL bring-up, volume mounts, and checkpointing.
+`modal-training-gym` is a pip-installable Python package that provides framework-aware launchers for distributed training on Modal's multi-node GPU clusters. The current entrypoint is `TrainConfig` + a recipe (`SlimeRecipe` / `MilesConfig`), then `.train()` / `.launch()` — the package handles image construction, cluster topology, Ray/NCCL bring-up, volume mounts, and checkpointing.
 
 ## Commands
 
@@ -36,31 +36,17 @@ uv run python scripts/generate_all.py                 # full regen + build
 uv run modal deploy docs-next/docs_next_app.py        # docs site → gym.modal.dev
 uv run modal deploy dashboards/app.py                  # observability dashboard
 
-# Validate tutorials (runs on Modal — costs GPU time)
-uv run python scripts/validate_tutorials.py --list           # show discovered targets
-uv run python scripts/validate_tutorials.py --preflight-only # local checks only
-uv run python scripts/validate_tutorials.py --only slime_gsm8k  # single tutorial
+# Validate model configs / map a diff to affected tutorials
+uv run python scripts/validate_model_configs.py list
+uv run python scripts/validate_model_configs.py check -m qwen3-4b
+git diff | uv run python scripts/diff_impact.py
 ```
 
 ## Architecture
 
-### Two-class framework pattern
+### TrainConfig + recipe
 
-Every framework exposes two config classes:
-
-- **`<F>FrameworkConfig`** — Modal infra (gpu, image, n_nodes) + framework CLI flags. Pydantic with `extra="forbid"`.
-- **`<F>Config`** — Composes `dataset: DatasetConfig`, `model: ModelConfig`, `wandb: WandbConfig`, and `framework_config`. Exposes `build_app()`.
-
-```
-SlimeConfig.build_app()
-  → build_slime_app(slime=self)  [in launcher.py]
-    → returns modal.App with:
-        app.download()          — ModelConfig.download()
-        app.prepare_dataset()   — DatasetConfig.prepare()
-        app.train()             — Ray cluster submit → TrainResult
-```
-
-SlimeConfig is a Pydantic dataclass following the two-class composition pattern.
+`TrainConfig` composes `dataset`, `model`, and a recipe (`SlimeRecipe` or `MilesConfig`). Call `.train()` or `.launch()` — there is no public `build_app()`. Recipes carry Modal infra + framework CLI flags (`extra="forbid"`).
 
 ### Train pipeline
 
@@ -75,15 +61,15 @@ Every framework mounts three Modal Volumes:
 
 ### Model presets
 
-Models can declare `training: ModelTrainingConfig` or framework-specific presets (e.g. `SlimePreset`) with tuned parallelism/GPU settings. Framework configs apply these as defaults to unset fields during `__post_init__`.
+Known-model presets live under `train_recipes/` (e.g. `Qwen3_4b_Recipe`); `TrainConfig.merge_model_recipe` (bool, default `True`) merges them onto unset recipe fields.
 
 ### Cloudpickle caller resolution
 
-`build_app()` factories use `resolve_caller_module()` (in `common/framework.py`) to find the user's tutorial module by walking the stack past `modal_training_gym.*` frames. This enables cloudpickle to serialize inline `DatasetConfig`/`ModelConfig` subclasses by value to remote containers.
+Launchers use `resolve_caller_module()` (in `common/framework.py`) to find the user's tutorial module by walking the stack past `modal_training_gym.*` frames. This enables cloudpickle to serialize inline `DatasetConfig`/`ModelConfig` subclasses by value to remote containers.
 
 ### TrainResult persistence
 
-`TrainResult` is a dataclass written to a `modal.Dict` (keyed by `{app_name}-train-results`). Created by each framework's `train()` on rank 0. Loaded by eval scripts via `TrainResult.load(app_name)`. The `.model` property reconstructs a `ModelConfig` pointing at the checkpoint for serving.
+`TrainResult` is a dataclass written to the metadata volume (`MetadataStore.TRAIN_RESULTS`, keyed by `training_run_id`). Created by each framework's `train()` on rank 0. Loaded by eval scripts via `TrainResult.load(training_run_id)`. The `.model` property reconstructs a `ModelConfig` pointing at the checkpoint for serving.
 
 ### Tutorial system
 
@@ -104,7 +90,7 @@ Each source declares `TUTORIAL_METADATA` dict with `framework`, `cluster_shape`,
 ## Working rules
 
 - Use `uv` for all Python operations. Never install packages at the system level.
-- Never edit `tutorials/<name>/<name>.py` or `.ipynb` — they are generated. Edit `tutorials/tutorial_generator/<name>.py` and run the generator.
+- Never edit `tutorials/<bucket>/<name>/<name>.py` or `.ipynb` — they are generated. Edit `tutorials/tutorial_generator/<bucket>/<name>.py` and run the generator.
 - Ruff excludes `tutorials/**` — generated tutorial code is not linted.
 - Python 3.12 is pinned. Modal's `serialized=True` requires local ↔ remote Python version match.
 - Modal Secrets `huggingface-secret` (HF_TOKEN) and `wandb-secret` (WANDB_API_KEY) are required for remote runs.

--- a/skills/modal-training/SKILL.md
+++ b/skills/modal-training/SKILL.md
@@ -95,7 +95,7 @@ modal app stop <app-id>
 modal app logs <app-id> --tail 500 | rg "error|CUDA|OOM|loss"
 
 # Fetch only stderr from a particular function call
-modal app logs <app-id> --source stderr --function-call-id <function-call-id>
+modal app logs <app-id> --source stderr --function-call <function-call-id>
 
 # Search for specific keywords in logs
 modal app logs <app-id> --search "error"

--- a/skills/training-gym-overview/SKILL.md
+++ b/skills/training-gym-overview/SKILL.md
@@ -3,12 +3,12 @@ name: training-gym-overview
 description: >-
   One-stop reference for the modal-training-gym repo: package layout, core
   abstractions (ModelConfig, DatasetConfig, framework two-class split,
-  build_app, cloudpickle caller resolution), the tutorial generator system,
+  TrainConfig, cloudpickle caller resolution), the tutorial generator system,
   model catalog, tools/ directory, and common gotchas. Use when working with
   tutorials, models, frameworks, or any code in this repository.
 when_to_use: >-
   User edits or asks about modal_training_gym/ code, tutorials, framework
-  configs, ModelConfig, DatasetConfig, build_app, the tutorial generator,
+  configs, ModelConfig, DatasetConfig, TrainConfig, the tutorial generator,
   adding a new model or tutorial, or repo structure questions.
 ---
 
@@ -46,14 +46,14 @@ tutorials/
 ├── tutorial_generator/     <- decorator-annotated source files -- THIS is
 │                             what you edit; each file is one tutorial
 └── generate_tutorial.py    <- AST-walks each source, emits
-                              tutorials/<name>/<name>.py + .ipynb
+                              tutorials/<bucket>/<name>/<name>.py + .ipynb
 
 tests/                      <- plain-script tests (uv run python tests/<x>.py)
 .claude/skills/             <- agent-facing skills (you are here)
 ```
 
-**Never edit `tutorials/<name>/<name>.py` or `.ipynb` directly -- they are
-generated.** Edit `tutorials/tutorial_generator/<name>.py` and run
+**Never edit `tutorials/<bucket>/<name>/<name>.py` or `.ipynb` directly -- they are
+generated.** Edit `tutorials/tutorial_generator/<bucket>/<name>.py` and run
 `uv run python tutorials/generate_tutorial.py`.
 
 ## Core abstractions
@@ -81,13 +81,13 @@ Built-in subclasses:
 | Class | HF repo | Architecture populated? | Notes |
 |---|---|---|---|
 | `Qwen3_4B` | `Qwen/Qwen3-4B` | yes | slime-ready |
-| `GLM_4_7` | `zai-org/GLM-4.7` | no | architecture inferred from HF config |
+| `GLM_4_7` | `zai-org/GLM-4.7` | yes | MoE; slime-ready |
 | `Llama2_7B` | `meta-llama/Llama-2-7b-hf` | no | torchrun-based workflows |
-| `Kimi_K2_5` | `moonshotai/Kimi-K2.5` | no | **overrides `download`**: snapshot + INT4->BF16 conversion via `tools/convert_kimi_int4_to_bf16.py` |
+| `Kimi_K2_5` | `moonshotai/Kimi-K2.5` | no | **overrides `download`**: HF snapshot + seeds transformers dynamic-module cache (INT4→BF16 is recipe-side, not `download`) |
 
 **Rule of thumb for slime**: slime emits architecture fields as CLI flags,
 so it requires `architecture` to be a populated `ModelArchitecture(...)`.
-The `SlimeConfig._validate_custom_model_architecture` preflight raises an
+`SlimeRecipe._validate_custom_model_architecture` raises an
 actionable `ValueError` if a user attaches a model with
 `architecture is None`. Every other framework only needs `model_name`.
 
@@ -98,40 +98,26 @@ In `modal_training_gym/common/dataset.py`. Plain class; subclass and override
 attrs (`prompt_data`, `input_key`, `rm_type`, etc.) are interpreted by each
 framework's config converter.
 
-### Framework config two-class split
+### `TrainConfig` + recipe
 
-Every framework exposes **two** dataclasses:
-
-- `<F>FrameworkConfig` -- Modal infra (gpu, image, n_nodes, gpus_per_node) +
-  framework-specific CLI flags. Uses pydantic with `extra="forbid"`, so any
-  unknown kwarg fails loudly.
-- `<F>Config` -- wraps `dataset`, `model`, `wandb`, `framework_config`.
-  Exposes `build_app()` which delegates to the launcher's
-  `build_<f>_app(...)` factory. Typically has `_WRAPPER_FIELDS` (in some
-  frameworks) to exclude the wrapper slots from CLI-arg rendering.
-
-User code builds an app like:
+`TrainConfig` composes `dataset`, `model`, and a recipe (`SlimeRecipe` /
+`MilesConfig`). Recipes carry Modal infra + framework CLI flags
+(`extra="forbid"`). Call `.train()` / `.launch()` — no public `build_app()`.
 
 ```python
-cfg = MyFrameworkConfig(
+cfg = TrainConfig(
     dataset=MyDataset(...),
     model=Qwen3_4B(),
-    wandb=WandbConfig(project="..."),
-    framework_config=MyFrameworkFrameworkConfig(gpu="H100", n_nodes=1, ...),
+    recipe=Qwen3_4b_Recipe(gpu_type="H100", ...),
 )
-app = cfg.build_app()
+result = cfg.train()
 ```
 
-### `build_app()` delegation
+### Caller resolution for cloudpickle
 
-`<F>Config.build_app()` -> `build_<f>_app(<f>=self)` -> constructs a
-`modal.App` with Modal functions for each stage (typically
-`download`, `prepare_dataset`, `train` / `train_multi_node`, plus
-framework-specific ones like `convert_hf_to_mcore`, `upload_reward`, etc).
-
-The launcher walks the call stack via
+Launchers walk the call stack via
 `common.framework.resolve_caller_module()` to find the true user-tutorial
-module (skipping `modal_training_gym.*` frames) and registers that module
+module (skipping `modal_training_gym.*` frames) and register that module
 for cloudpickle by-value inlining -- this is how a user's inline
 `DatasetConfig` / `ModelConfig` subclasses survive serialization to
 the remote container.
@@ -185,8 +171,7 @@ remote_path=TOOLS_REMOTE_PATH, copy=True)` on every framework image.
    __all__ = [..., "MyModel"]
    ```
 
-3. **Verify** via `tests/test_model_configuration.py` (or an analogous
-   snippet):
+3. **Verify** with a one-liner smoke (or an analogous snippet):
 
    ```python
    from modal_training_gym.common.models import MyModel
@@ -208,7 +193,7 @@ remote_path=TOOLS_REMOTE_PATH, copy=True)` on every framework image.
 1. **Pick the framework** -- almost always one of the catalog above.
 
 2. **Create the source** at
-   `tutorials/tutorial_generator/<name>.py`. Structure (follow
+   `tutorials/tutorial_generator/<bucket>/<name>.py`. Structure (follow
    existing slime tutorials as templates):
 
    ```python
@@ -235,10 +220,7 @@ remote_path=TOOLS_REMOTE_PATH, copy=True)` on every framework image.
 
        from modal_training_gym.common.dataset import DatasetConfig
        from modal_training_gym.common.models import <BuiltinModelOrModelConfiguration>
-       from modal_training_gym.common.wandb import WandbConfig
-       from modal_training_gym.frameworks.<framework> import (
-           <F>Config, <F>FrameworkConfig,
-       )
+       from modal_training_gym import TrainConfig, Qwen3_4b_Recipe
 
 
    @code
@@ -250,36 +232,25 @@ remote_path=TOOLS_REMOTE_PATH, copy=True)` on every framework image.
 
    @code
    def _define_config():
-       fw_cfg = <F>FrameworkConfig(gpu="H100", n_nodes=1, gpus_per_node=1, ...)
-       my_training_run = <F>Config(
+       my_training_run = TrainConfig(
            dataset=MyDataset(...),
            model=<BuiltinModel>(),
-           wandb=WandbConfig(project="..."),
-           framework_config=fw_cfg,
+           recipe=Qwen3_4b_Recipe(gpu_type="H100", ...),
        )
-
-
-   @code
-   def _build_app():
-       app = my_training_run.build_app()
 
 
    @py_only
    @markdown
    def _run_cli():
        """```bash
-       uv run modal run tutorials/<name>/<name>.py::app.download
-       uv run modal run tutorials/<name>/<name>.py::app.prepare_dataset
-       uv run modal run --detach tutorials/<name>/<name>.py::app.train
+       uv run python tutorials/<bucket>/<name>/<name>.py
        ```"""
 
 
    @notebook_only
    @code
    def _invoke_train():
-       with modal.enable_output():
-           with app.run():
-               app.train.remote()
+       train_result = my_training_run.train()
    ```
 
 3. **Decorators cheat sheet**:
@@ -301,12 +272,10 @@ remote_path=TOOLS_REMOTE_PATH, copy=True)` on every framework image.
 
 5. **Keep training cheap by default**. Tutorials should smoke in a single
    step by default so Tier 2 validation is cheap:
-   - `num_train_epochs=1`, `train_iters=1` (or framework equivalent).
    - Small `global_batch_size` / tiny dataset slice
      (e.g. `split="train[:4]"`).
-   - `log_interval=1` so the first training step is visible.
-   - Disable eval / save if they'd gate the first-step marker
-     (`test_freq=-1`, `save_freq=-1`).
+   - For slime, prefer short recipes (`num_rollout=1`) so the first training step is visible.
+   - Disable eval / save if they'd gate the first-step marker.
 
 ### Custom-model tutorial pattern (no built-in subclass)
 
@@ -345,31 +314,28 @@ Always follow the tiered policy in
 Per-change default: Tier 0 + Tier 1, plus Tier 2 for the new/modified
 tutorial only. Don't expand to all tutorials on a single change.
 
-`tests/test_model_configuration.py` is the current model-API regression
-test. Run with `uv run python tests/test_model_configuration.py`.
-
 ## Gotchas
 
 - **Python version pin**. The repo pins 3.12 (see `pyproject.toml` +
   `CLAUDE.md`). Modal's `serialized=True` functions require the remote
   image's Python to match the local one. If a framework image has Python
   3.11 (e.g. some ModelScope images), app build fails with `InvalidError`.
-- **Framework image switches**. To override a framework's default image,
-  set `image=` on `<F>FrameworkConfig` in your tutorial. The launcher's
-  `pip_install` chain reinstalls the framework fresh, so
-  switching the base is usually enough. Check whether transitive deps
-  (megatron-core, pillow, tokenizers for transformers) are in the new
+- **Framework image switches**. Recipes have no `image=`; use
+  `image_overlay=` (slime/miles) or Miles `docker_image=` to customize.
+  The launcher's `pip_install` chain reinstalls the framework fresh, so
+  switching/overlaying the base is usually enough. Check whether transitive
+  deps (megatron-core, pillow, tokenizers for transformers) are in the new
   image; the ModelScope image shipped many, bare CUDA/NGC images don't.
-- **cloudpickle caller_module**. `SlimeConfig.build_app()` (and the other
-  wrapper `build_app` methods) now all delegate to the launcher, meaning
-  `inspect.stack()[1]` inside `build_<f>_app` is the config wrapper, not
-  the tutorial. Launchers use `resolve_caller_module()` to walk past
+- **cloudpickle caller_module**. `TrainConfig.train()` / `.launch()` (and
+  the internal `_build_app` path) delegate to the launcher, meaning
+  `inspect.stack()[1]` inside `build_<f>_app` is not the tutorial.
+  Launchers use `resolve_caller_module()` to walk past
   `modal_training_gym.*` frames. Never use raw `inspect.stack()[1]` here.
 - **Secrets required for most remote runs**: `huggingface-secret` (with
   `HF_TOKEN`) and `wandb-secret` (with `WANDB_API_KEY`) must exist as Modal
   Secrets in your environment.
 - **Do not edit generated tutorials**. The pre-commit hook rewrites them.
-- **Do not add framework-specific quirks to `<F>Config`** that only matter
+- **Do not add framework-specific quirks to `TrainConfig`** that only matter
   for one model. Put those in the model's `download` override and
   make the tool script live in `modal_training_gym/tools/`.
 
@@ -379,6 +345,6 @@ test. Run with `uv run python tests/test_model_configuration.py`.
 - Adding/modifying a framework -> `modal_training_gym/frameworks/<name>/`.
 - Cross-framework scripts -> `modal_training_gym/tools/`.
 - Cross-framework helpers -> `modal_training_gym/common/framework.py`.
-- Tutorial sources -> `tutorials/tutorial_generator/<name>.py`.
+- Tutorial sources -> `tutorials/tutorial_generator/<bucket>/<name>.py`.
 - Tutorial regeneration -> `uv run python tutorials/generate_tutorial.py`.
 - Tests -> `tests/test_*.py`, run via `uv run python tests/<file>.py`.


### PR DESCRIPTION
changes:

- [#6](https://github.com/modal-projects/training-gym/pull/6) added `TrainConfig` + recipes and removed `SlimeConfig` / `SlimePreset` / `ModelTrainingConfig`; public `build_app()` renamed to `_build_app` in [#7](https://github.com/modal-projects/training-gym/pull/7)
- [#177](https://github.com/modal-projects/training-gym/pull/177) added `validate_model_configs.py` and deleted `validate_tutorials.py`
- [#187](https://github.com/modal-projects/training-gym/pull/187) added `TrainConfig.merge_model_recipe`; recipe presets introduced in #6
- [#4](https://github.com/modal-projects/training-gym/pull/4) changed `TrainResult.load(app_name)` → `load(training_run_id)`; [#6](https://github.com/modal-projects/training-gym/pull/6) dropped `modal.Dict`; [#7](https://github.com/modal-projects/training-gym/pull/7)/[#8](https://github.com/modal-projects/training-gym/pull/8) moved persistence onto the metadata volume (`MetadataStore`)
- [#3](https://github.com/modal-projects/training-gym/pull/3) introduced tutorials under `tutorials/<bucket>/<name>/`
- logs filter `--function-call-id` never existed; [Modal 1.4.0](https://modal.com/docs/sdk/py/changelog#140-2026-03-25) added `--function-call`
- [#56](https://github.com/modal-projects/training-gym/pull/56) re-added `GLM_4_7` with full `ModelArchitecture`; [#89](https://github.com/modal-projects/training-gym/pull/89) put Kimi INT4→BF16 conversion in the Miles recipe