### PR TITLE
add custom rollout-log hook

### DIFF
--- a/modal_training_gym/frameworks/slime/phase_reporting.py
+++ b/modal_training_gym/frameworks/slime/phase_reporting.py
@@ -16,6 +16,7 @@ This module keeps the reporting entry points (``report_*``, ``log_*``,
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from typing import Any
 
 from modal_training_gym.common.status import SlimeStatus
@@ -119,6 +120,12 @@ def report_phase(
     )
 
 
+@dataclass(frozen=True)
+class RolloutLogResult:
+    samples: Any = None
+    skip_default_logging: bool = False
+
+
 def report_rollout_samples(
     rollout_id: int,
     args: Any,
@@ -148,6 +155,8 @@ def report_rollout_samples(
         ]
     except TypeError:
         return
+    if not sample_dicts:
+        return
     payload = {
         **_run_context(args),
         "rollout_id": int(rollout_id),
@@ -170,6 +179,22 @@ def _call_hook(path_key: str, args: Any, *hook_args: Any, **hook_kwargs: Any) ->
     return hook(*hook_args, **hook_kwargs)
 
 
+def _rollout_log_decision(result: Any, samples: Any) -> tuple[Any, bool]:
+    if result is None:
+        return samples, False
+    if isinstance(result, RolloutLogResult):
+        report = samples if result.samples is None else result.samples
+        return report, bool(result.skip_default_logging)
+    if isinstance(result, (list, tuple)):
+        return result, False
+    if isinstance(result, bool):
+        return samples, result
+    raise TypeError(
+        "custom_rollout_log_function must return None, bool, list, tuple, or "
+        f"RolloutLogResult; got {type(result).__name__}"
+    )
+
+
 def log_rollout_data(
     rollout_id: int,
     args: Any,
@@ -187,9 +212,6 @@ def log_rollout_data(
         metrics=rollout_extra_metrics,
         rollout_time=rollout_time,
     )
-    report_rollout_samples(
-        rollout_id, args, samples, rollout_extra_metrics, rollout_time
-    )
     result = _call_hook(
         CUSTOM_ROLLOUT_LOG_FUNCTION_PATH_KEY,
         args,
@@ -199,9 +221,11 @@ def log_rollout_data(
         rollout_extra_metrics,
         rollout_time,
     )
-    if result is None:
-        return False
-    return bool(result)
+    report, skip_default_logging = _rollout_log_decision(result, samples)
+    report_rollout_samples(
+        rollout_id, args, report, rollout_extra_metrics, rollout_time
+    )
+    return skip_default_logging
 
 
 def log_eval_rollout_data(
@@ -302,6 +326,7 @@ def report_step_event(
 
 
 __all__ = [
+    "RolloutLogResult",
     "before_log_prob_hook",
     "before_train_step_hook",
     "report_advantage_distribution",

--- a/modal_training_gym/frameworks/slime/phase_reporting.py
+++ b/modal_training_gym/frameworks/slime/phase_reporting.py
@@ -16,6 +16,7 @@ This module keeps the reporting entry points (``report_*``, ``log_*``,
 from __future__ import annotations
 
 import time
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -189,10 +190,16 @@ def _rollout_log_decision(result: Any, samples: Any) -> tuple[Any, bool]:
         return result, False
     if isinstance(result, bool):
         return samples, result
-    raise TypeError(
-        "custom_rollout_log_function must return None, bool, list, tuple, or "
-        f"RolloutLogResult; got {type(result).__name__}"
+    warnings.warn(
+        "custom_rollout_log_function should return None, bool, list, tuple, or "
+        f"RolloutLogResult; got {type(result).__name__}.",
+        RuntimeWarning,
+        stacklevel=2,
     )
+    try:
+        return samples, bool(result)
+    except Exception:
+        return samples, False
 
 
 def log_rollout_data(

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -396,9 +396,17 @@ class SlimeRecipe(BaseTrainRecipe):
         Replaces slime's entire rollout loop (``--rollout-function-path``).
     custom_rollout_log_function : Callable | str | None
         Called with each rollout's data for logging; the gym wraps it so
-        phase reporting and dashboard capture still run.
+        phase reporting and dashboard capture still run. The hook runs
+        *before* the dashboard post, so returning a list of samples (or a
+        ``phase_reporting.RolloutLogResult``) picks what gets uploaded.
+        Collapse a per-step rollout to one sample per episode and only that
+        list is sent. Returning ``None``/``bool`` keeps every sample, as
+        slime's own contract does.
     custom_eval_rollout_log_function : Callable | str | None
-        Same as above, for eval rollouts.
+        Called with each eval rollout's data for logging. Unlike the train
+        hook above, this path still follows slime's bool/None contract only:
+        ``None``/falsy keeps slime's default W&B eval logging, truthy skips
+        it. There is no sample rewrite and no ``RolloutLogResult`` support.
     custom_megatron_before_log_prob_hook : Callable | str | None
         Hook run in the Megatron trainer before log-prob computation.
     custom_megatron_before_train_step_hook : Callable | str | None

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -401,7 +401,9 @@ class SlimeRecipe(BaseTrainRecipe):
         ``phase_reporting.RolloutLogResult``) picks what gets uploaded.
         Collapse a per-step rollout to one sample per episode and only that
         list is sent. Returning ``None``/``bool`` keeps every sample, as
-        slime's own contract does.
+        slime's own contract does. A ``list``/``tuple`` only redirects the
+        dashboard payload; to also skip slime's default W&B logging, return
+        ``True`` or ``RolloutLogResult(samples=..., skip_default_logging=True)``.
     custom_eval_rollout_log_function : Callable | str | None
         Called with each eval rollout's data for logging. Unlike the train
         hook above, this path still follows slime's bool/None contract only:


### PR DESCRIPTION
A rollout can contain many training samples, but the dashboard conflates the two (i.e., only shows training samples).

This change lets a custom rollout-log hook run before the dashboard post and choose what gets reported (for example, one sample per rollout), while leaving the training sample list untouched.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->