### PR TITLE
Add documentation previews for PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,42 @@ jobs:
       - name: Validate docs_next_app.py
         run: uv run python -m py_compile docs-next/docs_next_app.py
 
+      - name: Archive docs dist
+        if: github.event_name == 'pull_request'
+        run: tar -czf docs.tar.gz -C docs-next/dist .
+
+      - name: Upload docs artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-dist
+          path: docs.tar.gz
+
+  preview:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.PREVIEW_MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.PREVIEW_MODAL_TOKEN_SECRET }}
+      MODAL_ENVIRONMENT: training-gym
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-dist
+
+      - name: Deploy docs preview
+        run: uv run --no-project --with modal python scripts/previews/deploy.py ${{ github.event.pull_request.number }} docs docs.tar.gz
+
   deploy:
     # The `secrets` context is not available in job-level `if:`, so gate on the
     # ref only; credentials come from the `modal-deploy` environment, which has

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,6 +83,9 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       MODAL_TOKEN_ID: ${{ secrets.PREVIEW_MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.PREVIEW_MODAL_TOKEN_SECRET }}
@@ -102,6 +105,33 @@ jobs:
 
       - name: Deploy docs preview
         run: uv run --no-project --with modal python scripts/previews/deploy.py ${{ github.event.pull_request.number }} docs docs.tar.gz
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_BASE_URL: ${{ vars.PREVIEW_BASE_URL }}
+        with:
+          script: |
+            const marker = "<!-- training-gym-docs-preview -->";
+            const prNumber = context.payload.pull_request.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            if (comments.some((comment) => comment.body.includes(marker))) {
+              console.log("Preview comment already exists; skipping");
+              return;
+            }
+
+            const baseUrl = process.env.PREVIEW_BASE_URL.replace(/\/+$/, "");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `${marker}\nDocumentation preview: ${baseUrl}/${prNumber}/docs`,
+            });
 
   deploy:
     # The `secrets` context is not available in job-level `if:`, so gate on the

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: docs
+  group: docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/previews-app.yml
+++ b/.github/workflows/previews-app.yml
@@ -1,0 +1,38 @@
+name: Previews App
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/previews-app.yml"
+      - "scripts/previews/frontend_previews.py"
+      - "scripts/previews/nginx/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: previews-app
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == ''
+    environment: modal-deploy
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      MODAL_ENVIRONMENT: training-gym
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Deploy previews app to Modal
+        run: uv run --no-project --with modal modal deploy scripts/previews/frontend_previews.py

--- a/.github/workflows/previews-app.yml
+++ b/.github/workflows/previews-app.yml
@@ -19,7 +19,6 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == ''
     environment: modal-deploy
     env:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}

--- a/scripts/previews/README.md
+++ b/scripts/previews/README.md
@@ -1,0 +1,6 @@
+The training gym preview system automatically generates previews of the dashboard and documentation frontends for relevant PRs. When a PR is opened or updated, CI uploads `.tar.gz` artifacts to a Modal volume, then calls a Modal function in `frontend_previews.py` to deploy the preview to a Modal Sandbox. A simple web function, called the redirector, takes care of directing users to the correct sandbox.
+
+For this to work, a few prerequisites need to be met:
+* `frontend_previews.py` must be deployed. This is taken care of by the `previews-app.yml` workflow, which is run on every push to `main`, but you may need to manually rerun the workflow if the app was deleted from Modal.
+* `PREVIEW_MODAL_TOKEN_ID` and `PREVIEW_MODAL_TOKEN_SECRET` need to be set to a valid Modal API key in the repository's secrets.
+* `PREVIEW_BASE_URL` must be set in the repository settings to the URL of the deployed redirector. This is so that CI workflows can post comments with preview URLs.

--- a/scripts/previews/deploy.py
+++ b/scripts/previews/deploy.py
@@ -1,0 +1,40 @@
+"""Deploy a frontend preview for a PR.
+
+Uploads the given artifact (a .tar.gz of the built frontend) to the preview
+volume and deploys it for the given PR.
+
+Run with plain `python`, not `modal run`:
+
+    python scripts/previews/deploy.py 244 dashboard path/to/dashboard.tar.gz
+"""
+
+import argparse
+import secrets
+from pathlib import Path
+import modal
+import asyncio
+
+async def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pr_number", type=int, help="PR number to deploy the preview for")
+    parser.add_argument("type", choices=["dashboard", "docs"], help="which frontend to deploy")
+    parser.add_argument("artifact", type=Path, help="path to the artifact .tar.gz")
+    args = parser.parse_args()
+
+    if not args.artifact.is_file():
+        parser.error(f"artifact not found: {args.artifact}")
+
+    artifact_name = f"pr{args.pr_number}-{args.type}-{secrets.token_hex(8)}.tar.gz"
+
+    deploy_preview = modal.Function.from_name("training-gym-previews", "deploy_preview")
+    vol = modal.Volume.from_name("preview-artifacts")
+
+    print(f"Uploading {args.artifact} as {artifact_name}")
+    async with vol.batch_upload.aio() as batch:
+        batch.put_file(str(args.artifact), f"/{artifact_name}")
+
+    print(f"Deploying {args.type} preview for #{args.pr_number}")
+    await deploy_preview.remote.aio(args.pr_number, args.type, artifact_name)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/previews/deploy.py
+++ b/scripts/previews/deploy.py
@@ -14,10 +14,15 @@ from pathlib import Path
 import modal
 import asyncio
 
+
 async def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("pr_number", type=int, help="PR number to deploy the preview for")
-    parser.add_argument("type", choices=["dashboard", "docs"], help="which frontend to deploy")
+    parser.add_argument(
+        "pr_number", type=int, help="PR number to deploy the preview for"
+    )
+    parser.add_argument(
+        "type", choices=["dashboard", "docs"], help="which frontend to deploy"
+    )
     parser.add_argument("artifact", type=Path, help="path to the artifact .tar.gz")
     args = parser.parse_args()
 
@@ -35,6 +40,7 @@ async def main():
 
     print(f"Deploying {args.type} preview for #{args.pr_number}")
     await deploy_preview.remote.aio(args.pr_number, args.type, artifact_name)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -1,0 +1,205 @@
+from pathlib import Path
+import modal
+from collections import defaultdict
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta
+from typing import Literal, TypeAlias, Optional
+
+NGINX_CONF_DIR = Path("/root/nginx")
+
+image = (
+    modal.Image.debian_slim()
+    .pip_install("PyGithub~=2.6.1")
+    .add_local_dir(Path(__file__).resolve().parent / "nginx", NGINX_CONF_DIR)
+)
+
+with image.imports():
+    from github import Github
+
+redirector_image = (
+    modal.Image.debian_slim()
+    .pip_install("fastapi[standard]==0.139.0")
+)
+
+app = modal.App(
+    name="training-gym-previews",
+    image=image,
+)
+
+vol = modal.Volume.from_name("preview-artifacts", create_if_missing=True)
+deployments = modal.Dict.from_name("training-gym-deployments", create_if_missing=True)
+
+MOUNT_POINT = Path("/vol")
+SANDBOX_APP_NAME = "training-gym-preview-sandboxes"
+SANDBOX_PORT = 80
+SANDBOX_TIMEOUT = timedelta(hours=24)
+
+def get_mounted_artifact_path(name):
+    return MOUNT_POINT / name
+
+PreviewType: TypeAlias = Literal["dashboard", "docs"]
+
+@dataclass
+class PreviewDeployment:
+    type: PreviewType
+    artifact: str
+    sandbox_id: Optional[str] = None
+    url: Optional[str] = None
+    expiration: datetime | None = None
+
+    def deploy(self):
+        print(f"Deploying {self.type} preview from {self.artifact}")
+
+        path = get_mounted_artifact_path(self.artifact)
+        image = (
+            modal.Image.from_registry("nginx")
+            .run_commands("rm /etc/nginx/conf.d/default.conf")
+            .add_local_file(path, "/root/artifact.tar.gz", copy=True)
+            .run_commands(
+                "tar -xzf /root/artifact.tar.gz -C /usr/share/nginx/html",
+                "rm /root/artifact.tar.gz",
+            )
+        )
+
+        remote_conf = "/etc/nginx/conf.d/preview.conf"
+
+        if self.type == "dashboard":
+            image = image.add_local_file(NGINX_CONF_DIR / "dashboard.conf", remote_conf)
+
+        if self.type == "docs":
+            image = image.add_local_file(NGINX_CONF_DIR / "docs.conf", remote_conf)
+
+        sb_app = modal.App.lookup(SANDBOX_APP_NAME, create_if_missing=True)
+        self.expiration = datetime.now() + SANDBOX_TIMEOUT
+
+        sb = modal.Sandbox.create(
+            "nginx", "-g", "daemon off;",
+            app=sb_app, image=image,
+            encrypted_ports=[SANDBOX_PORT],
+            idle_timeout=int(SANDBOX_TIMEOUT.total_seconds()),
+            timeout=int(SANDBOX_TIMEOUT.total_seconds()),
+        )
+
+        print(f"Created sandbox {sb.object_id}")
+
+        tunnels = sb.tunnels()
+        tunnel = tunnels[SANDBOX_PORT]
+        self.sandbox_id = sb.object_id
+        self.url = tunnel.url
+        sb.detach()
+
+        print(f"Deployed {self.type} preview to {self.url} ({self.sandbox_id})")
+    
+    def refresh(self):
+        print(f"Refreshing {self.type} deploy for {self.artifact}")
+        self.terminate()
+        self.deploy()
+
+    def terminate(self):
+        print(f"Terminating {self.type} deploy for {self.artifact} ({self.sandbox_id})")
+        
+        sb = modal.Sandbox.from_id(self.sandbox_id)
+        sb.terminate(wait=False)
+
+        print(f"Requested termination of sandbox {self.sandbox_id}")
+
+        self.sandbox_id = None
+        self.url = None
+        self.expiration = None
+    
+    def cleanup_artifact(self):
+        path = get_mounted_artifact_path(self.artifact)
+        path.unlink(missing_ok=True)
+        print(f"Removed {path}")
+
+@app.function(volumes={MOUNT_POINT: vol})
+def deploy_preview(pr_number: int, type: PreviewType, artifact: str):
+    print(f"Deploying {type} preview for #{pr_number}")
+    key = (pr_number, type)
+    deployment_dict = deployments.get((pr_number, type), None)
+    if deployment_dict is not None:
+        deployment = PreviewDeployment(**deployment_dict)
+        deployment.terminate()
+        deployment.cleanup_artifact()
+    
+    vol.reload()
+
+    deployment = PreviewDeployment(type=type, artifact=artifact)
+    deployment.deploy()
+    deployments[key] = asdict(deployment)
+
+def needs_refresh(preview: PreviewDeployment):
+    if preview.expiration is not None:
+        if datetime.now() + timedelta(hours=1) >= preview.expiration:
+            return True
+    return False
+
+def is_expired(preview: PreviewDeployment):
+    if preview.expiration is not None:
+        return datetime.now() >= preview.expiration
+    return False
+
+@app.function(schedule=modal.Period(hours=1), volumes={MOUNT_POINT: vol})
+def refresh_sandboxes():
+    from github.GithubException import UnknownObjectException
+
+    print("Refreshing sandboxes")
+
+    gh = Github()
+    repo = gh.get_repo("modal-projects/training-gym")
+
+    prs = defaultdict(list)
+    for (pr_number, _), deployment in list(deployments.items()):
+        prs[pr_number].append(PreviewDeployment(**deployment))
+    
+    for pr_number, pr_deployments in prs.items():
+        try:
+            pr = repo.get_pull(pr_number)
+            is_open = pr.state == "open"        
+
+            for deployment in pr_deployments:
+                key = (pr_number, type)
+                if is_open:
+                    if needs_refresh(deployment):
+                        deployment.refresh()
+                        deployments[key] = asdict(deployment)
+                else:
+                    if is_expired(deployment):
+                        deployment.terminate()
+                        deployment.cleanup_artifact()
+                        deployments.pop(key, None)
+        except UnknownObjectException:
+            print(f"Warning: Unknown PR #{pr_number}")
+
+@app.function(image=redirector_image)
+@modal.asgi_app()
+def preview_redirector():
+    from fastapi import FastAPI, Request
+    from fastapi.responses import PlainTextResponse, RedirectResponse
+    redirector = FastAPI()
+
+    @redirector.get("/{pr_number}/{type}/{path:path}")
+    @redirector.get("/{pr_number}/{type}")
+    async def redirect_to_preview(request: Request, pr_number: int, type: PreviewType, path: str = ""):
+        deployment_dict = await deployments.get.aio((pr_number, type), None)
+        if deployment_dict is None:
+            return PlainTextResponse(
+                content="Preview not found",
+                status_code=404,
+            )
+    
+        deployment = PreviewDeployment(**deployment_dict)
+        if deployment.url is None:
+            return PlainTextResponse(
+                content="Deployment is missing a URL",
+                status=503,
+            )
+    
+        url = deployment.url
+        if path:
+            url = f"{url}/{path}"
+        if request.query_params:
+            url = f"{url}?{request.query_params}"
+        return RedirectResponse(url)
+
+    return redirector

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -16,10 +16,7 @@ image = (
 with image.imports():
     from github import Github
 
-redirector_image = (
-    modal.Image.debian_slim()
-    .pip_install("fastapi[standard]==0.139.0")
-)
+redirector_image = modal.Image.debian_slim().pip_install("fastapi[standard]==0.139.0")
 
 app = modal.App(
     name="training-gym-previews",
@@ -34,10 +31,13 @@ SANDBOX_APP_NAME = "training-gym-preview-sandboxes"
 SANDBOX_PORT = 80
 SANDBOX_TIMEOUT = timedelta(hours=24)
 
+
 def get_mounted_artifact_path(name):
     return MOUNT_POINT / name
 
+
 PreviewType: TypeAlias = Literal["dashboard", "docs"]
+
 
 @dataclass
 class PreviewDeployment:
@@ -73,8 +73,11 @@ class PreviewDeployment:
         self.expiration = datetime.now() + SANDBOX_TIMEOUT
 
         sb = modal.Sandbox.create(
-            "nginx", "-g", "daemon off;",
-            app=sb_app, image=image,
+            "nginx",
+            "-g",
+            "daemon off;",
+            app=sb_app,
+            image=image,
             encrypted_ports=[SANDBOX_PORT],
             idle_timeout=int(SANDBOX_TIMEOUT.total_seconds()),
             timeout=int(SANDBOX_TIMEOUT.total_seconds()),
@@ -89,7 +92,7 @@ class PreviewDeployment:
         sb.detach()
 
         print(f"Deployed {self.type} preview to {self.url} ({self.sandbox_id})")
-    
+
     def refresh(self):
         print(f"Refreshing {self.type} deploy for {self.artifact}")
         self.terminate()
@@ -97,7 +100,7 @@ class PreviewDeployment:
 
     def terminate(self):
         print(f"Terminating {self.type} deploy for {self.artifact} ({self.sandbox_id})")
-        
+
         sb = modal.Sandbox.from_id(self.sandbox_id)
         sb.terminate(wait=False)
 
@@ -106,11 +109,12 @@ class PreviewDeployment:
         self.sandbox_id = None
         self.url = None
         self.expiration = None
-    
+
     def cleanup_artifact(self):
         path = get_mounted_artifact_path(self.artifact)
         path.unlink(missing_ok=True)
         print(f"Removed {path}")
+
 
 @app.function(volumes={MOUNT_POINT: vol})
 def deploy_preview(pr_number: int, type: PreviewType, artifact: str):
@@ -121,12 +125,13 @@ def deploy_preview(pr_number: int, type: PreviewType, artifact: str):
         deployment = PreviewDeployment(**deployment_dict)
         deployment.terminate()
         deployment.cleanup_artifact()
-    
+
     vol.reload()
 
     deployment = PreviewDeployment(type=type, artifact=artifact)
     deployment.deploy()
     deployments[key] = asdict(deployment)
+
 
 def needs_refresh(preview: PreviewDeployment):
     if preview.expiration is not None:
@@ -134,10 +139,12 @@ def needs_refresh(preview: PreviewDeployment):
             return True
     return False
 
+
 def is_expired(preview: PreviewDeployment):
     if preview.expiration is not None:
         return datetime.now() >= preview.expiration
     return False
+
 
 @app.function(schedule=modal.Period(hours=1), volumes={MOUNT_POINT: vol})
 def refresh_sandboxes():
@@ -151,11 +158,11 @@ def refresh_sandboxes():
     prs = defaultdict(list)
     for (pr_number, _), deployment in list(deployments.items()):
         prs[pr_number].append(PreviewDeployment(**deployment))
-    
+
     for pr_number, pr_deployments in prs.items():
         try:
             pr = repo.get_pull(pr_number)
-            is_open = pr.state == "open"        
+            is_open = pr.state == "open"
 
             for deployment in pr_deployments:
                 key = (pr_number, type)
@@ -171,30 +178,34 @@ def refresh_sandboxes():
         except UnknownObjectException:
             print(f"Warning: Unknown PR #{pr_number}")
 
+
 @app.function(image=redirector_image)
 @modal.asgi_app()
 def preview_redirector():
     from fastapi import FastAPI, Request
     from fastapi.responses import PlainTextResponse, RedirectResponse
+
     redirector = FastAPI()
 
     @redirector.get("/{pr_number}/{type}/{path:path}")
     @redirector.get("/{pr_number}/{type}")
-    async def redirect_to_preview(request: Request, pr_number: int, type: PreviewType, path: str = ""):
+    async def redirect_to_preview(
+        request: Request, pr_number: int, type: PreviewType, path: str = ""
+    ):
         deployment_dict = await deployments.get.aio((pr_number, type), None)
         if deployment_dict is None:
             return PlainTextResponse(
                 content="Preview not found",
                 status_code=404,
             )
-    
+
         deployment = PreviewDeployment(**deployment_dict)
         if deployment.url is None:
             return PlainTextResponse(
                 content="Deployment is missing a URL",
                 status=503,
             )
-    
+
         url = deployment.url
         if path:
             url = f"{url}/{path}"

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -169,7 +169,9 @@ def refresh_sandboxes():
                     if is_open:
                         if needs_refresh(deployment):
                             try:
-                                print(f"Refreshing {deployment.type} deploy for {deployment.artifact}")
+                                print(
+                                    f"Refreshing {deployment.type} deploy for {deployment.artifact}"
+                                )
                                 deployment.terminate()
                                 deployment.deploy()
                             finally:

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -120,13 +120,14 @@ class PreviewDeployment:
 def deploy_preview(pr_number: int, type: PreviewType, artifact: str):
     print(f"Deploying {type} preview for #{pr_number}")
     key = (pr_number, type)
+
+    vol.reload()
+
     deployment_dict = deployments.get((pr_number, type), None)
     if deployment_dict is not None:
         deployment = PreviewDeployment(**deployment_dict)
         deployment.terminate()
         deployment.cleanup_artifact()
-
-    vol.reload()
 
     deployment = PreviewDeployment(type=type, artifact=artifact)
     deployment.deploy()

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -165,7 +165,7 @@ def refresh_sandboxes():
             is_open = pr.state == "open"
 
             for deployment in pr_deployments:
-                key = (pr_number, type)
+                key = (pr_number, deployment.type)
                 if is_open:
                     if needs_refresh(deployment):
                         deployment.refresh()
@@ -203,7 +203,7 @@ def preview_redirector():
         if deployment.url is None:
             return PlainTextResponse(
                 content="Deployment is missing a URL",
-                status=503,
+                status_code=503,
             )
 
         url = deployment.url

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -1,3 +1,4 @@
+import traceback
 from pathlib import Path
 import modal
 from collections import defaultdict
@@ -166,16 +167,25 @@ def refresh_sandboxes():
             is_open = pr.state == "open"
 
             for deployment in pr_deployments:
-                key = (pr_number, deployment.type)
-                if is_open:
-                    if needs_refresh(deployment):
-                        deployment.refresh()
-                        deployments[key] = asdict(deployment)
-                else:
-                    if is_expired(deployment):
-                        deployment.terminate()
-                        deployment.cleanup_artifact()
-                        deployments.pop(key, None)
+                try:
+                    key = (pr_number, deployment.type)
+                    if is_open:
+                        if needs_refresh(deployment):
+                            deployment.refresh()
+                            deployments[key] = asdict(deployment)
+                    else:
+                        if is_expired(deployment):
+                            deployment.terminate()
+                            deployment.cleanup_artifact()
+                            deployments.pop(key, None)
+                except Exception as e:
+                    action = "refresh" if is_open else "clean up"
+                    print(
+                        f"Error: Failed to {action} {deployment.type} preview for "
+                        f"#{pr_number} (sandbox={deployment.sandbox_id}, "
+                        f"artifact={deployment.artifact}): {e!r}"
+                    )
+                    traceback.print_exc()
         except UnknownObjectException:
             print(f"Warning: Unknown PR #{pr_number}")
 

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -94,11 +94,6 @@ class PreviewDeployment:
 
         print(f"Deployed {self.type} preview to {self.url} ({self.sandbox_id})")
 
-    def refresh(self):
-        print(f"Refreshing {self.type} deploy for {self.artifact}")
-        self.terminate()
-        self.deploy()
-
     def terminate(self):
         print(f"Terminating {self.type} deploy for {self.artifact} ({self.sandbox_id})")
 
@@ -124,15 +119,17 @@ def deploy_preview(pr_number: int, type: PreviewType, artifact: str):
 
     vol.reload()
 
-    deployment_dict = deployments.get((pr_number, type), None)
-    if deployment_dict is not None:
-        deployment = PreviewDeployment(**deployment_dict)
-        deployment.terminate()
-        deployment.cleanup_artifact()
+    try:
+        deployment_dict = deployments.get((pr_number, type), None)
+        if deployment_dict is not None:
+            deployment = PreviewDeployment(**deployment_dict)
+            deployment.terminate()
+            deployment.cleanup_artifact()
 
-    deployment = PreviewDeployment(type=type, artifact=artifact)
-    deployment.deploy()
-    deployments[key] = asdict(deployment)
+        deployment = PreviewDeployment(type=type, artifact=artifact)
+        deployment.deploy()
+    finally:
+        deployments[key] = asdict(deployment)
 
 
 def needs_refresh(preview: PreviewDeployment):
@@ -171,11 +168,19 @@ def refresh_sandboxes():
                     key = (pr_number, deployment.type)
                     if is_open:
                         if needs_refresh(deployment):
-                            deployment.refresh()
-                            deployments[key] = asdict(deployment)
+                            try:
+                                print(f"Refreshing {deployment.type} deploy for {deployment.artifact}")
+                                deployment.terminate()
+                                deployment.deploy()
+                            finally:
+                                deployments[key] = asdict(deployment)
                     else:
                         if is_expired(deployment):
-                            deployment.terminate()
+                            try:
+                                deployment.terminate()
+                            except:
+                                deployments[key] = asdict(deployment)
+                                raise
                             deployment.cleanup_artifact()
                             deployments.pop(key, None)
                 except Exception as e:

--- a/scripts/previews/nginx/dashboard.conf
+++ b/scripts/previews/nginx/dashboard.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/scripts/previews/nginx/docs.conf
+++ b/scripts/previews/nginx/docs.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+}


### PR DESCRIPTION
This PR introduces an automated documentation preview system for PRs. When a PR is opened, our CI builds the documentation, uploads it to a volume, and deploys it on a Modal Sandbox. A cron job, running on Modal, recreates sandboxes as necessary until the PR is merged or closed.

This will facilitate documentation-related PR reviews. An extension is in the works for previewing the dashboard itself - there are slightly more moving parts to that one.