### PR TITLE
don't overwrite resumed checkpoints in model download

### DIFF
--- a/modal_training_gym/common/models/base.py
+++ b/modal_training_gym/common/models/base.py
@@ -167,6 +167,10 @@ class ModelConfig:
     ``architecture``) as class attributes, then override ``download()``
     to materialize weights into the shared model volume.
 
+    ``model_path`` is the directory the weights load from. Launchers point it
+    at a resumed checkpoint, so ``download()`` must leave a populated
+    ``model_path`` as it found it.
+
     Set ``response_parser`` to a function that converts raw model output
     into a :class:`ParsedResponse`.  For example, Qwen3 models set
     ``response_parser = parse_qwen3_response``.
@@ -196,11 +200,20 @@ class ModelConfig:
         return ParsedResponse(content=text)
 
 
+def _is_populated(path: str) -> bool:
+    if not os.path.isdir(path):
+        return False
+    with os.scandir(path) as entries:
+        return any(entries)
+
+
 class HFModelConfiguration(ModelConfig):
     """ModelConfig for models hosted on HuggingFace.
 
     Implements ``download()`` via ``huggingface_hub.snapshot_download``
-    using ``self.model_name`` as the repo ID.
+    using ``self.model_name`` as the repo ID. An empty ``model_path`` is
+    seeded from the snapshot; a populated one already holds the weights to
+    load and is left untouched.
     """
 
     def download(self) -> None:
@@ -213,9 +226,7 @@ class HFModelConfiguration(ModelConfig):
         # forces a re-download. Populating the cache keeps base models
         # reusable across runs.
         snapshot_dir = snapshot_download(repo_id=self.model_name)
-        if self.model_path and str(self.model_path) != snapshot_dir:
-            # An explicit model_path was requested: mirror the cached snapshot
-            # into it from the local cache (no second network download).
+        if self.model_path and not _is_populated(str(self.model_path)):
             import shutil
 
             shutil.copytree(snapshot_dir, str(self.model_path), dirs_exist_ok=True)

--- a/tests/test_model_download.py
+++ b/tests/test_model_download.py
@@ -1,0 +1,58 @@
+"""``HFModelConfiguration.download()`` against a populated ``model_path``.
+
+Launchers point ``model_path`` at a resumed checkpoint
+(``frameworks/slime/launcher.py``, ``frameworks/miles/launcher.py``) and then
+call ``download()``, so mirroring the base snapshot there must not replace
+trained weights.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modal_training_gym.common.models.base import HFModelConfiguration
+
+
+class _Model(HFModelConfiguration):
+    model_name = "org/base-model"
+
+
+@pytest.fixture
+def snapshot(tmp_path, monkeypatch):
+    import huggingface_hub
+
+    snapshot_dir = tmp_path / "hub" / "snapshot"
+    snapshot_dir.mkdir(parents=True)
+    (snapshot_dir / "model.safetensors").write_text("base weights")
+    (snapshot_dir / "config.json").write_text("{}")
+
+    monkeypatch.setattr(
+        huggingface_hub, "snapshot_download", lambda **kwargs: str(snapshot_dir)
+    )
+    return snapshot_dir
+
+
+def test_populated_model_path_keeps_its_weights(snapshot, tmp_path):
+    checkpoint = tmp_path / "checkpoints" / "r0_hf"
+    checkpoint.mkdir(parents=True)
+    (checkpoint / "model.safetensors").write_text("trained weights")
+
+    _Model(model_path=str(checkpoint)).download()
+
+    assert (checkpoint / "model.safetensors").read_text() == "trained weights"
+    assert not (checkpoint / "config.json").exists()
+
+
+def test_empty_model_path_receives_the_snapshot(snapshot, tmp_path):
+    destination = tmp_path / "model"
+
+    _Model(model_path=str(destination)).download()
+
+    assert (destination / "model.safetensors").read_text() == "base weights"
+    assert (destination / "config.json").read_text() == "{}"
+
+
+def test_model_path_equal_to_snapshot_dir_is_left_alone(snapshot):
+    _Model(model_path=str(snapshot)).download()
+
+    assert (snapshot / "model.safetensors").read_text() == "base weights"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->