### PR TITLE
Tiny bug fix - Qwen3_6_35b_Recipe_Long_Context so it can be used

### DIFF
--- a/modal_training_gym/train_recipes/slime_recipe/__init__.py
+++ b/modal_training_gym/train_recipes/slime_recipe/__init__.py
@@ -8,6 +8,9 @@ from modal_training_gym.train_recipes.slime_recipe.qwen3_4b import Qwen3_4b_Reci
 from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b import (
     Qwen3_6_35b_Recipe,
 )
+from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b_long_context import (
+    Qwen3_6_35b_Recipe_Long_Context,
+)
 from modal_training_gym.train_recipes.slime_recipe.qwen3_asr_1_7b import (
     Qwen3_ASR_1_7b_Recipe,
 )
@@ -23,6 +26,7 @@ __all__ = [
     "Qwen3_4b_Recipe",
     "Qwen3_8b_Recipe",
     "Qwen3_6_35b_Recipe",
+    "Qwen3_6_35b_Recipe_Long_Context",
     "Qwen3_ASR_1_7b_Recipe",
     "Qwen3_VL_8b_Recipe",
 ]


### PR DESCRIPTION
`Qwen3_6_35b_Recipe_Long_Context` exists in `slime_recipe/qwen3_6_35b_long_context.py` but isn't exported anywhere, so it’s usuable (unless you directly import the file). So I exported it like the other models.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->