### PR TITLE
Restore goldenfile test for Slime substep patching

### DIFF
--- a/.github/workflows/validate-slime-patch-snapshots.yml
+++ b/.github/workflows/validate-slime-patch-snapshots.yml
@@ -1,0 +1,37 @@
+name: Validate Slime patch snapshots
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/validate-slime-patch-snapshots.yml"
+      - "modal_training_gym/frameworks/slime/launcher.py"
+      - "scripts/fetch_slime_patch_snapshots.py"
+      - "tests/testdata/*.input"
+
+jobs:
+  validate-snapshot:
+    runs-on: ubuntu-latest
+    environment: modal
+    permissions:
+      contents: read
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      MODAL_ENVIRONMENT: training-gym
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Fetch source from pinned Slime image
+        run: uv run modal run scripts/fetch_slime_patch_snapshots.py
+
+      - name: Verify committed snapshot is current
+        run: git diff --exit-code -- tests/testdata/*.input


### PR DESCRIPTION
I accidentally removed @cskitty's workflow from #226 in a rebase and didn't catch it; this PR re-adds it.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->