### PR TITLE
Pin ruff lint rules to historical default to stop CI churn on ruff upgrades

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,11 @@ docs = [
 
 [tool.ruff]
 extend-exclude = ["tutorials/**"]
+
+# Pin the rule selection explicitly so linting is deterministic across ruff
+# releases. ruff 0.16 expanded the *default* rule set for projects without an
+# explicit select, which turned CI red overnight. This mirrors ruff's historical
+# default select (E4/E7/E9 + F) so linting matches what we've been enforcing,
+# independent of the installed ruff version.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ docs = [
 ]
 
 [tool.ruff]
-extend-exclude = ["tutorials/**"]
+# "*.md": ruff 0.16 started formatting Markdown (fenced code blocks), which
+# 0.15 did not — exclude it so the formatter only touches the files it always
+# has, independent of the installed ruff version.
+extend-exclude = ["tutorials/**", "*.md"]
 
 # Pin the rule selection explicitly so linting is deterministic across ruff
 # releases. ruff 0.16 expanded the *default* rule set for projects without an


### PR DESCRIPTION
So Astral just released [Ruff v0.16.0 with a greatly expanded default ruleset](https://astral.sh/blog/ruff-v0.16.0), and while we should look into adopting the new defaults, for now this is a quick PR to fix CI failing.

Original description for this Devin-generated PR follows:

## Summary

The `format` CI job (`astral-sh/ruff-action@v3`, no pinned version) installs the **latest** ruff. ruff **0.16.0** shipped and expanded the *default* lint rule set for projects with no explicit `lint.select` — from `E4/E7/E9 + F` (59 rules) to ~413 rules (ASYNC, B, BLE, D, DTZ, I, N, PERF, PL*, PT, PTH, RUF, S, SIM, TRY, UP, YTT, …). Our `[tool.ruff]` config only set `extend-exclude`, so CI went from green to **267 errors overnight** with no code change. Local commits still passed because the pre-commit hook pins `rev: v0.11.13`.

This makes the selection explicit and version-independent by mirroring ruff's historical default:

```toml
[tool.ruff.lint]
select = ["E4", "E7", "E9", "F"]
```

Note: `["E", "F"]` would over-select (pulls in `E5` → `E501` line-too-long, 236 new errors), so the exact `E4/E7/E9` subset is used to match prior behavior. This does **not** pin the ruff version — CI stays on latest (0.16.0); only the rule set is now deterministic.

Verified `ruff check modal_training_gym/` passes on both `0.15.17` and latest (`0.16.0`) with this change.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/bfa0e57221a54e47861b942198f8880d
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->