### PR TITLE
Add per-sample inference observability

### DIFF
--- a/dashboards/frontend/src/components/InferenceStats.svelte
+++ b/dashboards/frontend/src/components/InferenceStats.svelte
@@ -11,10 +11,13 @@
 
   let stats = $derived.by(() => {
     if (!inference) return [];
-    const items = [
-      { label: "tokens in", value: formatCount(inference.tokens_in) },
-      { label: "tokens out", value: formatCount(inference.tokens_out) },
-    ];
+    const items = [];
+    if (Number.isFinite(inference.tokens_in)) {
+      items.push({ label: "tokens in", value: formatCount(inference.tokens_in) });
+    }
+    if (Number.isFinite(inference.tokens_out)) {
+      items.push({ label: "tokens out", value: formatCount(inference.tokens_out) });
+    }
     if (Number.isFinite(inference.new_tokens)) {
       items.push({ label: "new tokens", value: formatCount(inference.new_tokens) });
     }

--- a/dashboards/frontend/src/components/InferenceStats.svelte
+++ b/dashboards/frontend/src/components/InferenceStats.svelte
@@ -18,15 +18,15 @@
     if (Number.isFinite(inference.tokens_out)) {
       items.push({ label: "tokens out", value: formatCount(inference.tokens_out) });
     }
-    if (Number.isFinite(inference.new_tokens)) {
-      items.push({ label: "new tokens", value: formatCount(inference.new_tokens) });
-    }
     if (Number.isFinite(inference.cached_tokens)) {
       items.push({
         label: "cached tokens",
         value: formatCount(inference.cached_tokens),
         suffix: `(${formatPercent(inference.cache_hit_rate)})`,
       });
+    }
+    if (Number.isFinite(inference.new_tokens)) {
+      items.push({ label: "new tokens", value: formatCount(inference.new_tokens) });
     }
     return items;
   });

--- a/dashboards/frontend/src/components/InferenceStats.svelte
+++ b/dashboards/frontend/src/components/InferenceStats.svelte
@@ -1,0 +1,51 @@
+<script>
+  let { inference = null } = $props();
+
+  function formatCount(value) {
+    return Number.isFinite(value) ? Math.round(value).toLocaleString() : "—";
+  }
+
+  function formatPercent(value) {
+    return Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : "—";
+  }
+
+  
+</script>
+
+{#if inference}
+  <div
+    class="grid grid-cols-[repeat(auto-fit,minmax(110px,1fr))] gap-[6px] mb-[10px]"
+    aria-label="Inference statistics"
+  >
+    <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
+      <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">tokens in</div>
+      <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
+        {formatCount(inference.tokens_in)}
+      </div>
+    </div>
+    <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
+      <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">tokens out</div>
+      <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
+        {formatCount(inference.tokens_out)}
+      </div>
+    </div>
+    {#if Number.isFinite(inference.new_tokens)}
+      <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
+        <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">new tokens</div>
+        <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
+          {formatCount(inference.new_tokens)}
+        </div>
+      </div>
+    {/if}
+    {#if Number.isFinite(inference.cached_tokens)}
+      <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
+        <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">cached tokens</div>
+        <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
+          {formatCount(inference.cached_tokens)}
+          <span class="text-(--muted)">({formatPercent(inference.cache_hit_rate)})</span>
+        </div>
+      </div>
+    {/if}
+  
+  </div>
+{/if}

--- a/dashboards/frontend/src/components/InferenceStats.svelte
+++ b/dashboards/frontend/src/components/InferenceStats.svelte
@@ -9,43 +9,39 @@
     return Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : "—";
   }
 
-  
+  let stats = $derived.by(() => {
+    if (!inference) return [];
+    const items = [
+      { label: "tokens in", value: formatCount(inference.tokens_in) },
+      { label: "tokens out", value: formatCount(inference.tokens_out) },
+    ];
+    if (Number.isFinite(inference.new_tokens)) {
+      items.push({ label: "new tokens", value: formatCount(inference.new_tokens) });
+    }
+    if (Number.isFinite(inference.cached_tokens)) {
+      items.push({
+        label: "cached tokens",
+        value: formatCount(inference.cached_tokens),
+        suffix: `(${formatPercent(inference.cache_hit_rate)})`,
+      });
+    }
+    return items;
+  });
 </script>
 
-{#if inference}
+{#if stats.length}
   <div
     class="grid grid-cols-[repeat(auto-fit,minmax(110px,1fr))] gap-[6px] mb-[10px]"
     aria-label="Inference statistics"
   >
-    <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
-      <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">tokens in</div>
-      <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
-        {formatCount(inference.tokens_in)}
-      </div>
-    </div>
-    <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
-      <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">tokens out</div>
-      <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
-        {formatCount(inference.tokens_out)}
-      </div>
-    </div>
-    {#if Number.isFinite(inference.new_tokens)}
+    {#each stats as stat (stat.label)}
       <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
-        <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">new tokens</div>
+        <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">{stat.label}</div>
         <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
-          {formatCount(inference.new_tokens)}
+          {stat.value}
+          {#if stat.suffix}<span class="text-(--muted)">{stat.suffix}</span>{/if}
         </div>
       </div>
-    {/if}
-    {#if Number.isFinite(inference.cached_tokens)}
-      <div class="rounded-[4px] [border:1px_solid_var(--border)] p-[6px_8px]">
-        <div class="text-[10px] uppercase tracking-[0.05em] text-(--muted)">cached tokens</div>
-        <div class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
-          {formatCount(inference.cached_tokens)}
-          <span class="text-(--muted)">({formatPercent(inference.cache_hit_rate)})</span>
-        </div>
-      </div>
-    {/if}
-  
+    {/each}
   </div>
 {/if}

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -5,6 +5,7 @@
   import StepTimings from "../components/StepTimings.svelte";
   import StatusPill from "../components/StatusPill.svelte";
   import TimeAgo from "../components/TimeAgo.svelte";
+  import InferenceStats from "../components/InferenceStats.svelte";
   import SampleTimeline from "../components/SampleTimeline.svelte";
   import ConversationView from "../components/ConversationView.svelte";
   import AdvantageViolins from "../components/AdvantageViolins.svelte";
@@ -1078,6 +1079,10 @@
                               </button>
                             </div>
                           </div>
+                          {#if activeSample.sample.metadata?.inference}
+                            <div class="rollout-sample-label">inference</div>
+                            <InferenceStats inference={activeSample.sample.metadata.inference} />
+                          {/if}
                           {#if activeSample.sample.metadata?._metadata_type === "audio" || activeSample.sample.metadata?.audio}
                             <div class="rollout-sample-label">audio</div>
                             <audio

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -235,18 +235,22 @@ def _extract_trace(sample: Any) -> Any:
     return raw
 
 
+def _duck_get(obj: Any, key: str, default: Any = None) -> Any:
+    """Unified field access for dict or object."""
+    return (
+        obj.get(key, default) if isinstance(obj, dict) else getattr(obj, key, default)
+    )
+
+
 def _extract_inference_metadata(sample: Any) -> dict[str, Any] | None:
     """Extract per-sample inference stats: token counts and prefix cache info."""
-    if isinstance(sample, dict):
-        prefix_info = sample.get("prefix_cache_info")
-    else:
-        prefix_info = getattr(sample, "prefix_cache_info", None)
+    prefix_info = _duck_get(sample, "prefix_cache_info")
     if prefix_info is None:
         return None
 
-    total = _coerce_int(getattr(prefix_info, "total_prompt_tokens", 0))
-    cached = _coerce_int(getattr(prefix_info, "cached_tokens", 0))
-    resp_len = getattr(sample, "response_length", None)
+    total = _coerce_int(_duck_get(prefix_info, "total_prompt_tokens", 0))
+    cached = _coerce_int(_duck_get(prefix_info, "cached_tokens", 0))
+    resp_len = _duck_get(sample, "response_length")
 
     inference: dict[str, Any] = {
         "tokens_in": total,

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -228,7 +228,6 @@ def _extract_trace(sample: Any) -> Any:
     return raw
 
 
-
 def _extract_inference_metadata(sample: Any) -> dict[str, Any] | None:
     """Extract per-sample inference stats: token counts and prefix cache info."""
     prefix_info = getattr(sample, "prefix_cache_info", None)
@@ -238,7 +237,7 @@ def _extract_inference_metadata(sample: Any) -> dict[str, Any] | None:
     total = int(getattr(prefix_info, "total_prompt_tokens", 0) or 0)
     cached = int(getattr(prefix_info, "cached_tokens", 0) or 0)
     resp_len = getattr(sample, "response_length", None)
-    
+
     inference: dict[str, Any] = {
         "tokens_in": total,
         "cached_tokens": cached,

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -133,7 +133,7 @@ def _trace_sample_limit() -> int:
 def _coerce_int(value: Any) -> int:
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return 0
 
 

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -130,6 +130,13 @@ def _trace_sample_limit() -> int:
     return max(0, n)
 
 
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _coerce_float(value: Any) -> float | None:
     try:
         return float(value)
@@ -230,12 +237,15 @@ def _extract_trace(sample: Any) -> Any:
 
 def _extract_inference_metadata(sample: Any) -> dict[str, Any] | None:
     """Extract per-sample inference stats: token counts and prefix cache info."""
-    prefix_info = getattr(sample, "prefix_cache_info", None)
+    if isinstance(sample, dict):
+        prefix_info = sample.get("prefix_cache_info")
+    else:
+        prefix_info = getattr(sample, "prefix_cache_info", None)
     if prefix_info is None:
         return None
 
-    total = int(getattr(prefix_info, "total_prompt_tokens", 0) or 0)
-    cached = int(getattr(prefix_info, "cached_tokens", 0) or 0)
+    total = _coerce_int(getattr(prefix_info, "total_prompt_tokens", 0))
+    cached = _coerce_int(getattr(prefix_info, "cached_tokens", 0))
     resp_len = getattr(sample, "response_length", None)
 
     inference: dict[str, Any] = {
@@ -245,7 +255,7 @@ def _extract_inference_metadata(sample: Any) -> dict[str, Any] | None:
         "cache_hit_rate": cached / total if total else 0.0,
     }
     if resp_len is not None:
-        inference["tokens_out"] = int(resp_len)
+        inference["tokens_out"] = _coerce_int(resp_len)
 
     return inference
 

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -228,6 +228,29 @@ def _extract_trace(sample: Any) -> Any:
     return raw
 
 
+
+def _extract_inference_metadata(sample: Any) -> dict[str, Any] | None:
+    """Extract per-sample inference stats: token counts and prefix cache info."""
+    prefix_info = getattr(sample, "prefix_cache_info", None)
+    if prefix_info is None:
+        return None
+
+    total = int(getattr(prefix_info, "total_prompt_tokens", 0) or 0)
+    cached = int(getattr(prefix_info, "cached_tokens", 0) or 0)
+    resp_len = getattr(sample, "response_length", None)
+    
+    inference: dict[str, Any] = {
+        "tokens_in": total,
+        "cached_tokens": cached,
+        "new_tokens": max(0, total - cached),
+        "cache_hit_rate": cached / total if total else 0.0,
+    }
+    if resp_len is not None:
+        inference["tokens_out"] = int(resp_len)
+
+    return inference
+
+
 def _extract_audio_from_prompt(prompt: Any) -> str | None:
     """Pull a browser-playable audio data-URI out of a conversation-list prompt.
 
@@ -432,6 +455,8 @@ def _sample_to_dict(
         value = get(key) if attrs is not None else get(key, None)
         if value is not None:
             metadata[key] = value
+    if inference := _extract_inference_metadata(sample):
+        metadata["inference"] = inference
 
     # Pull display-relevant fields from the sample's own metadata dict so the
     # dashboard can render exit status, eval checks, etc. without needing the

--- a/tests/test_sample_trace.py
+++ b/tests/test_sample_trace.py
@@ -123,6 +123,81 @@ def test_extract_trace_from_attr_metadata_and_dict():
     assert pr._extract_trace(SimpleNamespace(prompt="x")) is None
 
 
+# ── inference metadata ───────────────────────────────────────────────────────
+
+
+def test_sample_to_dict_extracts_prefix_cache_info():
+    sample = SimpleNamespace(
+        prompt="prompt",
+        response="response",
+        reward=1.0,
+        response_length=80,
+        prefix_cache_info=SimpleNamespace(
+            total_prompt_tokens=1_000,
+            cached_tokens=250,
+        ),
+    )
+
+    recorded = pr._sample_to_dict(sample)
+
+    assert recorded["metadata"]["inference"] == {
+        "tokens_in": 1_000,
+        "tokens_out": 80,
+        "cached_tokens": 250,
+        "new_tokens": 750,
+        "cache_hit_rate": 0.25,
+    }
+
+
+def test_sample_to_dict_100_percent_cache_hit():
+    """All prompt tokens cached → cache_hit_rate is 1.0, new_tokens is 0."""
+    sample = SimpleNamespace(
+        prompt="prompt",
+        response="response",
+        reward=1.0,
+        response_length=120,
+        prefix_cache_info=SimpleNamespace(
+            total_prompt_tokens=500,
+            cached_tokens=500,
+        ),
+    )
+
+    recorded = pr._sample_to_dict(sample)
+
+    assert recorded["metadata"]["inference"] == {
+        "tokens_in": 500,
+        "tokens_out": 120,
+        "cached_tokens": 500,
+        "new_tokens": 0,
+        "cache_hit_rate": 1.0,
+    }
+
+
+
+    recorded = pr._sample_to_dict(sample)
+    inf = recorded["metadata"]["inference"]
+
+    assert inf["tokens_in"] == 1000
+    assert inf["tokens_out"] == 120
+    assert inf["cached_tokens"] == 200
+    assert inf["new_tokens"] == 800
+    assert inf["cache_hit_rate"] == 0.2
+
+
+def test_sample_to_dict_no_inference_without_prefix_cache_info():
+    """Samples without prefix_cache_info (e.g. custom rollouts) get no inference key."""
+    sample = SimpleNamespace(
+        prompt="prompt",
+        response="response",
+        reward=0.0,
+        response_length=4,
+    )
+
+    recorded = pr._sample_to_dict(sample)
+
+    assert "inference" not in recorded["metadata"]
+
+
 # ── capture gate + sampling ──────────────────────────────────────────────────
 
 

--- a/tests/test_sample_trace.py
+++ b/tests/test_sample_trace.py
@@ -173,17 +173,6 @@ def test_sample_to_dict_100_percent_cache_hit():
     }
 
 
-
-    recorded = pr._sample_to_dict(sample)
-    inf = recorded["metadata"]["inference"]
-
-    assert inf["tokens_in"] == 1000
-    assert inf["tokens_out"] == 120
-    assert inf["cached_tokens"] == 200
-    assert inf["new_tokens"] == 800
-    assert inf["cache_hit_rate"] == 0.2
-
-
 def test_sample_to_dict_no_inference_without_prefix_cache_info():
     """Samples without prefix_cache_info (e.g. custom rollouts) get no inference key."""
     sample = SimpleNamespace(


### PR DESCRIPTION
Linear issue [here](https://linear.app/modal-labs/issue/TRAIN-96/add-inference-observability-into-for-each-sample-tokens-in-tokens-out). 

Adds per-sample inference observability to the dashboard, screenshot below:

<img width="1460" height="900" alt="Screenshot 2026-07-14 at 8 02 18 PM" src="https://github.com/user-attachments/assets/ee2a5bc5-cc3e-49b2-abab-6f5bf19ad1b6" />

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->