### PR TITLE
Update haiku tutorial reward function to be more idiomatic

### DIFF
--- a/tutorials/rl/000_rl_basics/000_rl_basics.ipynb
+++ b/tutorials/rl/000_rl_basics/000_rl_basics.ipynb
@@ -366,7 +366,8 @@
    "outputs": [],
    "source": [
     "async def haiku_rm(args, sample, **kwargs) -> float:\n",
-    "    return score_haiku(sample.response.replace(\"<|im_end|>\", \"\"))\n",
+    "    response = base_model.parse_response(sample.response)\n",
+    "    return score_haiku(response.content)\n",
     "\n",
     "training_run = TrainConfig(\n",
     "    model=base_model,\n",

--- a/tutorials/rl/000_rl_basics/000_rl_basics.py
+++ b/tutorials/rl/000_rl_basics/000_rl_basics.py
@@ -44,6 +44,23 @@ from modal_training_gym import (
     list_checkpoints,
 )
 
+# ## Serve the base model
+#
+# So, how does Qwen3-4B currently fare at writing haikus? We can
+# serve the base model and find out.
+#
+# The training gym has several config classes so you can define deployment, training, and evaluation configurations,
+# and reuse them across different runs for parameter sweeps.
+#
+# Let's start by initializing a `DeploymentConfig`.
+#
+# Calling `DeploymentConfig.serve()` builds and deploys an SGLang app, then
+# returns a `ModelDeployment` with the endpoint URL. Pass
+# `unauthenticated=True` so the endpoint is reachable without Modal
+# proxy-auth tokens.
+
+base_model = Qwen3_4B()
+
 # Let's now cover the evaluation part of the tutorial.
 #
 # A good eval takes a particular outcome and assigns a score to it. It can be binary (pass/fail) or continuous (0-100),
@@ -137,7 +154,8 @@ def eval_response_fn(_example: dict, response: str) -> EvalRowResult:
 # You can also add patches to slime using the `image_overlay` argument.
 
 async def haiku_rm(args, sample, **kwargs) -> float:
-    return score_haiku(sample.response.replace("<|im_end|>", ""))
+    response = base_model.parse_response(sample.response)
+    return score_haiku(response.content)
 
 import modal
 
@@ -152,22 +170,6 @@ def _main_impl() -> None:
             "https://modal.com/secrets with an HF_TOKEN entry, then re-run."
         ) from e
 
-    # ## Serve the base model
-    #
-    # So, how does Qwen3-4B currently fare at writing haikus? We can
-    # serve the base model and find out.
-    #
-    # The training gym has several config classes so you can define deployment, training, and evaluation configurations,
-    # and reuse them across different runs for parameter sweeps.
-    #
-    # Let's start by initializing a `DeploymentConfig`.
-    #
-    # Calling `DeploymentConfig.serve()` builds and deploys an SGLang app, then
-    # returns a `ModelDeployment` with the endpoint URL. Pass
-    # `unauthenticated=True` so the endpoint is reachable without Modal
-    # proxy-auth tokens.
-
-    base_model = Qwen3_4B()
     base_model_deployment = DeploymentConfig(
         model=base_model,
         unauthenticated=True,

--- a/tutorials/tutorial_generator/rl/000_rl_basics.py
+++ b/tutorials/tutorial_generator/rl/000_rl_basics.py
@@ -295,7 +295,8 @@ def _train_intro():
 @code
 def _define_training_run():
     async def haiku_rm(args, sample, **kwargs) -> float:
-        return score_haiku(sample.response.replace("<|im_end|>", ""))
+        response = base_model.parse_response(sample.response)
+        return score_haiku(response.content)
     
     training_run = TrainConfig(
         model=base_model,


### PR DESCRIPTION
Quick follow-up to #283 that uses a more idiomatic approach to strip out the `<|im_end|>` token, using `ModelConfig.parse_response` instead of replacing strings.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->