### PR TITLE
Automatically reveal details for first rollout

### DIFF
--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -264,10 +264,16 @@
   async function loadRollouts(signal) {
     if (!runId) return;
     try {
+      const wasEmpty = rolloutSummaries.length === 0;
       const rows = await fetchRunRollouts(runId, { signal });
       if (signal?.aborted) return;
       rolloutSummaries = rows;
       rolloutsError = "";
+
+      // Reveal the first rollout
+      if (wasEmpty && rolloutSummaries.length > 0 && expandedRolloutId === null) {
+        toggleRolloutDetail(rolloutSummaries[0].rollout_id);
+      }
     } catch (err) {
       if (signal?.aborted) return;
       // Keep the rollouts we already have on a transient poll failure — only


### PR DESCRIPTION
To make the ability to expand rollout details more discoverable, this PR automatically reveals the details of the first rollout in each training run:

<img width="1809" height="1399" alt="Screenshot 2026-07-21 at 16 47 59" src="https://github.com/user-attachments/assets/a0f451d7-d472-43fd-a3fa-bc6e8b5993dd" />
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->