### PR TITLE
Wrap generate function around new chat function with OpenAI-compatible messages input

### DIFF
--- a/modal_training_gym/common/deployment.py
+++ b/modal_training_gym/common/deployment.py
@@ -497,8 +497,11 @@ class ModelDeployment(BaseModel):
         ensure_ready: bool = True,
         **kwargs,
     ) -> str:
+        messages = kwargs.pop("messages", None)
+        if messages is None:
+            messages = [{"role": "user", "content": prompt}]
         message = self.chat(
-            [{"role": "user", "content": prompt}],
+            messages,
             ensure_ready=ensure_ready,
             **kwargs,
         )

--- a/modal_training_gym/common/deployment.py
+++ b/modal_training_gym/common/deployment.py
@@ -402,12 +402,19 @@ class ModelDeployment(BaseModel):
             "served_model_name": value.served_model_name,
         }
 
-    def generate(
+    # TODO(atoniolo76): A future PR should update all existing tutorials to
+    # use this new function while getting rid of the old generate.
+    def chat(
         self,
-        prompt: str | list[dict],
+        messages: list[dict],
         ensure_ready: bool = True,
+        max_attempts: int = 4,
+        timeout: int = 120,
         **kwargs,
-    ) -> str:
+    ) -> dict:
+        """Return one OpenAI-compatible chat-completion message while
+        preserving structured fields like tool_calls and reasoning_content.
+        """
         import time
 
         import requests
@@ -416,18 +423,17 @@ class ModelDeployment(BaseModel):
             self.wait_until_ready()
         body = {
             "model": self.deployment_config.served_model_name,
-            "messages": [{"role": "user", "content": prompt}],
+            "messages": messages,
             **kwargs,
         }
-        transient_status_codes = {502, 503, 504}
-        max_attempts = 4
+        transient_status_codes = {429, 500, 502, 503, 504}
 
         for attempt in range(1, max_attempts + 1):
             try:
                 resp = requests.post(
                     f"{self.url}/v1/chat/completions",
                     json=body,
-                    timeout=120,
+                    timeout=timeout,
                     headers=_modal_proxy_auth_headers(),
                 )
                 if (
@@ -443,13 +449,7 @@ class ModelDeployment(BaseModel):
                     continue
                 _raise_for_proxy_auth(resp.status_code, self.url)
                 resp.raise_for_status()
-                message = resp.json()["choices"][0]["message"]
-                content = message.get("content")
-                if isinstance(content, str):
-                    return content
-                if content is None:
-                    return message.get("reasoning_content", "")
-                return str(content)
+                return resp.json()["choices"][0]["message"]
             except (requests.ConnectionError, requests.Timeout) as exc:
                 if attempt >= max_attempts:
                     raise
@@ -463,6 +463,24 @@ class ModelDeployment(BaseModel):
         raise RuntimeError(
             f"Failed to generate from {self.url} after {max_attempts} attempts"
         )
+
+    def generate(
+        self,
+        prompt: str | list[dict],
+        ensure_ready: bool = True,
+        **kwargs,
+    ) -> str:
+        message = self.chat(
+            [{"role": "user", "content": prompt}],
+            ensure_ready=ensure_ready,
+            **kwargs,
+        )
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if content is None:
+            return message.get("reasoning_content", "")
+        return str(content)
 
     def save(self) -> None:
         payload = self.model_dump(mode="json")

--- a/modal_training_gym/common/deployment.py
+++ b/modal_training_gym/common/deployment.py
@@ -14,6 +14,7 @@ import asyncio
 from dataclasses import dataclass
 from enum import Enum
 import inspect
+import json
 import os
 import threading
 
@@ -119,6 +120,32 @@ def _raise_for_proxy_auth(status_code: int, url: str) -> None:
         "issued from remote workers (e.g. a custom rm/reward function), also "
         "forward the pair into the worker via a modal.Secret."
     )
+
+
+def _messages_to_openai(messages: list[dict]) -> list[dict]:
+    """Serialize internal tool-call arguments without mutating caller messages."""
+    wire_messages = []
+    for message in messages:
+        wire_message = dict(message)
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list):
+            wire_tool_calls = []
+            for tool_call in tool_calls:
+                if not isinstance(tool_call, dict):
+                    wire_tool_calls.append(tool_call)
+                    continue
+                wire_tool_call = dict(tool_call)
+                function = tool_call.get("function")
+                if isinstance(function, dict):
+                    wire_function = dict(function)
+                    arguments = function.get("arguments")
+                    if isinstance(arguments, dict):
+                        wire_function["arguments"] = json.dumps(arguments)
+                    wire_tool_call["function"] = wire_function
+                wire_tool_calls.append(wire_tool_call)
+            wire_message["tool_calls"] = wire_tool_calls
+        wire_messages.append(wire_message)
+    return wire_messages
 
 
 @dataclass
@@ -423,7 +450,7 @@ class ModelDeployment(BaseModel):
             self.wait_until_ready()
         body = {
             "model": self.deployment_config.served_model_name,
-            "messages": messages,
+            "messages": _messages_to_openai(messages),
             **kwargs,
         }
         transient_status_codes = {429, 500, 502, 503, 504}

--- a/tests/test_deployment_chat.py
+++ b/tests/test_deployment_chat.py
@@ -61,3 +61,38 @@ def test_chat_serializes_tool_arguments_without_mutating_messages(monkeypatch) -
         '{"key": "value"}'
     )
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == {"key": "value"}
+
+
+def test_generate_accepts_caller_supplied_messages(monkeypatch) -> None:
+    deployment = ModelDeployment.model_construct(
+        deployment_id="test",
+        deployment_config=SimpleNamespace(served_model_name="test-model"),
+        url="https://example.test",
+    )
+    supplied_messages = [
+        {"role": "system", "content": "Write Python."},
+        {"role": "user", "content": "Return hello world."},
+    ]
+    captured = {}
+
+    def chat(self, messages, ensure_ready=True, **kwargs):
+        captured["messages"] = messages
+        captured["ensure_ready"] = ensure_ready
+        captured["kwargs"] = kwargs
+        return {"content": "print('hello world')"}
+
+    monkeypatch.setattr(ModelDeployment, "chat", chat)
+
+    response = deployment.generate(
+        "unused fallback",
+        ensure_ready=False,
+        messages=supplied_messages,
+        temperature=0,
+    )
+
+    assert response == "print('hello world')"
+    assert captured == {
+        "messages": supplied_messages,
+        "ensure_ready": False,
+        "kwargs": {"temperature": 0},
+    }

--- a/tests/test_deployment_chat.py
+++ b/tests/test_deployment_chat.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from modal_training_gym.common import deployment as deployment_module
+from modal_training_gym.common.deployment import ModelDeployment
+
+
+def test_chat_serializes_tool_arguments_without_mutating_messages(monkeypatch) -> None:
+    structured_message = {
+        "content": "",
+        "tool_calls": [{"function": {"name": "lookup", "arguments": "{}"}}],
+    }
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+        @staticmethod
+        def json() -> dict:
+            return {"choices": [{"message": structured_message}]}
+
+    request_body = {}
+
+    def post(url, *, json, timeout, headers):
+        request_body.update(json)
+        return _Response()
+
+    import requests
+
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setattr(deployment_module, "_modal_proxy_auth_headers", lambda: {})
+    deployment = ModelDeployment.model_construct(
+        deployment_id="test",
+        deployment_config=SimpleNamespace(served_model_name="test-model"),
+        url="https://example.test",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_0",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": {"key": "value"},
+                    },
+                }
+            ],
+        }
+    ]
+
+    response = deployment.chat(messages, ensure_ready=False)
+
+    assert response == structured_message
+    assert request_body["model"] == "test-model"
+    assert request_body["messages"][0]["tool_calls"][0]["function"]["arguments"] == (
+        '{"key": "value"}'
+    )
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == {"key": "value"}


### PR DESCRIPTION
When deploying a custom model for multi-turn trajectories, the gym's `generate` function only accepts a single prompt string. This PR adds a `chat` function that accepts a list of messages compatible with OpenAI endpoints and wraps the existing `generate` function around it. #246 directly calls the `chat` function.

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->