### PR TITLE
allow user-specified volumes

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -524,12 +524,31 @@ def build_slime_app(
     metadata_volume = Volume.from_name("training-gym-metadata", create_if_missing=True)
     if checkpoint is not None and checkpoint.path and not model.model_path:
         model.model_path = checkpoint.path
-    all_volumes: dict[str | PurePosixPath, Any] = {
+    all_volumes: dict[str, Volume] = {
         str(HF_CACHE_PATH): hf_cache_volume,
         str(DATA_PATH): data_volume,
         checkpoints_mount_path: checkpoints_volume,
         "/metadata": metadata_volume,
     }
+    train_function_kwargs = dict(slime.train_function_kwargs or {})
+    user_volumes = train_function_kwargs.pop("volumes", None) or {}
+    if not isinstance(user_volumes, dict):
+        raise TypeError(
+            "train_function_kwargs['volumes'] must be a dict of "
+            f"{{mount_path: modal.Volume}}, got {type(user_volumes).__name__}"
+        )
+    conflicts = sorted(path for path in user_volumes if path in all_volumes)
+    if conflicts:
+        raise ValueError(
+            "train_function_kwargs volumes cannot override reserved mounts: "
+            + ", ".join(conflicts)
+        )
+    for path, volume in user_volumes.items():
+        if not isinstance(volume, Volume):
+            raise TypeError(
+                "train_function_kwargs['volumes'] values must be modal.Volume, "
+                f"got {type(volume).__name__} for mount {path}"
+            )
 
     # ── App ──────────────────────────────────────────────────────────────────
     tags = build_app_tags(
@@ -568,13 +587,15 @@ def build_slime_app(
 
     @app.function(
         image=image,
-        volumes={str(DATA_PATH): data_volume},
+        volumes={str(DATA_PATH): data_volume, **user_volumes},
         timeout=2 * 60 * 60,
         secrets=hf_secrets(),
         serialized=True,
         name="prepare_dataset",
     )
     def prepare_dataset():
+        for volume in user_volumes.values():
+            volume.reload()
         run_prepare_dataset(dataset, data_volume, SlimeRecipe._resolve_data_paths)
 
     convert_nnodes = get_checkpoint_conversion_policy(slime, model=model)[0]
@@ -790,7 +811,6 @@ def build_slime_app(
     train_secrets.extend(proxy_auth_secrets())
     train_experimental_options: dict[str, Any] = {"efa_enabled": True}
 
-    train_function_kwargs = dict(slime.train_function_kwargs or {})
     user_secrets = train_function_kwargs.pop("secrets", None)
     if user_secrets is not None:
         if not isinstance(user_secrets, (list, tuple)):
@@ -862,7 +882,7 @@ def build_slime_app(
         memory=slime.memory,
         cloud=slime.cloud,
         region=slime.region,
-        volumes=all_volumes,
+        volumes={**all_volumes, **user_volumes},
         secrets=train_secrets or None,
         ephemeral_disk=train_ephemeral_disk,
         timeout=24 * 60 * 60,
@@ -900,6 +920,7 @@ def build_slime_app(
             hf_cache_volume.reload.aio(),
             data_volume.reload.aio(),
             checkpoints_volume.reload.aio(),
+            *(volume.reload.aio() for volume in user_volumes.values()),
         )
 
         cluster = ModalRayCluster()

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b.py
@@ -1,4 +1,5 @@
 from dataclasses import field
+from typing import Any
 
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
@@ -13,7 +14,7 @@ class Qwen3_6_35b_Recipe(SlimeRecipe):
     gpu_type: str = "H100"
     slime_model_script: str = "scripts/models/qwen3.5-35B-A3B.sh"
     hf_checkpoint: str = "Qwen/Qwen3.6-35B-A3B"
-    train_function_kwargs: dict[str, int] = field(
+    train_function_kwargs: dict[str, Any] = field(
         default_factory=lambda: {"ephemeral_disk": 1_048_576}
     )
 

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_long_context.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_long_context.py
@@ -1,4 +1,5 @@
 from dataclasses import field
+from typing import Any
 
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
@@ -13,7 +14,7 @@ class Qwen3_6_35b_Recipe_Long_Context(SlimeRecipe):
     gpu_type: str = "H200"
     slime_model_script: str = "scripts/models/qwen3.5-35B-A3B.sh"
     hf_checkpoint: str = "Qwen/Qwen3.6-35B-A3B"
-    train_function_kwargs: dict[str, int] = field(
+    train_function_kwargs: dict[str, Any] = field(
         default_factory=lambda: {"ephemeral_disk": 1_048_576}
     )
 

--- a/tests/test_train_function_kwargs.py
+++ b/tests/test_train_function_kwargs.py
@@ -1,0 +1,90 @@
+"""Thin coverage for ``train_function_kwargs['volumes']`` on slime prepare/train."""
+
+from __future__ import annotations
+
+import pytest
+from modal import Volume
+
+from modal_training_gym.common.dataset import DatasetConfig
+from modal_training_gym.common.models import ModelArchitecture, ModelConfig
+from modal_training_gym.frameworks.slime.launcher import build_slime_app
+from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
+
+_SLIME_KW = dict(
+    gpu_type="H100",
+    colocate=True,
+    tensor_model_parallel_size=1,
+    sequence_parallel=False,
+    rollout_num_gpus_per_engine=8,
+    num_rollout=1,
+    rollout_batch_size=8,
+    rollout_max_response_len=128,
+    rollout_temperature=1.0,
+    save_interval=10,
+    actor_num_gpus_per_node=8,
+)
+
+
+class _TinyDataset(DatasetConfig):
+    label_key = "label"
+    input_key = "prompt"
+
+    def prepare(self, path: str, eval_paths: dict[str, str] | None = None) -> None:
+        return None
+
+
+def _build_app(train_function_kwargs: dict) -> object:
+    recipe = SlimeRecipe(**_SLIME_KW, train_function_kwargs=train_function_kwargs)
+    model = ModelConfig(
+        model_name="Qwen/Qwen3-0.6B",
+        architecture=ModelArchitecture(),
+    )
+    return build_slime_app(
+        training_run_id="test-train-fn-kwargs",
+        slime=recipe,
+        model=model,
+        dataset=_TinyDataset(),
+        name="slime-train-fn-kwargs-test",
+    )
+
+
+def test_volumes_mount_on_prepare_and_train_not_convert() -> None:
+    prompts = Volume.from_name("test-extra-volume", create_if_missing=True)
+    app = _build_app({"volumes": {"/prompts": prompts}})
+
+    prepare = app.registered_functions["prepare_dataset"]
+    train = app.registered_functions["train"]
+    convert = app.registered_functions["convert_checkpoint"]
+
+    assert set(prepare.spec.volumes) == {"/data", "/prompts"}
+    assert "test-extra-volume" in repr(prepare.spec.volumes["/prompts"])
+
+    assert "/prompts" in train.spec.volumes
+    assert "test-extra-volume" in repr(train.spec.volumes["/prompts"])
+    assert set(train.spec.volumes) >= {
+        "/data",
+        "/checkpoints",
+        "/metadata",
+        "/prompts",
+        "/root/.cache/huggingface",
+    }
+
+    assert "/prompts" not in convert.spec.volumes
+    assert set(convert.spec.volumes) == {
+        "/data",
+        "/checkpoints",
+        "/metadata",
+        "/root/.cache/huggingface",
+    }
+
+
+def test_volumes_reject_reserved_mount() -> None:
+    with pytest.raises(ValueError, match="cannot override reserved mounts: /data"):
+        _build_app(
+            {"volumes": {"/data": Volume.from_name("x", create_if_missing=True)}}
+        )
+
+
+def test_volumes_must_be_volume_instances() -> None:
+    with pytest.raises(TypeError, match="values must be modal.Volume"):
+        _build_app({"volumes": {"/prompts": "not-a-volume"}})


### PR DESCRIPTION
For pipelines that collect data into a Modal Volume (outside the reserved gym mounts), allow attaching that Volume so `DatasetConfig.prepare()` can read it directly, instead of uploading to Hugging Face and pulling it back down.

e.g.:
```python
from io import BytesIO
from pathlib import Path

import modal

from modal_training_gym.common.dataset import DatasetConfig
from modal_training_gym.common.models import Qwen3_0_6B
from modal_training_gym.frameworks.slime.launcher import build_slime_app
from modal_training_gym.train_recipes.slime_recipe import Qwen3_0_6b_Recipe

vol = modal.Volume.from_name("tg-smoke-train-volumes-prompts", create_if_missing=True)
app = modal.App("tg-smoke-train-volumes")


class CustomDataset(DatasetConfig):
    input_key, label_key = "prompt", "label"
    output_format = "jsonl"

    def prepare(self, path: str, eval_paths=None) -> None:
        assert Path("/prompts/seed.jsonl").is_file()
        stub = '{"prompt":"x","label":"y"}\n'
        for p in [path, *(eval_paths or {}).values()]:
            Path(p).parent.mkdir(parents=True, exist_ok=True)
            Path(p).write_text(stub)


@app.local_entrypoint()
def main():
    with vol.batch_upload(force=True) as batch:
        batch.put_file(BytesIO(b'{"prompt":"x","label":"y"}\n'), "/seed.jsonl")

    slime = build_slime_app(
        training_run_id="tg-smoke-train-volumes",
        slime=Qwen3_0_6b_Recipe(train_function_kwargs={"volumes": {"/prompts": vol}}),
        model=Qwen3_0_6B(),
        dataset=CustomDataset(),
        name="tg-smoke-train-volumes-slime",
    )
    assert "/prompts" in slime.registered_functions["prepare_dataset"].spec.volumes
    with modal.enable_output(), slime.run():
        slime.prepare_dataset.remote()
```

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->