### PR TITLE
Remove assistant message from Hugging Face formatter

### DIFF
--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -201,7 +201,6 @@ class HuggingFaceDataset(DatasetConfig):
             if sys_prompt:
                 msgs.append({"role": "system", "content": sys_prompt})
             msgs.append({"role": "user", "content": user_content})
-            msgs.append({"role": "assistant", "content": row[out_col]})
             return {"messages": msgs, label_key: str(row[out_col])}
 
         return ds.map(_to_chat, remove_columns=ds.column_names)


### PR DESCRIPTION
This PR makes a small change to the `_to_chat` function in `modal_training_gym/common/dataset.py`. The function no longer adds the dataset's output column as a message in the returned chat structure, but still includes it as a label.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->