### PR TITLE
Fix non-colocated substep timings

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -920,7 +920,9 @@ def build_slime_app(
     SUBSTEP_ORDER = [substep.value for substep in Substep]
     OPTIONAL_SUBSTEPS = {
         Substep.EVAL_BEFORE.value,
+        Substep.OFFLOAD_ROLLOUT.value,
         Substep.CHECKPOINT_SAVE.value,
+        Substep.OFFLOAD_TRAIN.value,
         Substep.EVAL_AFTER.value,
     }
 

--- a/scripts/validate_model_configs.py
+++ b/scripts/validate_model_configs.py
@@ -226,6 +226,7 @@ def run_base_training_on_slime(
     wandb_secret_name: str = "wandb-secret",
     eval_interval: int | None = None,
     save_interval: int | None = None,
+    colocate: bool | None = None,
 ) -> TutorialResult:
     model_config = get_model_config_from_model_name(model_name)
     if not _supports_slime(model_config):
@@ -240,6 +241,12 @@ def run_base_training_on_slime(
     model_short_name = model_config.model_name.rsplit("/", 1)[-1]
     train_recipe = SlimeRecipe.get_base_recipe(model_config)
     train_recipe.num_rollout = step_count
+    if colocate is not None:
+        train_recipe.colocate = colocate
+    if colocate is False and train_recipe.rollout_num_gpus is None:
+        train_recipe.rollout_num_gpus = (
+            train_recipe.actor_num_nodes * train_recipe.actor_num_gpus_per_node
+        )
     if eval_interval is not None:
         train_recipe.eval_interval = eval_interval
     if save_interval is not None:
@@ -336,6 +343,11 @@ def __main__():
         help="Override the recipe save_interval (checkpoint every N rollouts).",
     )
     check_parser.add_argument(
+        "--non-colocated",
+        action="store_true",
+        help="Allocate rollout GPUs separately from trainer GPUs.",
+    )
+    check_parser.add_argument(
         "-o",
         "--output",
         help="Write the result as JSON to this file path.",
@@ -400,6 +412,7 @@ def __main__():
         args.wandb_secret_name,
         eval_interval=args.eval_interval,
         save_interval=args.save_interval,
+        colocate=False if args.non_colocated else None,
     )
     tutorial_result.format_tutorial_result()
 

--- a/tests/test_step_times.py
+++ b/tests/test_step_times.py
@@ -23,7 +23,13 @@ SUBSTEP_ORDER = [
     WEIGHT_SYNC,
     EVAL_AFTER,
 ]
-OPTIONAL_SUBSTEPS = {EVAL_BEFORE, CHECKPOINT_SAVE, EVAL_AFTER}
+OPTIONAL_SUBSTEPS = {
+    EVAL_BEFORE,
+    OFFLOAD_ROLLOUT,
+    CHECKPOINT_SAVE,
+    OFFLOAD_TRAIN,
+    EVAL_AFTER,
+}
 
 RUN_ID = "run-hooks"
 STEP = 1
@@ -220,13 +226,29 @@ def test_substep_times_with_missing_substeps():
     ]
     assert aggregate_durations(schedule_missing_offload_rollout) == {
         EVAL_BEFORE: 1.5,
-        ROLLOUT_LOGGING: None,
+        ROLLOUT_LOGGING: 4.0,
         COMPUTE_LOG_PROBS: 4.0,
         OPTIMIZER_STEP: 2.0,
         CHECKPOINT_SAVE: 1.0,
         OFFLOAD_TRAIN: 2.0,
         WEIGHT_SYNC: 1.0,
         EVAL_AFTER: 2.0,
+    }
+
+    schedule_missing_both_offloads = [
+        (0.0, "substep_window_start"),
+        (2.0, "step_start"),
+        (6.0, "compute_log_probs"),
+        (10.0, "optimizer_step"),
+        (15.0, "weight_sync"),
+        (18.0, "substep_finish"),
+        (18.0, "step_complete"),
+    ]
+    assert aggregate_durations(schedule_missing_both_offloads) == {
+        ROLLOUT_LOGGING: 4.0,
+        COMPUTE_LOG_PROBS: 4.0,
+        OPTIMIZER_STEP: 5.0,
+        WEIGHT_SYNC: 3.0,
     }
 
     schedule_missing_substep_finish = [


### PR DESCRIPTION
Make offload rollout and train optional for when noncolocated training runs do not include them. Currently noncolocated runs will mark substep duration of rollouts as none since the start time of the next step (offloading) does not exist, when it should just take the start time of the following step.

Also update tests and validate model configs flags accordingly to test.