### PR TITLE
Surface per-sample metadata in dashboard

### DIFF
--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -129,6 +129,7 @@ export async function fetchRunRollouts(trainingRunId, { signal } = {}) {
         ? Number(item.rollout_time)
         : null,
       error_summary: item.error_summary || null,
+      tag_stats: item.tag_stats || {},
     }))
     .sort((a, b) => a.rollout_id - b.rollout_id);
 }

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -952,6 +952,36 @@
     })),
   );
 
+  // Custom reward-function tags: any numeric sample.metadata key a reward fn
+  // sets (e.g. sample.metadata["step_K"] = k) gets aggregated per rollout on
+  // the backend (TrainingRolloutResult.tag_stats) and charted here the same
+  // way as the reward line above — one chart per discovered tag name.
+  let customTagNames = $derived(
+    Array.from(
+      new Set(rolloutSummaries.flatMap((r) => Object.keys(r.tag_stats || {}))),
+    ).sort(),
+  );
+
+  $inspect(rolloutSummaries, customTagNames).with(console.trace);
+
+  function tagChartData(tag) {
+    return rolloutSummaries
+      .filter((r) => r.tag_stats?.[tag])
+      .map((r) => ({
+        x: Number(r.rollout_id) || 0,
+        y: Number(r.tag_stats[tag].mean) || 0,
+        rollout_id: Number(r.rollout_id) || 0,
+      }));
+  }
+
+  function tagChartStats(tag) {
+    const values = rolloutSummaries
+      .filter((r) => r.tag_stats?.[tag])
+      .map((r) => Number(r.tag_stats[tag].mean) || 0);
+    if (!values.length) return null;
+    return { min: Math.min(...values), max: Math.max(...values), latest: values[values.length - 1] };
+  }
+
   // Score-distribution comparison: the first rollout (step 0) vs the most
   // recent one, to see how sample scores shifted over training.
   let firstRolloutId = $derived(
@@ -1278,6 +1308,29 @@
                 </div>
               </div>
             {/if}
+
+            {#if customTagNames.length}
+              <div class="chart-grid">
+                {#each customTagNames as tag (tag)}
+                  <div class="rollout-chart">
+                    <LineChart
+                      title={`${tag} (mean)`}
+                      data={tagChartData(tag)}
+                      formatX={(row) => `rollout ${row.rollout_id}`}
+                      formatY={(value) => formatMean(value)}
+                      ariaLabel={`${tag} chart`}
+                    />
+                    {#if tagChartStats(tag)}
+                      <div class="flex gap-[16px] mt-[6px] text-[11px] text-(--muted) [font-variant-numeric:tabular-nums]">
+                        <span>min {formatMean(tagChartStats(tag).min)}</span>
+                        <span>latest {formatMean(tagChartStats(tag).latest)}</span>
+                        <span>max {formatMean(tagChartStats(tag).max)}</span>
+                      </div>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            {/if}
           {/if}
         </div>
         <aside class="summary-tab-side">
@@ -1517,6 +1570,35 @@
                             <div class="rollout-sample-label">failure reason</div>
                             <pre class="rollout-sample-text">{activeSample.sample.metadata.eval_detail}</pre>
                           {/if}
+                          <!-- Catch-all: any other tag a custom reward/rollout function set on
+                               sample.metadata (e.g. sample.metadata["guessing"] = {...}) that
+                               isn't one of the known keys rendered explicitly above. -->
+                          {#each Object.entries(activeSample.sample.metadata ?? {}).filter(
+                            ([key]) =>
+                              ![
+                                "inference",
+                                "_metadata_type",
+                                "audio",
+                                "image",
+                                "trajectory_messages",
+                                "eval_report",
+                                "reference",
+                                "metrics",
+                                "exit_status",
+                                "eval_detail",
+                                "response_length",
+                                "prompt_length",
+                                "rollout_id",
+                                "rollout_idx",
+                              ].includes(key),
+                          ) as [name, value] (name)}
+                            <div class="rollout-sample-label">{name}</div>
+                            {#if value !== null && typeof value === "object"}
+                              <pre class="rollout-sample-text">{JSON.stringify(value, null, 2)}</pre>
+                            {:else}
+                              <span class="rollout-sample-metric">{String(value)}</span>
+                            {/if}
+                          {/each}
                           {#if activeSample.sample.trace?.length}
                             <div class="rollout-sample-label">trajectory timeline</div>
                             <SampleTimeline trace={activeSample.sample.trace} />

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -962,8 +962,6 @@
     ).sort(),
   );
 
-  $inspect(rolloutSummaries, customTagNames).with(console.trace);
-
   function tagChartData(tag) {
     return rolloutSummaries
       .filter((r) => r.tag_stats?.[tag])

--- a/modal_training_gym/common/training_rollout.py
+++ b/modal_training_gym/common/training_rollout.py
@@ -28,6 +28,47 @@ from modal_training_gym.utils.metadata import (
 # existing imports; new code should use Sample.
 TrainingRolloutSample = Sample
 
+# Metadata keys that are internal bookkeeping rather than reward-function
+# tags — numeric, but not something a user wants charted as a custom metric.
+_NON_TAG_METADATA_KEYS = frozenset(
+    {
+        "inference",
+        "_metadata_type",
+        "audio",
+        "image",
+        "response_length",
+        "prompt_length",
+        "rollout_id",
+        "rollout_idx",
+    }
+)
+
+
+def _tag_stats_for_samples(samples: list[Sample]) -> dict[str, dict[str, Any]]:
+    """Per-tag numeric stats (count/mean/min/max) across a rollout's samples.
+
+    Scans each sample's free-form ``metadata`` for numeric values under
+    custom reward-function tag keys, so the dashboard can chart them over
+    rollouts without a fixed schema. Pure function, no IO.
+    """
+    values_by_tag: dict[str, list[float]] = {}
+    for sample in samples:
+        for key, value in sample.metadata.items():
+            if key in _NON_TAG_METADATA_KEYS:
+                continue
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                values_by_tag.setdefault(key, []).append(float(value))
+
+    return {
+        tag: {
+            "count": len(values),
+            "mean": sum(values) / len(values),
+            "min": min(values),
+            "max": max(values),
+        }
+        for tag, values in values_by_tag.items()
+    }
+
 
 class TrainingRolloutResult(BaseModel):
     """All samples from one rollout of one training run."""
@@ -100,6 +141,16 @@ class TrainingRolloutResult(BaseModel):
             out["verdict"] = "partial_infra_failure"
         return out
 
+    @property
+    def tag_stats(self) -> dict[str, dict[str, Any]]:
+        """Per-tag numeric stats across this rollout's samples, or {} if none.
+
+        Populated from custom reward-function tags on ``Sample.metadata``
+        (anything numeric that isn't internal bookkeeping) — lets the
+        dashboard chart arbitrary reward-shaping signals over rollouts.
+        """
+        return _tag_stats_for_samples(self.samples)
+
     def to_summary(self) -> dict[str, Any]:
         summary: dict[str, Any] = {
             "training_run_id": self.training_run_id,
@@ -113,6 +164,9 @@ class TrainingRolloutResult(BaseModel):
         err = self.error_summary
         if err:
             summary["error_summary"] = err
+        tags = self.tag_stats
+        if tags:
+            summary["tag_stats"] = tags
         return summary
 
     def _touch_created_at(self) -> None:

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -49,6 +49,28 @@ _TRAJECTORY_MSG_CHARS_MAX = 8000
 _TRAJECTORY_MAX_MESSAGES = 128
 
 
+# Keys handled separately below (compacted/size-limited their own way) —
+# never copy them through the generic passthrough too, or they'd end up
+# duplicated under the same name with two different shapes.
+_RESERVED_METADATA_KEYS = frozenset({"trajectory_messages", "eval_report"})
+# Per-tag cap on the generic metadata passthrough so a stray large value a
+# reward function stashes on the sample can't bloat the rollout payload.
+_MAX_TAG_VALUE_BYTES = 2048
+
+
+def _is_small_json_value(value: Any, max_bytes: int = _MAX_TAG_VALUE_BYTES) -> bool:
+    """Best-effort check that ``value`` is JSON-serializable and small.
+
+    Reward/rollout functions can stash arbitrary tags on ``sample.metadata``;
+    this keeps the passthrough safe (skip non-serializable values) and
+    bounded (skip oversized ones) without requiring callers to sanitize.
+    """
+    try:
+        return len(json.dumps(value)) <= max_bytes
+    except (TypeError, ValueError):
+        return False
+
+
 def _resolve_hook(path: str | None) -> Any:
     if not path:
         return None
@@ -497,21 +519,18 @@ def _sample_to_dict(
     if inference := _extract_inference_metadata(sample):
         metadata["inference"] = inference
 
-    # Pull display-relevant fields from the sample's own metadata dict so the
-    # dashboard can render exit status, eval checks, etc. without needing the
-    # (potentially huge) full trajectory_messages blob.
+    # Pull the sample's own metadata dict through to the dashboard so it can
+    # render exit status, eval checks, custom reward-function tags, etc.
+    # Reserved keys are handled separately below (their own compaction), and
+    # oversized/non-serializable values are dropped rather than bloating the
+    # rollout payload.
     sample_meta = get("metadata") if attrs is not None else get("metadata", None)
     if isinstance(sample_meta, dict):
-        for key in (
-            "exit_status",
-            "eval_detail",
-            "training_response_source",
-            "training_assistant_turns",
-            _SHAPED_REWARD_KEY,
-            "task_passed",
-        ):
-            if key in sample_meta and sample_meta[key] is not None:
-                metadata[key] = sample_meta[key]
+        for key, value in sample_meta.items():
+            if key in _RESERVED_METADATA_KEYS or value is None:
+                continue
+            if _is_small_json_value(value):
+                metadata[key] = value
         # Multi-turn trajectory (capped to the first N samples): lets the
         # dashboard's ConversationView render the full agent conversation.
         # Without it, multi-turn rollouts collapse to a single flat block.

--- a/tests/test_opd_rollout_score.py
+++ b/tests/test_opd_rollout_score.py
@@ -48,3 +48,32 @@ def test_sample_to_dict_maps_shaped_reward_onto_gym_sample():
     assert sample.metadata["shaped_reward"] == 0.71
     assert sample.metadata["task_passed"] is False
     assert sample.metadata["response_length"] == 12
+
+
+def test_sample_to_dict_forwards_arbitrary_reward_function_tags():
+    """A tag set by a custom reward/rollout fn (not on any allowlist) survives."""
+    raw = {
+        "prompt": "p",
+        "response": "r",
+        "reward": 0.5,
+        "metadata": {"guessing": {"target": "cat", "success": True, "turns_taken": 3}},
+    }
+    sample = Sample.model_validate(_sample_to_dict(raw))
+    assert sample.metadata["guessing"] == {
+        "target": "cat",
+        "success": True,
+        "turns_taken": 3,
+    }
+
+
+def test_sample_to_dict_drops_oversized_tag_value():
+    """An accidentally-huge tag value is dropped rather than bloating the payload."""
+    raw = {
+        "prompt": "p",
+        "response": "r",
+        "reward": 0.5,
+        "metadata": {"small_tag": 1, "huge_tag": "x" * 4096},
+    }
+    sample = Sample.model_validate(_sample_to_dict(raw))
+    assert sample.metadata["small_tag"] == 1
+    assert "huge_tag" not in sample.metadata

--- a/tests/test_rollout_tag_stats.py
+++ b/tests/test_rollout_tag_stats.py
@@ -1,0 +1,62 @@
+"""Per-tag numeric aggregation across a rollout's samples.
+
+Custom reward-function tags land in each ``Sample.metadata`` dict (see
+``sample_extraction.py``'s generic passthrough). ``TrainingRolloutResult``
+reduces the numeric ones to count/mean/min/max at summary time so the
+dashboard can chart them over rollouts without a fixed schema.
+"""
+
+from modal_training_gym.common.sample import Sample
+from modal_training_gym.common.training_rollout import TrainingRolloutResult
+
+
+def _rollout(samples_metadata):
+    return TrainingRolloutResult(
+        training_run_id="t",
+        rollout_id=0,
+        samples=[Sample(metadata=m) for m in samples_metadata],
+    )
+
+
+def test_tag_stats_aggregates_numeric_tags_across_samples():
+    rollout = _rollout(
+        [
+            {"step_K": 2, "task_reward": 1.0},
+            {"step_K": 4, "task_reward": 0.0},
+            {"step_K": 6, "task_reward": 0.5},
+        ]
+    )
+    stats = rollout.tag_stats
+    assert stats["step_K"] == {"count": 3, "mean": 4.0, "min": 2.0, "max": 6.0}
+    assert stats["task_reward"] == {"count": 3, "mean": 0.5, "min": 0.0, "max": 1.0}
+
+
+def test_tag_stats_excludes_internal_bookkeeping_keys():
+    rollout = _rollout([{"response_length": 12, "prompt_length": 4, "custom": 7}])
+    stats = rollout.tag_stats
+    assert "response_length" not in stats
+    assert "prompt_length" not in stats
+    assert stats["custom"] == {"count": 1, "mean": 7.0, "min": 7.0, "max": 7.0}
+
+
+def test_tag_stats_ignores_non_numeric_and_bool_values():
+    rollout = _rollout([{"task_passed": True, "label": "cat", "score_like": 1}])
+    stats = rollout.tag_stats
+    assert "task_passed" not in stats
+    assert "label" not in stats
+    assert stats["score_like"] == {"count": 1, "mean": 1.0, "min": 1.0, "max": 1.0}
+
+
+def test_tag_stats_empty_when_no_numeric_tags():
+    assert _rollout([{"label": "cat"}]).tag_stats == {}
+    assert _rollout([]).tag_stats == {}
+
+
+def test_to_summary_includes_tag_stats_only_when_present():
+    with_tags = _rollout([{"step_K": 1}])
+    assert with_tags.to_summary()["tag_stats"] == {
+        "step_K": {"count": 1, "mean": 1.0, "min": 1.0, "max": 1.0}
+    }
+
+    without_tags = _rollout([{"label": "cat"}])
+    assert "tag_stats" not in without_tags.to_summary()


### PR DESCRIPTION
A few of our tutorials (such as [our multi-turn RL tutorial](https://gym.modal.dev/tutorials/rl/002_multiturn/#offline-multi-turn-trajectory-evaluator)) demonstrate how to store metadata alongside each rollout sample by updating `sample.metadata`. This PR surfaces this metadata on the dashboard.

On the summary tab, the per-rollout means of any numeric keys are displayed as line charts:
<img width="607" height="416" src="https://github.com/user-attachments/assets/b6831754-352b-4155-9b67-a4adb271fc58" />

On the rollouts tab, metadata is shown alongside each sample:
<img width="288" height="404" src="https://github.com/user-attachments/assets/7239ed20-b565-4a9b-84c0-0adffc5e1a6d" />
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->