### PR TITLE
Fix spacing around training loading message

### DIFF
--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -1987,7 +1987,8 @@ table.rollout-table td {
 .detail-empty {
   color: var(--muted);
   font-size: 13px;
-  padding: 16px 0;
+  padding-top: 16px;
+  padding-bottom: 16px;
 }
 
 .dot {


### PR DESCRIPTION
The `padding: 16px 0` rule on `.detail-empty` was overriding Tailwind's `px-[24px]`, causing the run loading message to appear like this:

<img width="362" height="238" alt="Screenshot 2026-07-21 at 17 00 39" src="https://github.com/user-attachments/assets/02ca17f9-95f0-41c9-a412-377c0da28b98" />

This PR splits the `padding` rule into `padding-left` and `padding-right` so that Tailwind modifiers can now take effect:

<img width="359" height="209" alt="Screenshot 2026-07-21 at 17 00 31" src="https://github.com/user-attachments/assets/3edd6671-87df-4c2f-8800-8eace7125b11" />
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->