### PR TITLE
group multi-sample rollouts by rollout_index

### DIFF
--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -136,6 +136,8 @@ export async function fetchRunRollouts(trainingRunId, { signal } = {}) {
       rollout_id: Number(item.rollout_id) || 0,
       created_at: Number(item.created_at) || 0,
       total: Number(item.total) || 0,
+      episode_count:
+        item.episode_count == null ? null : Number(item.episode_count) || 0,
       mean: typeof item.mean === "number" ? item.mean : Number(item.mean) || 0,
       rollout_time: Number.isFinite(Number(item.rollout_time))
         ? Number(item.rollout_time)

--- a/dashboards/frontend/src/lib/rolloutGrouping.js
+++ b/dashboards/frontend/src/lib/rolloutGrouping.js
@@ -17,17 +17,9 @@ export function groupByRollout(samples) {
   return [...groups.values()];
 }
 
-export function rolloutScore(samples, positions) {
-  const sum = positions.reduce((a, i) => a + (Number(samples[i]?.score) || 0), 0);
-  return sum / positions.length;
-}
-
-export function rolloutScores(samples) {
-  return groupByRollout(samples).map((positions) => rolloutScore(samples, positions));
-}
-
-export function meanRolloutScore(samples) {
-  const scores = rolloutScores(samples);
-  if (!scores.length) return 0;
-  return scores.reduce((a, v) => a + v, 0) / scores.length;
+export function rolloutScores(samples, groups = groupByRollout(samples)) {
+  return groups.map((positions) => {
+    const sum = positions.reduce((a, i) => a + (Number(samples[i]?.score) || 0), 0);
+    return sum / positions.length;
+  });
 }

--- a/dashboards/frontend/src/lib/rolloutGrouping.js
+++ b/dashboards/frontend/src/lib/rolloutGrouping.js
@@ -1,0 +1,33 @@
+export function rolloutIndex(sample) {
+  const index = sample?.rollout_index ?? sample?.metadata?.rollout_id;
+  if (index == null || index === "") return null;
+  const n = Number(index);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function groupByRollout(samples) {
+  const groups = new Map();
+  (samples || []).forEach((sample, i) => {
+    const index = rolloutIndex(sample);
+    const key = index ?? `sample:${i}`;
+    const group = groups.get(key);
+    if (group) group.push(i);
+    else groups.set(key, [i]);
+  });
+  return [...groups.values()];
+}
+
+export function rolloutScore(samples, positions) {
+  const sum = positions.reduce((a, i) => a + (Number(samples[i]?.score) || 0), 0);
+  return sum / positions.length;
+}
+
+export function rolloutScores(samples) {
+  return groupByRollout(samples).map((positions) => rolloutScore(samples, positions));
+}
+
+export function meanRolloutScore(samples) {
+  const scores = rolloutScores(samples);
+  if (!scores.length) return 0;
+  return scores.reduce((a, v) => a + v, 0) / scores.length;
+}

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -23,6 +23,13 @@
     fetchRunAdvantageStep,
     fetchRunLogs,
   } from "../lib/api.js";
+  import {
+    groupByRollout,
+    meanRolloutScore,
+    rolloutIndex,
+    rolloutScore,
+    rolloutScores,
+  } from "../lib/rolloutGrouping.js";
 
   // Number of historical log lines requested per page.
   const HIST_PAGE = 500;
@@ -247,11 +254,11 @@
   let activeBucket = $state(null); // histogram bucket index, or null
   let activeSamplePos = $state(0); // position within the active bucket's list
 
-  // Bucket the expanded rollout's samples by score.
   let sampleDist = $derived.by(() => {
     const samples = expandedRollout?.samples || [];
-    if (!samples.length) return null;
-    const scores = samples.map((s) => Number(s.score) || 0);
+    const rollouts = groupByRollout(samples);
+    if (!rollouts.length) return null;
+    const scores = rollouts.map((p) => rolloutScore(samples, p));
     // Loop instead of Math.min(...arr): a single rollout's per-sample array can
     // exceed the engine's max argument count and make the spread throw a
     // RangeError (same failure class buildDist avoids).
@@ -261,20 +268,48 @@
       if (v < lo) lo = v;
       if (v > hi) hi = v;
     }
-    // When every sample scored the same, a single bucket reads clearer than a
+    // When every rollout scored the same, a single bucket reads clearer than a
     // lone bar pinned to one edge.
     const count = lo === hi ? 1 : BUCKET_COUNT;
     const span = hi - lo || 1;
-    const buckets = Array.from({ length: count }, () => []);
-    samples.forEach((s, i) => {
-      const score = Number(s.score) || 0;
-      let b = count === 1 ? 0 : Math.floor(((score - lo) / span) * count);
+    const buckets = Array.from({ length: count }, () => ({ rollouts: 0, samples: [] }));
+    rollouts.forEach((positions, r) => {
+      let b = count === 1 ? 0 : Math.floor(((scores[r] - lo) / span) * count);
       b = Math.max(0, Math.min(count - 1, b));
-      buckets[b].push(i);
+      buckets[b].rollouts += 1;
+      buckets[b].samples.push(...positions);
     });
-    const maxCount = Math.max(...buckets.map((b) => b.length), 1);
-    return { lo, hi, count, span, buckets, maxCount, total: samples.length };
+    const maxCount = Math.max(...buckets.map((b) => b.rollouts), 1);
+    return {
+      lo,
+      hi,
+      count,
+      span,
+      buckets,
+      maxCount,
+      total: rollouts.length,
+      sampleCount: samples.length,
+    };
   });
+
+  let grouped = $derived(!!sampleDist && sampleDist.total !== sampleDist.sampleCount);
+  let distSummary = $derived(
+    !sampleDist
+      ? ""
+      : grouped
+        ? `${plural(sampleDist.total, "rollout")} · ${plural(sampleDist.sampleCount, "sample")}`
+        : plural(sampleDist.total, "sample"),
+  );
+
+  function plural(n, unit) {
+    return `${n} ${unit}${n === 1 ? "" : "s"}`;
+  }
+
+  function bucketLabel(bucket, b) {
+    const head = plural(bucket.rollouts, grouped ? "rollout" : "sample");
+    const of = grouped ? ` · ${plural(bucket.samples.length, "sample")}` : "";
+    return `${head}${of} · reward ${bucketRange(b)}`;
+  }
 
   function bucketRange(b) {
     const d = sampleDist;
@@ -286,7 +321,7 @@
 
   function openBucket(b) {
     const d = sampleDist;
-    if (!d || !d.buckets[b]?.length) return;
+    if (!d || !d.buckets[b]?.samples.length) return;
     activeBucket = b;
     activeSamplePos = 0;
   }
@@ -299,7 +334,7 @@
   function stepSample(delta) {
     const d = sampleDist;
     if (!d || activeBucket == null) return;
-    const list = d.buckets[activeBucket] || [];
+    const list = d.buckets[activeBucket]?.samples || [];
     if (!list.length) return;
     activeSamplePos = Math.max(0, Math.min(list.length - 1, activeSamplePos + delta));
   }
@@ -308,7 +343,7 @@
   let activeSample = $derived.by(() => {
     const d = sampleDist;
     if (!d || activeBucket == null) return null;
-    const list = d.buckets[activeBucket] || [];
+    const list = d.buckets[activeBucket]?.samples || [];
     const idx = list[activeSamplePos];
     if (idx == null) return null;
     return {
@@ -334,6 +369,9 @@
   function sampleToPayload(s) {
     return {
       score: s.score,
+      rollout_index: rolloutIndex(s),
+      sample_index: s.sample_index ?? null,
+      group_index: s.group_index ?? null,
       prompt: s.prompt || null,
       response: s.response || null,
       thinking: s.thinking || null,
@@ -364,7 +402,9 @@
       training_run_id: runId,
       rollout_id: rollout,
       total: expandedRollout.samples.length,
-      mean: expandedRollout.samples.reduce((a, s) => a + (s.score || 0), 0) / expandedRollout.samples.length,
+      rollouts: groupByRollout(expandedRollout.samples).length,
+      n_samples_per_prompt: expandedRollout.n_samples_per_prompt ?? null,
+      mean: meanRolloutScore(expandedRollout.samples),
       samples: expandedRollout.samples.map(sampleToPayload),
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
@@ -486,7 +526,7 @@
         expandedRollout = detail;
         // Preselect the first populated bucket so a sample is shown right away.
         const d = sampleDist;
-        const first = d ? d.buckets.findIndex((b) => b.length > 0) : -1;
+        const first = d ? d.buckets.findIndex((b) => b.samples.length > 0) : -1;
         if (first >= 0) openBucket(first);
       }
     } finally {
@@ -1143,12 +1183,7 @@
   }
 
   function buildScoreDist(firstSamples, lastSamples, firstId, lastId) {
-    return buildDist(
-      firstSamples.map((s) => Number(s.score) || 0),
-      lastSamples.map((s) => Number(s.score) || 0),
-      firstId,
-      lastId,
-    );
+    return buildDist(rolloutScores(firstSamples), rolloutScores(lastSamples), firstId, lastId);
   }
 
   // Adapt a buildDist result into ComparativeBarChart inputs: one category per
@@ -1529,7 +1564,7 @@
                         {@const responseMissing = Number(m["agent/response_missing_sample_count"]) || 0}
                         {@const infraInvalid = Number(m["agent/invalid_infra_sample_count"]) || 0}
                         {@const limitsExceeded = Number(m["agent/limits_exceeded_sample_count"]) || 0}
-                        {@const totalSamples = Number(m["agent/valid_sample_count"]) || sampleDist.total || 0}
+                        {@const totalSamples = Number(m["agent/valid_sample_count"]) || sampleDist.sampleCount || 0}
                         {@const hasErrors = remoteErr > 0 || responseMissing > 0 || infraInvalid > 0}
                         {#if hasErrors}
                           <div class="rollout-diagnostics" class:diag-critical={remoteErr >= totalSamples}>
@@ -1571,33 +1606,33 @@
                             title="Download all samples as JSON"
                           >
                             <Download size={13} />
-                            Download all ({sampleDist.total} samples)
+                            Download all ({sampleDist.sampleCount} samples)
                           </button>
                         </div>
                         <div class="chart-scroll">
                           <div
                             class="flex items-end gap-[2px] h-[120px] pt-[14px] min-w-[280px] [border-bottom:1px_solid_var(--border,#2f2f2f)]"
                             role="group"
-                            aria-label="Sample score distribution"
+                            aria-label="Reward distribution"
                           >
                             {#each sampleDist.buckets as bucket, b (b)}
                               <button
                                 type="button"
                                 class="dist-bar"
                                 class:detail-active={activeBucket === b}
-                                class:is-empty={!bucket.length}
-                                style:height={`${(bucket.length / sampleDist.maxCount) * 100}%`}
-                                disabled={!bucket.length}
-                                title={`${bucket.length} sample${bucket.length === 1 ? "" : "s"} · reward ${bucketRange(b)}`}
+                                class:is-empty={!bucket.rollouts}
+                                style:height={`${(bucket.rollouts / sampleDist.maxCount) * 100}%`}
+                                disabled={!bucket.rollouts}
+                                title={bucketLabel(bucket, b)}
                                 onclick={() => openBucket(b)}
                               >
-                                <span class="absolute top-[-14px] left-0 right-0 text-center text-[10px] text-(--muted) [font-variant-numeric:tabular-nums]">{bucket.length || ""}</span>
+                                <span class="absolute top-[-14px] left-0 right-0 text-center text-[10px] text-(--muted) [font-variant-numeric:tabular-nums]">{bucket.rollouts || ""}</span>
                               </button>
                             {/each}
                           </div>
                           <div class="dist-axis">
                             <span>{formatMean(sampleDist.lo)}</span>
-                            <span class="dist-axis-label">reward · {sampleDist.total} samples</span>
+                            <span class="dist-axis-label">reward · {distSummary}</span>
                             <span>{formatMean(sampleDist.hi)}</span>
                           </div>
                         </div>

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -277,7 +277,7 @@
       let b = count === 1 ? 0 : Math.floor(((scores[r] - lo) / span) * count);
       b = Math.max(0, Math.min(count - 1, b));
       buckets[b].rollouts += 1;
-      buckets[b].samples.push(...positions);
+      for (const p of positions) buckets[b].samples.push(p);
     });
     const maxCount = Math.max(...buckets.map((b) => b.rollouts), 1);
     return {

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount, tick } from "svelte";
+  import { onMount, tick, untrack } from "svelte";
   import { ArrowLeft, ChevronLeft, ChevronRight, Download, ExternalLink, Minimize2, X } from "lucide-svelte";
   import Tabs from "../components/Tabs.svelte";
   import RunSummary from "../components/RunSummary.svelte";
@@ -410,7 +410,10 @@
   async function loadRollouts(signal) {
     if (!runId) return;
     try {
-      const wasEmpty = rolloutSummaries.length === 0;
+      // Untracked: the fetch effect calls this synchronously, so a tracked read
+      // here makes the effect depend on the state it is about to write, and
+      // every fetch (which always yields a fresh array) retriggers it forever.
+      const wasEmpty = untrack(() => rolloutSummaries.length === 0);
       const rows = await fetchRunRollouts(runId, { signal });
       if (signal?.aborted) return;
       rolloutSummaries = rows;

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -268,7 +268,7 @@
     rollouts.forEach((positions, r) => {
       let b = count === 1 ? 0 : Math.floor(((scores[r] - lo) / span) * count);
       b = Math.max(0, Math.min(count - 1, b));
-      buckets[b].push(positions[0]);
+      buckets[b].push({ positions, score: scores[r] });
     });
     const maxCount = Math.max(...buckets.map((b) => b.length), 1);
     return {
@@ -326,10 +326,12 @@
     const d = sampleDist;
     if (!d || activeBucket == null) return null;
     const list = d.buckets[activeBucket] || [];
-    const idx = list[activeSamplePos];
-    if (idx == null) return null;
+    const entry = list[activeSamplePos];
+    if (!entry) return null;
     return {
-      sample: expandedRollout.samples[idx],
+      sample: expandedRollout.samples[entry.positions[0]],
+      samples: entry.positions.map((p) => expandedRollout.samples[p]),
+      score: entry.score,
       pos: activeSamplePos,
       count: list.length,
     };
@@ -366,7 +368,11 @@
 
   function downloadSampleTrajectory() {
     if (!activeSample) return;
-    const payload = sampleToPayload(activeSample.sample);
+    const turns = activeSample.samples;
+    const payload =
+      turns.length === 1
+        ? sampleToPayload(turns[0])
+        : { mean: activeSample.score, turns: turns.length, samples: turns.map(sampleToPayload) };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -1650,7 +1656,9 @@
                             </div>
                             <div class="sample-viewer-actions">
                               <span class="text-(--text-bright) [font-variant-numeric:tabular-nums]">
-                                reward {formatMean(activeSample.sample.score)}
+                                reward {formatMean(activeSample.score)}{activeSample.samples.length > 1
+                                  ? ` · first of ${activeSample.samples.length} turns`
+                                  : ""}
                               </span>
                               <button
                                 class="sample-nav-btn"

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -23,13 +23,7 @@
     fetchRunAdvantageStep,
     fetchRunLogs,
   } from "../lib/api.js";
-  import {
-    groupByRollout,
-    meanRolloutScore,
-    rolloutIndex,
-    rolloutScore,
-    rolloutScores,
-  } from "../lib/rolloutGrouping.js";
+  import { groupByRollout, rolloutIndex, rolloutScores } from "../lib/rolloutGrouping.js";
 
   // Number of historical log lines requested per page.
   const HIST_PAGE = 500;
@@ -258,7 +252,7 @@
     const samples = expandedRollout?.samples || [];
     const rollouts = groupByRollout(samples);
     if (!rollouts.length) return null;
-    const scores = rollouts.map((p) => rolloutScore(samples, p));
+    const scores = rolloutScores(samples, rollouts);
     // Loop instead of Math.min(...arr): a single rollout's per-sample array can
     // exceed the engine's max argument count and make the spread throw a
     // RangeError (same failure class buildDist avoids).
@@ -398,14 +392,17 @@
   function downloadAllTrajectories() {
     if (!expandedRollout?.samples?.length) return;
     const rollout = expandedRolloutId ?? 0;
+    const samples = expandedRollout.samples;
+    const groups = groupByRollout(samples);
+    const scores = rolloutScores(samples, groups);
     const payload = {
       training_run_id: runId,
       rollout_id: rollout,
-      total: expandedRollout.samples.length,
-      rollouts: groupByRollout(expandedRollout.samples).length,
+      total: samples.length,
+      rollouts: groups.length,
       n_samples_per_prompt: expandedRollout.n_samples_per_prompt ?? null,
-      mean: meanRolloutScore(expandedRollout.samples),
-      samples: expandedRollout.samples.map(sampleToPayload),
+      mean: scores.reduce((a, v) => a + v, 0) / scores.length,
+      samples: samples.map(sampleToPayload),
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -233,7 +233,7 @@
   const rolloutColumns = [
     { key: "step", label: "Step", width: 72, minWidth: 56 },
     { key: "mean", label: "Mean reward", width: 118, minWidth: 96 },
-    { key: "samples", label: "Samples", width: 80, minWidth: 64 },
+    { key: "rollouts", label: "Rollouts", width: 80, minWidth: 64 },
     { key: "when", label: "When", width: 88, minWidth: 64 },
   ];
 
@@ -242,8 +242,6 @@
   let advantageSteps = $state([]);
   let hasAdvantages = $derived(advantageSteps.length > 0);
 
-  // Per-step sample view: a histogram of sample scores. Clicking a bar opens
-  // a single-sample viewer scoped to that bucket; ←/→ step through it.
   const BUCKET_COUNT = 12;
   let activeBucket = $state(null); // histogram bucket index, or null
   let activeSamplePos = $state(0); // position within the active bucket's list
@@ -253,7 +251,7 @@
     const rollouts = groupByRollout(samples);
     if (!rollouts.length) return null;
     const scores = rolloutScores(samples, rollouts);
-    // Loop instead of Math.min(...arr): a single rollout's per-sample array can
+    // Loop instead of Math.min(...arr): a single step's rollout-score array can
     // exceed the engine's max argument count and make the spread throw a
     // RangeError (same failure class buildDist avoids).
     let lo = Infinity;
@@ -266,14 +264,13 @@
     // lone bar pinned to one edge.
     const count = lo === hi ? 1 : BUCKET_COUNT;
     const span = hi - lo || 1;
-    const buckets = Array.from({ length: count }, () => ({ rollouts: 0, samples: [] }));
+    const buckets = Array.from({ length: count }, () => []);
     rollouts.forEach((positions, r) => {
       let b = count === 1 ? 0 : Math.floor(((scores[r] - lo) / span) * count);
       b = Math.max(0, Math.min(count - 1, b));
-      buckets[b].rollouts += 1;
-      for (const p of positions) buckets[b].samples.push(p);
+      buckets[b].push(positions[0]);
     });
-    const maxCount = Math.max(...buckets.map((b) => b.rollouts), 1);
+    const maxCount = Math.max(...buckets.map((b) => b.length), 1);
     return {
       lo,
       hi,
@@ -286,23 +283,14 @@
     };
   });
 
-  let grouped = $derived(!!sampleDist && sampleDist.total !== sampleDist.sampleCount);
-  let distSummary = $derived(
-    !sampleDist
-      ? ""
-      : grouped
-        ? `${plural(sampleDist.total, "rollout")} · ${plural(sampleDist.sampleCount, "sample")}`
-        : plural(sampleDist.total, "sample"),
-  );
+  let distSummary = $derived(!sampleDist ? "" : plural(sampleDist.total, "rollout"));
 
   function plural(n, unit) {
     return `${n} ${unit}${n === 1 ? "" : "s"}`;
   }
 
   function bucketLabel(bucket, b) {
-    const head = plural(bucket.rollouts, grouped ? "rollout" : "sample");
-    const of = grouped ? ` · ${plural(bucket.samples.length, "sample")}` : "";
-    return `${head}${of} · reward ${bucketRange(b)}`;
+    return `${plural(bucket.length, "rollout")} · reward ${bucketRange(b)}`;
   }
 
   function bucketRange(b) {
@@ -315,7 +303,7 @@
 
   function openBucket(b) {
     const d = sampleDist;
-    if (!d || !d.buckets[b]?.samples.length) return;
+    if (!d || !d.buckets[b]?.length) return;
     activeBucket = b;
     activeSamplePos = 0;
   }
@@ -328,16 +316,16 @@
   function stepSample(delta) {
     const d = sampleDist;
     if (!d || activeBucket == null) return;
-    const list = d.buckets[activeBucket]?.samples || [];
+    const list = d.buckets[activeBucket] || [];
     if (!list.length) return;
     activeSamplePos = Math.max(0, Math.min(list.length - 1, activeSamplePos + delta));
   }
 
-  // The sample currently shown in the viewer (or null when no bucket is open).
+  // The rollout currently shown in the viewer (or null when no bucket is open).
   let activeSample = $derived.by(() => {
     const d = sampleDist;
     if (!d || activeBucket == null) return null;
-    const list = d.buckets[activeBucket]?.samples || [];
+    const list = d.buckets[activeBucket] || [];
     const idx = list[activeSamplePos];
     if (idx == null) return null;
     return {
@@ -384,7 +372,7 @@
     const a = document.createElement("a");
     a.href = url;
     const rollout = expandedRolloutId ?? 0;
-    a.download = `trajectory_r${rollout}_s${activeSample.pos}.json`;
+    a.download = `trajectory_r${rollout}_rollout${rolloutIndex(activeSample.sample) ?? activeSample.pos}.json`;
     a.click();
     URL.revokeObjectURL(url);
   }
@@ -521,9 +509,9 @@
       const detail = await fetchRollout(runId, rolloutId);
       if (expandedRolloutId === rolloutId) {
         expandedRollout = detail;
-        // Preselect the first populated bucket so a sample is shown right away.
+        // Preselect the first populated bucket so a rollout is shown right away.
         const d = sampleDist;
-        const first = d ? d.buckets.findIndex((b) => b.samples.length > 0) : -1;
+        const first = d ? d.buckets.findIndex((b) => b.length > 0) : -1;
         if (first >= 0) openBucket(first);
       }
     } finally {
@@ -1529,7 +1517,7 @@
                     <span class="inline-block text-[10px] font-medium p-[1px_6px] rounded-[3px] ml-[6px] align-middle bg-[rgba(251,191,36,0.15)] text-[#fbbf24] [border:1px_solid_rgba(251,191,36,0.25)]" title="Some samples failed due to infrastructure error">partial failure</span>
                   {/if}
                 </td>
-                <td>{r.total}</td>
+                <td>{r.episode_count ?? "—"}</td>
                 <td>
                   <TimeAgo timestamp={r.created_at} showJustNow falsyRepresentation="—" />
                 </td>
@@ -1538,9 +1526,9 @@
                 <tr>
                   <td class="p-[12px_10px] bg-(--color-c-gray-08,#1c1c1c) cursor-default" colspan={rolloutColumns.length}>
                     {#if expandedRolloutLoading}
-                      <div class="detail-empty">Loading samples…</div>
+                      <div class="detail-empty">Loading rollouts…</div>
                     {:else if !expandedRollout || !sampleDist}
-                      <div class="detail-empty">No samples recorded.</div>
+                      <div class="detail-empty">No rollouts recorded.</div>
                     {:else}
                       {@const stepTiming = stepTimingForRollout(r.rollout_id)}
                       {#if stepTiming}
@@ -1643,18 +1631,18 @@
                                 class="sample-nav-btn"
                                 onclick={() => stepSample(-1)}
                                 disabled={activeSample.pos === 0}
-                                aria-label="Previous sample"
+                                aria-label="Previous rollout"
                               >
                                 <ChevronLeft size={14} />
                               </button>
                               <span class="text-[12px] text-(--text-bright) [font-variant-numeric:tabular-nums]">
-                                Sample {activeSample.pos + 1} / {activeSample.count}
+                                Rollout {activeSample.pos + 1} / {activeSample.count}
                               </span>
                               <button
                                 class="sample-nav-btn"
                                 onclick={() => stepSample(1)}
                                 disabled={activeSample.pos === activeSample.count - 1}
-                                aria-label="Next sample"
+                                aria-label="Next rollout"
                               >
                                 <ChevronRight size={14} />
                               </button>
@@ -1675,7 +1663,7 @@
                               <button
                                 class="sample-nav-btn"
                                 onclick={closeBucket}
-                                aria-label="Close sample viewer"
+                                aria-label="Close rollout viewer"
                               >
                                 <X size={14} />
                               </button>
@@ -1771,7 +1759,7 @@
                           {/if}
                         </div>
                       {:else}
-                        <div class="text-[12px] text-(--muted) p-[4px_0]">Click a bar to inspect its samples.</div>
+                        <div class="text-[12px] text-(--muted) p-[4px_0]">Click a bar to inspect its rollouts.</div>
                       {/if}
                     {/if}
                   </td>

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -1605,13 +1605,13 @@
                                 type="button"
                                 class="dist-bar"
                                 class:detail-active={activeBucket === b}
-                                class:is-empty={!bucket.rollouts}
-                                style:height={`${(bucket.rollouts / sampleDist.maxCount) * 100}%`}
-                                disabled={!bucket.rollouts}
+                                class:is-empty={!bucket.length}
+                                style:height={`${(bucket.length / sampleDist.maxCount) * 100}%`}
+                                disabled={!bucket.length}
                                 title={bucketLabel(bucket, b)}
                                 onclick={() => openBucket(b)}
                               >
-                                <span class="absolute top-[-14px] left-0 right-0 text-center text-[10px] text-(--muted) [font-variant-numeric:tabular-nums]">{bucket.rollouts || ""}</span>
+                                <span class="absolute top-[-14px] left-0 right-0 text-center text-[10px] text-(--muted) [font-variant-numeric:tabular-nums]">{bucket.length || ""}</span>
                               </button>
                             {/each}
                           </div>

--- a/modal_training_gym/common/coerce.py
+++ b/modal_training_gym/common/coerce.py
@@ -11,3 +11,10 @@ def safe_int(value: Any) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 0
+
+
+def optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None

--- a/modal_training_gym/common/training_rollout.py
+++ b/modal_training_gym/common/training_rollout.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
-from modal_training_gym.common.coerce import safe_int
+from modal_training_gym.common.coerce import optional_int, safe_int
 from modal_training_gym.common.sample import Sample
 from modal_training_gym.utils.metadata import (
     MetadataStore,
@@ -56,26 +56,6 @@ _NON_TAG_METADATA_KEYS = frozenset(
 )
 
 
-def _optional_int(value: Any) -> int | None:
-    try:
-        return int(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
-
-
-def _rollout_groups(
-    samples: list[TrainingRolloutSample],
-) -> list[list[TrainingRolloutSample]]:
-    groups: dict[tuple[str, int], list[TrainingRolloutSample]] = {}
-    for position, sample in enumerate(samples):
-        index = sample.rollout_index
-        if index is None:
-            index = _optional_int(sample.metadata.get("rollout_id"))
-        key = ("rollout", index) if index is not None else ("sample", position)
-        groups.setdefault(key, []).append(sample)
-    return list(groups.values())
-
-
 def _numeric_tags(samples: list[TrainingRolloutSample]) -> dict[str, list[float]]:
     values_by_tag: dict[str, list[float]] = {}
     for sample in samples:
@@ -85,25 +65,6 @@ def _numeric_tags(samples: list[TrainingRolloutSample]) -> dict[str, list[float]
             if isinstance(value, (int, float)) and not isinstance(value, bool):
                 values_by_tag.setdefault(key, []).append(float(value))
     return values_by_tag
-
-
-def _tag_stats_for_samples(
-    samples: list[TrainingRolloutSample],
-) -> dict[str, dict[str, Any]]:
-    values_by_tag: dict[str, list[float]] = {}
-    for group in _rollout_groups(samples):
-        for tag, values in _numeric_tags(group).items():
-            values_by_tag.setdefault(tag, []).append(sum(values) / len(values))
-
-    return {
-        tag: {
-            "count": len(values),
-            "mean": sum(values) / len(values),
-            "min": min(values),
-            "max": max(values),
-        }
-        for tag, values in values_by_tag.items()
-    }
 
 
 class TrainingRolloutSummary(BaseModel):
@@ -125,10 +86,20 @@ class TrainingRolloutResult(BaseModel):
     training_run_id: str
     rollout_id: int
     created_at: int = 0
-    n_samples_per_prompt: int = 1
+    n_samples_per_prompt: int | None = None
     samples: list[TrainingRolloutSample] = Field(default_factory=list)
     metrics: dict[str, Any] = Field(default_factory=dict)
     rollout_time: float | None = None
+
+    def _rollout_groups(self) -> list[list[TrainingRolloutSample]]:
+        groups: dict[tuple[str, int], list[TrainingRolloutSample]] = {}
+        for position, sample in enumerate(self.samples):
+            index = sample.rollout_index
+            if index is None:
+                index = optional_int(sample.metadata.get("rollout_id"))
+            key = ("rollout", index) if index is not None else ("sample", position)
+            groups.setdefault(key, []).append(sample)
+        return list(groups.values())
 
     @property
     def total(self) -> int:
@@ -136,7 +107,7 @@ class TrainingRolloutResult(BaseModel):
 
     @property
     def mean(self) -> float:
-        groups = _rollout_groups(self.samples)
+        groups = self._rollout_groups()
         if not groups:
             return 0.0
         return sum(sum(s.score for s in group) / len(group) for group in groups) / len(
@@ -197,7 +168,20 @@ class TrainingRolloutResult(BaseModel):
     @property
     def tag_stats(self) -> dict[str, dict[str, Any]]:
         """Per-tag count/mean/min/max, weighted per rollout like ``mean``."""
-        return _tag_stats_for_samples(self.samples)
+        values_by_tag: dict[str, list[float]] = {}
+        for group in self._rollout_groups():
+            for tag, values in _numeric_tags(group).items():
+                values_by_tag.setdefault(tag, []).append(sum(values) / len(values))
+
+        return {
+            tag: {
+                "count": len(values),
+                "mean": sum(values) / len(values),
+                "min": min(values),
+                "max": max(values),
+            }
+            for tag, values in values_by_tag.items()
+        }
 
     def to_summary(self) -> dict[str, Any]:
         summary: dict[str, Any] = {

--- a/modal_training_gym/common/training_rollout.py
+++ b/modal_training_gym/common/training_rollout.py
@@ -106,6 +106,10 @@ class TrainingRolloutResult(BaseModel):
         return len(self.samples)
 
     @property
+    def episode_count(self) -> int:
+        return len(self._rollout_groups())
+
+    @property
     def mean(self) -> float:
         groups = self._rollout_groups()
         if not groups:
@@ -189,6 +193,7 @@ class TrainingRolloutResult(BaseModel):
             "rollout_id": self.rollout_id,
             "created_at": self.created_at,
             "total": self.total,
+            "episode_count": self.episode_count,
             "mean": self.mean,
         }
         if self.rollout_time is not None:

--- a/modal_training_gym/common/training_rollout.py
+++ b/modal_training_gym/common/training_rollout.py
@@ -13,7 +13,7 @@ import time
 from collections.abc import Awaitable
 from typing import Any
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from modal_training_gym.common.coerce import safe_int
 from modal_training_gym.common.sample import Sample
@@ -24,9 +24,21 @@ from modal_training_gym.utils.metadata import (
 )
 
 
-# A rollout sample is just a Sample (shared with eval rows). Alias kept for any
-# existing imports; new code should use Sample.
-TrainingRolloutSample = Sample
+class TrainingRolloutSample(Sample):
+    """``rollout_index`` is slime's per-episode ``Sample.rollout_id``, not the
+    step id on ``TrainingRolloutResult``."""
+
+    rollout_index: int | None = None
+    sample_index: int | None = None
+    group_index: int | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _promote_sample(cls, value: Any) -> Any:
+        if isinstance(value, Sample) and not isinstance(value, cls):
+            return value.model_dump()
+        return value
+
 
 # Metadata keys that are internal bookkeeping rather than reward-function
 # tags — numeric, but not something a user wants charted as a custom metric.
@@ -44,13 +56,27 @@ _NON_TAG_METADATA_KEYS = frozenset(
 )
 
 
-def _tag_stats_for_samples(samples: list[Sample]) -> dict[str, dict[str, Any]]:
-    """Per-tag numeric stats (count/mean/min/max) across a rollout's samples.
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
 
-    Scans each sample's free-form ``metadata`` for numeric values under
-    custom reward-function tag keys, so the dashboard can chart them over
-    rollouts without a fixed schema. Pure function, no IO.
-    """
+
+def _rollout_groups(
+    samples: list[TrainingRolloutSample],
+) -> list[list[TrainingRolloutSample]]:
+    groups: dict[tuple[str, int], list[TrainingRolloutSample]] = {}
+    for position, sample in enumerate(samples):
+        index = sample.rollout_index
+        if index is None:
+            index = _optional_int(sample.metadata.get("rollout_id"))
+        key = ("rollout", index) if index is not None else ("sample", position)
+        groups.setdefault(key, []).append(sample)
+    return list(groups.values())
+
+
+def _numeric_tags(samples: list[TrainingRolloutSample]) -> dict[str, list[float]]:
     values_by_tag: dict[str, list[float]] = {}
     for sample in samples:
         for key, value in sample.metadata.items():
@@ -58,6 +84,16 @@ def _tag_stats_for_samples(samples: list[Sample]) -> dict[str, dict[str, Any]]:
                 continue
             if isinstance(value, (int, float)) and not isinstance(value, bool):
                 values_by_tag.setdefault(key, []).append(float(value))
+    return values_by_tag
+
+
+def _tag_stats_for_samples(
+    samples: list[TrainingRolloutSample],
+) -> dict[str, dict[str, Any]]:
+    values_by_tag: dict[str, list[float]] = {}
+    for group in _rollout_groups(samples):
+        for tag, values in _numeric_tags(group).items():
+            values_by_tag.setdefault(tag, []).append(sum(values) / len(values))
 
     return {
         tag: {
@@ -89,7 +125,8 @@ class TrainingRolloutResult(BaseModel):
     training_run_id: str
     rollout_id: int
     created_at: int = 0
-    samples: list[Sample] = Field(default_factory=list)
+    n_samples_per_prompt: int = 1
+    samples: list[TrainingRolloutSample] = Field(default_factory=list)
     metrics: dict[str, Any] = Field(default_factory=dict)
     rollout_time: float | None = None
 
@@ -99,9 +136,12 @@ class TrainingRolloutResult(BaseModel):
 
     @property
     def mean(self) -> float:
-        if not self.samples:
+        groups = _rollout_groups(self.samples)
+        if not groups:
             return 0.0
-        return sum(s.score for s in self.samples) / len(self.samples)
+        return sum(sum(s.score for s in group) / len(group) for group in groups) / len(
+            groups
+        )
 
     @property
     def storage_key(self) -> str:
@@ -156,12 +196,7 @@ class TrainingRolloutResult(BaseModel):
 
     @property
     def tag_stats(self) -> dict[str, dict[str, Any]]:
-        """Per-tag numeric stats across this rollout's samples, or {} if none.
-
-        Populated from custom reward-function tags on ``Sample.metadata``
-        (anything numeric that isn't internal bookkeeping) — lets the
-        dashboard chart arbitrary reward-shaping signals over rollouts.
-        """
+        """Per-tag count/mean/min/max, weighted per rollout like ``mean``."""
         return _tag_stats_for_samples(self.samples)
 
     def to_summary(self) -> dict[str, Any]:

--- a/modal_training_gym/common/training_rollout.py
+++ b/modal_training_gym/common/training_rollout.py
@@ -74,6 +74,7 @@ class TrainingRolloutSummary(BaseModel):
     rollout_id: int
     created_at: int
     total: int
+    episode_count: int | None = None
     mean: float
     rollout_time: float | None = None
     error_summary: dict[str, Any] | None = None

--- a/modal_training_gym/frameworks/slime/phase_reporting.py
+++ b/modal_training_gym/frameworks/slime/phase_reporting.py
@@ -135,6 +135,7 @@ def report_rollout_samples(
     trace_limit = _trace_sample_limit() if _trace_enabled() else 0
     image_limit = _image_sample_limit()
     trajectory_limit = _trajectory_sample_limit()
+    n_per = _positive_int(_arg_value(args, "n_samples_per_prompt")) or 1
     try:
         sample_dicts = [
             _sample_to_dict(
@@ -143,6 +144,7 @@ def report_rollout_samples(
                 include_trace=(i < trace_limit),
                 include_image=(i < image_limit),
                 include_trajectory=(i < trajectory_limit),
+                n_samples_per_prompt=n_per,
             )
             for i, s in enumerate(samples)
         ]
@@ -152,6 +154,7 @@ def report_rollout_samples(
         **_run_context(args),
         "rollout_id": int(rollout_id),
         "created_at": int(time.time()),
+        "n_samples_per_prompt": n_per,
         "samples": sample_dicts,
         "metrics": _metrics_to_dict(rollout_extra_metrics),
     }

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -15,6 +15,7 @@ import json
 import os
 from typing import Any
 
+from modal_training_gym.common.coerce import optional_int
 from modal_training_gym.common.sample import Sample
 
 # Import path of the run model's response parser (a (str) -> ParsedResponse
@@ -488,13 +489,6 @@ def _extract_image_from_sample(sample: Any) -> str | None:
     return None
 
 
-def _optional_int(value: Any) -> int | None:
-    try:
-        return int(value)
-    except (TypeError, ValueError, OverflowError):
-        return None
-
-
 def _sample_to_dict(
     sample: Any,
     parser: Any = None,
@@ -589,8 +583,8 @@ def _sample_to_dict(
         "response": response_text,
         "metadata": metadata,
     }
-    sample_index = _optional_int(get("index"))
-    rollout_index = _optional_int(get("rollout_id"))
+    sample_index = optional_int(get("index"))
+    rollout_index = optional_int(get("rollout_id"))
     if rollout_index is None:
         rollout_index = sample_index
     if rollout_index is not None:

--- a/modal_training_gym/frameworks/slime/sample_extraction.py
+++ b/modal_training_gym/frameworks/slime/sample_extraction.py
@@ -488,6 +488,13 @@ def _extract_image_from_sample(sample: Any) -> str | None:
     return None
 
 
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
 def _sample_to_dict(
     sample: Any,
     parser: Any = None,
@@ -495,6 +502,7 @@ def _sample_to_dict(
     include_trace: bool = False,
     include_image: bool = False,
     include_trajectory: bool = False,
+    n_samples_per_prompt: int = 1,
 ) -> dict[str, Any]:
     """Best-effort extraction of (prompt, response, reward, metadata) from a
     slime Sample-like object. Duck-typed so we don't import slime here."""
@@ -581,6 +589,15 @@ def _sample_to_dict(
         "response": response_text,
         "metadata": metadata,
     }
+    sample_index = _optional_int(get("index"))
+    rollout_index = _optional_int(get("rollout_id"))
+    if rollout_index is None:
+        rollout_index = sample_index
+    if rollout_index is not None:
+        out["rollout_index"] = rollout_index
+    if sample_index is not None:
+        out["sample_index"] = sample_index
+        out["group_index"] = sample_index // max(1, int(n_samples_per_prompt or 1))
     # Store raw + parsed (mirrors eval's EvalRowResult) so the dashboard can show
     # cleaned content without re-parsing. Parsing happens here, in the recorder.
     parsed = _parsed_response_dict(response_text, parser)

--- a/tests/test_rollout_grouping.py
+++ b/tests/test_rollout_grouping.py
@@ -1,0 +1,249 @@
+from types import SimpleNamespace
+from typing import Any
+
+from modal_training_gym.common.sample import Sample
+from modal_training_gym.common.training_rollout import (
+    TrainingRolloutResult,
+    TrainingRolloutSample,
+)
+from modal_training_gym.frameworks.slime import phase_reporting as pr
+
+
+EPISODES = [(0.0, 1), (1.0, 2), (2.0, 3), (3.0, 4)]
+N_SAMPLES_PER_PROMPT = 2
+
+
+def _episode_samples():
+    samples = []
+    for index, (reward, turns) in enumerate(EPISODES):
+        for turn in range(turns):
+            samples.append(
+                SimpleNamespace(
+                    index=index,
+                    rollout_id=index,
+                    prompt=f"episode {index} turn {turn}",
+                    response="move",
+                    reward=reward,
+                )
+            )
+    return samples
+
+
+def _capture(monkeypatch, samples, args=None):
+    captured = {}
+    monkeypatch.setattr(
+        pr, "_enqueue_rollout", lambda payload: captured.update(payload)
+    )
+    pr.report_rollout_samples(
+        0,
+        args or SimpleNamespace(n_samples_per_prompt=N_SAMPLES_PER_PROMPT),
+        samples,
+        {},
+        None,
+    )
+    return captured
+
+
+def _rollout(samples):
+    return TrainingRolloutResult(training_run_id="t", rollout_id=0, samples=samples)
+
+
+def test_payload_tags_each_sample_with_its_rollout(monkeypatch):
+    captured = _capture(monkeypatch, _episode_samples())
+
+    # fmt: off
+    assert [s["rollout_index"] for s in captured["samples"]] == [0, 1, 1, 2, 2, 2, 3, 3, 3, 3]
+    assert [s["sample_index"] for s in captured["samples"]] == [0, 1, 1, 2, 2, 2, 3, 3, 3, 3]
+    assert [s["group_index"] for s in captured["samples"]] == [0, 0, 0, 1, 1, 1, 1, 1, 1, 1]
+    # fmt: on
+    assert captured["n_samples_per_prompt"] == N_SAMPLES_PER_PROMPT
+
+
+def test_payload_identifies_a_rollout_by_sample_index_when_rollout_id_unset(
+    monkeypatch,
+):
+    samples = [
+        SimpleNamespace(index=i, rollout_id=None, prompt="p", response="r", reward=1.0)
+        for i in range(3)
+    ]
+    captured = _capture(monkeypatch, samples)
+
+    assert [s["rollout_index"] for s in captured["samples"]] == [0, 1, 2]
+
+
+def test_payload_omits_grouping_when_slime_reports_no_indices(monkeypatch):
+    samples = [SimpleNamespace(prompt="p", response="r", reward=1.0)]
+    captured = _capture(monkeypatch, samples)
+
+    assert "rollout_index" not in captured["samples"][0]
+    assert "group_index" not in captured["samples"][0]
+
+
+def test_grouping_survives_the_rollout_sample_model():
+    sample = TrainingRolloutSample.model_validate(
+        {"score": 1.0, "rollout_index": 7, "sample_index": 7, "group_index": 3}
+    )
+    assert sample.rollout_index == 7
+    dumped = sample.model_dump(mode="json")
+    assert (dumped["sample_index"], dumped["group_index"]) == (7, 3)
+
+
+def test_grouping_stays_off_the_shared_eval_sample():
+    assert not hasattr(Sample(score=1.0), "rollout_index")
+
+
+def test_rollout_accepts_plain_samples():
+    rollout = _rollout([Sample(score=1.0), Sample(score=2.0)])
+
+    assert rollout.mean == 1.5
+    assert all(s.rollout_index is None for s in rollout.samples)
+
+
+def test_mean_averages_rollouts_not_samples():
+    samples = [
+        TrainingRolloutSample(score=reward, rollout_index=index)
+        for index, (reward, turns) in enumerate(EPISODES)
+        for _ in range(turns)
+    ]
+    rollout = _rollout(samples)
+
+    assert rollout.mean == 1.5
+    assert rollout.total == 10
+
+
+def test_mean_unchanged_for_one_sample_per_rollout():
+    samples = [TrainingRolloutSample(score=float(i), rollout_index=i) for i in range(4)]
+
+    assert _rollout(samples).mean == 1.5
+
+
+def test_mean_treats_ungrouped_samples_as_their_own_rollouts():
+    samples = [
+        TrainingRolloutSample(score=score) for score in (0.0, 1.0, 2.0, 3.0, 3.0)
+    ]
+
+    assert _rollout(samples).mean == 1.8
+
+
+def test_mean_falls_back_to_the_rollout_id_in_metadata():
+    samples = [
+        TrainingRolloutSample(score=reward, metadata={"rollout_id": index})
+        for index, (reward, turns) in enumerate(EPISODES)
+        for _ in range(turns)
+    ]
+    rollout = _rollout(samples)
+
+    assert rollout.mean == 1.5
+    assert rollout.total == 10
+
+
+def test_metadata_fallback_treats_rollout_zero_as_a_rollout():
+    samples = [
+        TrainingRolloutSample(score=score, metadata={"rollout_id": 0})
+        for score in (0.0, 4.0)
+    ]
+
+    assert _rollout(samples).mean == 2.0
+
+
+def test_top_level_rollout_index_wins_over_metadata():
+    samples = [
+        TrainingRolloutSample(score=0.0, rollout_index=0, metadata={"rollout_id": 9}),
+        TrainingRolloutSample(score=4.0, rollout_index=1, metadata={"rollout_id": 9}),
+    ]
+
+    assert _rollout(samples).mean == 2.0
+
+
+def test_unparseable_metadata_rollout_id_does_not_merge_rollouts():
+    samples = [
+        TrainingRolloutSample(score=score, metadata={"rollout_id": "episode-a"})
+        for score in (0.0, 4.0)
+    ]
+
+    assert _rollout(samples).mean == 2.0
+    samples.append(TrainingRolloutSample(score=8.0, metadata={"rollout_id": None}))
+    assert _rollout(samples).mean == 4.0
+
+
+def test_tag_stats_weight_each_rollout_once():
+    samples = [
+        TrainingRolloutSample(score=0.0, rollout_index=0, metadata={"step_K": 1.0}),
+        TrainingRolloutSample(score=0.0, rollout_index=1, metadata={"step_K": 5.0}),
+        TrainingRolloutSample(score=0.0, rollout_index=1, metadata={"step_K": 5.0}),
+        TrainingRolloutSample(score=0.0, rollout_index=1, metadata={"step_K": 5.0}),
+    ]
+
+    assert _rollout(samples).tag_stats["step_K"] == {
+        "count": 2,
+        "mean": 3.0,
+        "min": 1.0,
+        "max": 5.0,
+    }
+
+
+def test_tag_stats_average_a_tag_within_its_rollout():
+    samples = [
+        TrainingRolloutSample(score=0.0, rollout_index=0, metadata={"turn_cost": 0.0}),
+        TrainingRolloutSample(score=0.0, rollout_index=0, metadata={"turn_cost": 2.0}),
+        TrainingRolloutSample(score=0.0, rollout_index=1, metadata={"turn_cost": 4.0}),
+    ]
+
+    assert _rollout(samples).tag_stats["turn_cost"] == {
+        "count": 2,
+        "mean": 2.5,
+        "min": 1.0,
+        "max": 4.0,
+    }
+
+
+def test_tag_stats_count_only_the_rollouts_that_reported_the_tag():
+    samples = [
+        TrainingRolloutSample(score=0.0, rollout_index=0, metadata={"retries": 2.0}),
+        TrainingRolloutSample(score=0.0, rollout_index=0, metadata={}),
+        TrainingRolloutSample(score=0.0, rollout_index=1, metadata={}),
+    ]
+
+    assert _rollout(samples).tag_stats["retries"] == {
+        "count": 1,
+        "mean": 2.0,
+        "min": 2.0,
+        "max": 2.0,
+    }
+
+
+def test_tag_stats_group_historical_records_from_metadata():
+    samples = [
+        TrainingRolloutSample(metadata={"rollout_id": 0, "step_K": 1.0}),
+        TrainingRolloutSample(metadata={"rollout_id": 1, "step_K": 5.0}),
+        TrainingRolloutSample(metadata={"rollout_id": 1, "step_K": 5.0}),
+    ]
+
+    assert _rollout(samples).tag_stats["step_K"]["mean"] == 3.0
+
+
+def _regrouped_mean(record: dict) -> float:
+    groups: dict[Any, list[float]] = {}
+    for position, sample in enumerate(record["samples"]):
+        index = sample.get("rollout_index")
+        if index is None:
+            index = sample.get("metadata", {}).get("rollout_id")
+        key = ("rollout", index) if index is not None else ("sample", position)
+        groups.setdefault(key, []).append(float(sample["score"]))
+    return sum(sum(v) / len(v) for v in groups.values()) / len(groups)
+
+
+def test_export_keys_reproduce_the_mean_they_ship_with():
+    samples = [
+        TrainingRolloutSample(score=0.0, rollout_index=0),
+        TrainingRolloutSample(score=1.0, rollout_index=1),
+        TrainingRolloutSample(score=1.0, rollout_index=1),
+        TrainingRolloutSample(score=5.0, metadata={"rollout_id": 2}),
+        TrainingRolloutSample(score=5.0, metadata={"rollout_id": 2}),
+        TrainingRolloutSample(score=6.0),
+    ]
+    rollout = _rollout(samples)
+
+    assert rollout.mean == 3.0
+    assert _regrouped_mean(rollout.model_dump(mode="json")) == rollout.mean
+    assert rollout.to_summary()["mean"] == rollout.mean

--- a/tests/test_rollout_grouping.py
+++ b/tests/test_rollout_grouping.py
@@ -121,6 +121,9 @@ def test_mean_averages_rollouts_not_samples():
 
     assert rollout.mean == 1.5
     assert rollout.total == 10
+    assert rollout.episode_count == 4
+    assert rollout.to_summary()["episode_count"] == 4
+    assert rollout.to_summary()["total"] == 10
 
 
 def test_mean_unchanged_for_one_sample_per_rollout():
@@ -147,6 +150,7 @@ def test_mean_falls_back_to_the_rollout_id_in_metadata():
 
     assert rollout.mean == 1.5
     assert rollout.total == 10
+    assert rollout.episode_count == 4
 
 
 def test_metadata_fallback_treats_rollout_zero_as_a_rollout():

--- a/tests/test_rollout_grouping.py
+++ b/tests/test_rollout_grouping.py
@@ -88,6 +88,18 @@ def test_grouping_survives_the_rollout_sample_model():
     assert (dumped["sample_index"], dumped["group_index"]) == (7, 3)
 
 
+def test_samples_per_prompt_reads_as_unknown_when_the_recorder_did_not_report_it():
+    reported = TrainingRolloutResult.model_validate(
+        {"training_run_id": "t", "rollout_id": 0, "n_samples_per_prompt": 8}
+    )
+    historical = TrainingRolloutResult.model_validate(
+        {"training_run_id": "t", "rollout_id": 0}
+    )
+
+    assert reported.n_samples_per_prompt == 8
+    assert historical.n_samples_per_prompt is None
+
+
 def test_grouping_stays_off_the_shared_eval_sample():
     assert not hasattr(Sample(score=1.0), "rollout_index")
 

--- a/tests/test_rollout_grouping.py
+++ b/tests/test_rollout_grouping.py
@@ -5,6 +5,7 @@ from modal_training_gym.common.sample import Sample
 from modal_training_gym.common.training_rollout import (
     TrainingRolloutResult,
     TrainingRolloutSample,
+    TrainingRolloutSummary,
 )
 from modal_training_gym.frameworks.slime import phase_reporting as pr
 
@@ -124,6 +125,31 @@ def test_mean_averages_rollouts_not_samples():
     assert rollout.episode_count == 4
     assert rollout.to_summary()["episode_count"] == 4
     assert rollout.to_summary()["total"] == 10
+
+
+def test_episode_count_reaches_the_dashboard_through_the_summary_model():
+    samples = [
+        TrainingRolloutSample(score=reward, rollout_index=index)
+        for index, (reward, turns) in enumerate(EPISODES)
+        for _ in range(turns)
+    ]
+    summary = TrainingRolloutSummary.model_validate(_rollout(samples).to_summary())
+
+    assert (summary.episode_count, summary.total) == (4, 10)
+
+
+def test_episode_count_reads_as_unknown_for_records_written_before_it_existed():
+    summary = TrainingRolloutSummary.model_validate(
+        {
+            "training_run_id": "t",
+            "rollout_id": 0,
+            "created_at": 0,
+            "total": 3,
+            "mean": 1.0,
+        }
+    )
+
+    assert summary.episode_count is None
 
 
 def test_mean_unchanged_for_one_sample_per_rollout():


### PR DESCRIPTION
Screenshots showing the UI differences for handling multi-sample rollout grouping:

Before:

<img width="1729" height="1001" alt="image" src="https://github.com/user-attachments/assets/48f61cf7-fe01-4059-87d3-7ae08e6cf902" />

<img width="1752" height="1005" alt="Screenshot 2026-07-29 at 3 01 31 PM" src="https://github.com/user-attachments/assets/a49aaaf0-d956-468b-8c5c-2e1059f14a05" />

<img width="1729" height="998" alt="image" src="https://github.com/user-attachments/assets/0ccae28f-ce9e-46f6-b879-786b75880058" />

After:

<img width="1746" height="1001" alt="SCR-20260729-nlwb" src="https://github.com/user-attachments/assets/25e3ffe7-b012-4cc7-a484-765e5ac49e4e" />

<img width="1747" height="1001" alt="image" src="https://github.com/user-attachments/assets/d1cc6194-b358-4166-9904-774effb7047c" />

<img width="1744" height="1007" alt="image" src="https://github.com/user-attachments/assets/db1ff0a6-3668-473f-a61c-5c9047d90683" />

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->