### PR TITLE
Persist substep timings per rollout step

### DIFF
--- a/dashboards/frontend/src/components/FrameworkActivityTrace.svelte
+++ b/dashboards/frontend/src/components/FrameworkActivityTrace.svelte
@@ -1,0 +1,894 @@
+<script>
+  import { Download, ZoomIn, ZoomOut } from "lucide-svelte";
+  import {
+    buildActivityMetrics,
+    buildFrameworkTimeline,
+    isWait,
+  } from "./frameworkActivityTrace.js";
+
+  let {
+    steps,
+    stepTimes,
+    rolloutStats,
+    legend,
+    phaseOrder,
+    labelFor,
+    colorFor,
+    descriptionFor,
+    downloadJson,
+  } = $props();
+
+  const TIME_TICKS = [0, 0.25, 0.5, 0.75, 1];
+  const MIN_ZOOM = 1;
+  const MAX_ZOOM = 64;
+  const ZOOM_FACTOR = 1.5;
+  const WHEEL_SENSITIVITY = 0.0015;
+
+  let expandedGroups = $state(new Set());
+  let zoom = $state(1);
+  let viewport = $state(null);
+  let tip = $state(null);
+  let pinned = $state(false);
+  let selectedFlow = $state(null);
+
+  let metrics = $derived(buildActivityMetrics(steps, rolloutStats));
+  let timeline = $derived(
+    buildFrameworkTimeline(
+      steps,
+      stepTimes,
+      expandedGroups,
+      labelFor,
+      phaseOrder,
+    ),
+  );
+
+  function fmtSecs(value) {
+    if (value == null) return "—";
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds)) return "—";
+    const trim = (number) => number.toFixed(3).replace(/\.?0+$/, "");
+    if (seconds >= 60) {
+      const minutes = Math.floor(seconds / 60);
+      return `${minutes}m ${trim(seconds - minutes * 60)}s`;
+    }
+    return `${trim(seconds)}s`;
+  }
+
+  function fmtTimestamp(value) {
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds)) return "—";
+    return new Date(seconds * 1000)
+      .toISOString()
+      .replace("T", " ")
+      .replace("Z", " UTC");
+  }
+
+  function fmtClockUncertainty(value) {
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds)) return "—";
+    if (seconds < 0.001) return `${Math.round(seconds * 1_000_000)}µs`;
+    if (seconds < 1) {
+      return `${(seconds * 1000).toFixed(1).replace(/\.0$/, "")}ms`;
+    }
+    return fmtSecs(seconds);
+  }
+
+  function toggleGroup(group) {
+    const next = new Set(expandedGroups);
+    if (next.has(group)) next.delete(group);
+    else next.add(group);
+    expandedGroups = next;
+  }
+
+  function setZoom(next, anchorX = null) {
+    const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, next));
+    if (clamped === zoom) return;
+    if (!viewport) {
+      zoom = clamped;
+      return;
+    }
+    const rect = viewport.getBoundingClientRect();
+    const cursorX = anchorX == null ? rect.width / 2 : anchorX - rect.left;
+    const contentX = viewport.scrollLeft + cursorX;
+    const scale = clamped / zoom;
+    zoom = clamped;
+    requestAnimationFrame(() => {
+      viewport.scrollLeft = contentX * scale - cursorX;
+    });
+  }
+
+  function wheelZoom(node) {
+    const handleWheel = (event) => {
+      if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) return;
+      event.preventDefault();
+      setZoom(
+        zoom * Math.exp(-event.deltaY * WHEEL_SENSITIVITY),
+        event.clientX,
+      );
+    };
+    node.addEventListener("wheel", handleWheel, { passive: false });
+    return {
+      destroy() {
+        node.removeEventListener("wheel", handleWheel);
+      },
+    };
+  }
+
+  function isActive(step, substep) {
+    return (
+      tip &&
+      tip.step === step &&
+      tip.name === substep.name &&
+      tip.role === substep.role
+    );
+  }
+
+  function isRelated(substep) {
+    if (selectedFlow == null) return true;
+    const sourceMatches =
+      selectedFlow.source != null &&
+      substep.sourceRolloutId != null &&
+      Number(substep.sourceRolloutId) === selectedFlow.source;
+    const trainingMatches =
+      selectedFlow.training != null &&
+      substep.trainingRolloutId != null &&
+      Number(substep.trainingRolloutId) === selectedFlow.training;
+    return sourceMatches || trainingMatches;
+  }
+
+  function containedMeasurements(stepNumber, parent) {
+    const step = steps.find((candidate) => candidate.n === stepNumber);
+    const parentStart = Number(parent.start);
+    const parentEnd = parentStart + Number(parent.duration);
+    if (!step || !Number.isFinite(parentStart) || !Number.isFinite(parentEnd)) {
+      return [];
+    }
+    const contained = step.substeps
+      .filter((candidate) => {
+        if (
+          candidate.phase === parent.phase ||
+          candidate.phase === "full_step"
+        ) {
+          return false;
+        }
+        const parentMatches =
+          candidate.parentPhase != null &&
+          candidate.parentPhase === parent.phase;
+        const legacyRoleMatches =
+          candidate.parentPhase == null &&
+          (candidate.role === parent.role ||
+            (parent.phase === "train_models" &&
+              (candidate.role === "actor" || candidate.role === "critic")));
+        if (!parentMatches && !legacyRoleMatches) return false;
+        const start = Number(candidate.start);
+        const end = start + Number(candidate.duration);
+        return (
+          Number.isFinite(start) &&
+          Number.isFinite(end) &&
+          start >= parentStart - 0.001 &&
+          end <= parentEnd + 0.001
+        );
+      })
+      .sort((left, right) => Number(left.start) - Number(right.start));
+    const counts = new Map();
+    for (const candidate of contained) {
+      const key = `${candidate.role}:${candidate.phase}`;
+      counts.set(key, (counts.get(key) || 0) + 1);
+    }
+    const occurrences = new Map();
+    return contained.map((candidate) => {
+      const key = `${candidate.role}:${candidate.phase}`;
+      const occurrence = (occurrences.get(key) || 0) + 1;
+      occurrences.set(key, occurrence);
+      const suffix = counts.get(key) > 1 ? ` ${occurrence}` : "";
+      return {
+        key: `${candidate.role}:${candidate.name}`,
+        label: `${candidate.displayName || labelFor(candidate.phase)}${suffix} (${candidate.role})`,
+        duration: candidate.duration,
+      };
+    });
+  }
+
+  function tooltipFor(event, step, substep) {
+    return {
+      x: event.clientX,
+      y: event.clientY,
+      step,
+      name: substep.name,
+      phase: substep.phase,
+      role: substep.role,
+      displayName: substep.displayName,
+      duration: substep.duration,
+      start: substep.start,
+      description: descriptionFor(substep.phase),
+      details: containedMeasurements(step, substep),
+      activityRolloutId: substep.activityRolloutId,
+      activityRolloutKind: substep.activityRolloutKind,
+      sourceRolloutId: substep.sourceRolloutId,
+      trainingRolloutId: substep.trainingRolloutId,
+      clockUncertainty: substep.clockUncertainty,
+      executionSequence: substep.executionSequence,
+    };
+  }
+
+  function showTip(event, step, substep) {
+    if (!pinned) tip = tooltipFor(event, step, substep);
+  }
+
+  function moveTip(event) {
+    if (!pinned && tip) tip = { ...tip, x: event.clientX, y: event.clientY };
+  }
+
+  function hideTip() {
+    if (!pinned) tip = null;
+  }
+
+  function pinTip(event, step, substep) {
+    event.stopPropagation();
+    if (pinned && isActive(step, substep)) {
+      pinned = false;
+      tip = null;
+      selectedFlow = null;
+      return;
+    }
+    pinned = true;
+    tip = tooltipFor(event, step, substep);
+    selectedFlow =
+      substep.sourceRolloutId == null && substep.trainingRolloutId == null
+        ? null
+        : {
+            source:
+              substep.sourceRolloutId == null
+                ? null
+                : Number(substep.sourceRolloutId),
+            training:
+              substep.trainingRolloutId == null
+                ? null
+                : Number(substep.trainingRolloutId),
+          };
+  }
+
+  function handleWindowClick(event) {
+    if (
+      event.target instanceof Element &&
+      event.target.closest(".framework-activity-trace")
+    ) {
+      return;
+    }
+    pinned = false;
+    tip = null;
+    selectedFlow = null;
+  }
+</script>
+
+<svelte:window onclick={handleWindowClick} />
+
+{#snippet segment(substep, summary)}
+  <div
+    class="segment"
+    class:wait={!summary && isWait(substep)}
+    class:summary
+    class:unrelated={!isRelated(substep)}
+    class:active={pinned && isActive(substep.step, substep)}
+    style:left={`${substep.left}%`}
+    style:width={`${substep.width}%`}
+    style:background={substep.summaryColor ||
+      (isWait(substep) ? undefined : colorFor(substep.phase))}
+    role="button"
+    tabindex="0"
+    onmouseenter={(event) => showTip(event, substep.step, substep)}
+    onmousemove={moveTip}
+    onmouseleave={hideTip}
+    onclick={(event) => pinTip(event, substep.step, substep)}
+    onkeydown={(event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        pinTip(event, substep.step, substep);
+      }
+    }}
+  >
+    {#if substep.activityRolloutId != null}
+      {#if substep.phase === "generate_rollouts"}
+        <span class="segment-label">R{Number(substep.activityRolloutId) + 1}</span>
+      {:else if substep.phase === "train_model"}
+        <span class="segment-label">T{Number(substep.activityRolloutId) + 1}</span>
+      {/if}
+    {/if}
+  </div>
+{/snippet}
+
+<div class="framework-activity-trace">
+  <div class="trace-header">
+    <div class="legend">
+      {#each legend as phase (phase)}
+        <span class="legend-item">
+          <span
+            class="swatch"
+            class:wait={phase === "wait_for_rollout" ||
+              phase === "wait_for_next_rollout"}
+            style:background={colorFor(phase)}
+          ></span>
+          {labelFor(phase)}
+        </span>
+      {/each}
+    </div>
+    <div class="toolbar">
+      <div class="zoom-controls">
+        <button
+          onclick={() => setZoom(zoom / ZOOM_FACTOR)}
+          disabled={zoom <= MIN_ZOOM}
+          title="Zoom out"
+        >
+          <ZoomOut size={13} />
+        </button>
+        <button
+          class="zoom-level"
+          onclick={() => setZoom(MIN_ZOOM)}
+          disabled={zoom <= MIN_ZOOM}
+          title="Reset zoom to fit"
+        >
+          {zoom >= 10 ? Math.round(zoom) : zoom.toFixed(1).replace(/\.0$/, "")}×
+        </button>
+        <button
+          onclick={() => setZoom(zoom * ZOOM_FACTOR)}
+          disabled={zoom >= MAX_ZOOM}
+          title="Zoom in"
+        >
+          <ZoomIn size={13} />
+        </button>
+      </div>
+      <button class="download" onclick={downloadJson} title="Download timing JSON">
+        <Download size={13} />
+        Download JSON
+      </button>
+    </div>
+  </div>
+
+  {#if metrics.hasFrameworkActivity}
+    <div class="metrics">
+      <div class="metric">
+        <span class="metric-value">{metrics.rolloutCount}</span>
+        <span class="metric-label">Rollouts shown</span>
+      </div>
+      {#if metrics.throughput != null}
+        <div class="metric">
+          <span class="metric-value">{metrics.throughput.toFixed(1)}</span>
+          <span class="metric-label">Samples / rollout second</span>
+        </div>
+      {/if}
+      {#if metrics.overlap != null}
+        <div class="metric">
+          <span class="metric-value">{(metrics.overlap * 100).toFixed(1)}%</span>
+          <span class="metric-label">Rollout / train overlap</span>
+        </div>
+      {/if}
+      <div class="metric">
+        <span class="metric-value">{metrics.retries}</span>
+        <span class="metric-label">Role retries</span>
+      </div>
+    </div>
+  {/if}
+
+  <div class="viewport" bind:this={viewport} use:wheelZoom>
+    <div class="content" style:width={`${zoom * 100}%`}>
+      <div class="axis">
+        <div class="axis-head">Shared wall time</div>
+        {#each timeline.tracks as track (track.key)}
+          {#if track.isSummary}
+            <button
+              class="track-label group-label"
+              class:expanded={track.expanded}
+              disabled={!track.expandable}
+              onclick={(event) => {
+                event.stopPropagation();
+                toggleGroup(track.group);
+              }}
+            >
+              <span class="caret">{track.expandable ? "›" : ""}</span>
+              <span>{track.label}</span>
+            </button>
+          {:else}
+            <div class="track-label child-label">{track.label}</div>
+          {/if}
+        {/each}
+      </div>
+      <div class="timeline">
+        <div class="timeline-head">
+          {#each TIME_TICKS as tick (tick)}
+            <span
+              class="time-tick"
+              class:first={tick === 0}
+              class:last={tick === 1}
+              style:left={`${tick * 100}%`}
+            >
+              +{fmtSecs(timeline.duration * tick)}
+            </span>
+          {/each}
+        </div>
+        <div class="lanes">
+          {#each TIME_TICKS as tick (tick)}
+            <div class="grid-line" style:left={`${tick * 100}%`}></div>
+          {/each}
+          {#each timeline.tracks as track (track.key)}
+            <div
+              class="track"
+              class:summary-track={track.isSummary}
+              class:child-track={!track.isSummary}
+            >
+              {#each track.substeps as substep (`${substep.step}:${substep.name}`)}
+                {@render segment(substep, track.isSummary)}
+              {/each}
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="hint">
+    Shared span {fmtSecs(timeline.duration)} · expand groups for phase detail ·
+    striped color is a known wait · blank space is inactive or not instrumented
+  </div>
+
+  {#if tip}
+    <div
+      class="tooltip"
+      class:pinned
+      style:left={`${tip.x}px`}
+      style:top={`${tip.y}px`}
+    >
+      <span class="tooltip-step">
+        {#if
+          tip.sourceRolloutId != null &&
+          tip.trainingRolloutId != null &&
+          Number(tip.sourceRolloutId) !== Number(tip.trainingRolloutId)}
+          Source R{Number(tip.sourceRolloutId) + 1}
+          → Training T{Number(tip.trainingRolloutId) + 1}
+        {:else if tip.activityRolloutId != null}
+          {tip.activityRolloutKind === "source" ? "Source" : "Training"}
+          rollout {Number(tip.activityRolloutId) + 1}
+        {:else}
+          Step {tip.step}
+        {/if}
+      </span>
+      <span class="tooltip-name">
+        {tip.displayName || labelFor(tip.phase)} ({tip.role})
+      </span>
+      <span class="tooltip-duration">{fmtSecs(tip.duration)}</span>
+      <span class="tooltip-time">
+        {fmtTimestamp(tip.start)} → {fmtTimestamp(
+          Number(tip.start) + Number(tip.duration),
+        )}
+      </span>
+      {#if tip.description}
+        <span class="tooltip-description">{tip.description}</span>
+      {/if}
+      {#if tip.details.length}
+        <span class="tooltip-detail-title">Contained measurements</span>
+        <span class="tooltip-details">
+          {#each tip.details as detail (detail.key)}
+            <span class="tooltip-detail">
+              <span>{detail.label}</span>
+              <span>{fmtSecs(detail.duration)}</span>
+            </span>
+          {/each}
+        </span>
+      {/if}
+      {#if tip.clockUncertainty != null}
+        <span class="tooltip-uncertainty">
+          start aligned within ±{fmtClockUncertainty(tip.clockUncertainty)}
+        </span>
+      {/if}
+      {#if Number(tip.executionSequence) > 1}
+        <span class="tooltip-retry">
+          retry {Number(tip.executionSequence) - 1}
+        </span>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .framework-activity-trace {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .trace-header,
+  .toolbar,
+  .zoom-controls,
+  .legend,
+  .legend-item {
+    display: flex;
+    align-items: center;
+  }
+
+  .trace-header {
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .legend {
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    color: var(--muted);
+    font-size: 11px;
+  }
+
+  .legend-item {
+    gap: 5px;
+  }
+
+  .swatch {
+    width: 9px;
+    height: 9px;
+    flex-shrink: 0;
+    border-radius: 2px;
+  }
+
+  .wait {
+    background: repeating-linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 65%, #181818),
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 65%, #181818) 3px,
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 20%, #181818) 3px,
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 20%, #181818) 6px
+    ) !important;
+  }
+
+  .toolbar {
+    flex-shrink: 0;
+    gap: 8px;
+  }
+
+  .zoom-controls {
+    overflow: hidden;
+    border: 1px solid var(--border, #2f2f2f);
+    border-radius: 4px;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    background: none;
+    color: var(--muted);
+    cursor: pointer;
+    font-size: 11px;
+  }
+
+  .zoom-controls button {
+    padding: 3px 7px;
+  }
+
+  .zoom-level {
+    min-width: 38px;
+    border-right: 1px solid var(--border, #2f2f2f);
+    border-left: 1px solid var(--border, #2f2f2f);
+    font-variant-numeric: tabular-nums;
+  }
+
+  button:disabled {
+    cursor: default;
+    opacity: 0.4;
+  }
+
+  .download {
+    gap: 5px;
+    padding: 3px 8px;
+    border: 1px solid var(--border, #2f2f2f);
+    border-radius: 4px;
+  }
+
+  .metrics {
+    display: inline-flex;
+    width: fit-content;
+    flex-wrap: wrap;
+    overflow: hidden;
+    border: 1px solid var(--color-edge-secondary, #2f2f2f);
+    border-radius: 6px;
+    background: var(--color-surface-primary, #181818);
+  }
+
+  .metric {
+    display: flex;
+    min-width: 108px;
+    flex-direction: column;
+    gap: 2px;
+    padding: 7px 11px;
+    border-right: 1px solid var(--color-edge-secondary, #2f2f2f);
+  }
+
+  .metric:last-child {
+    border-right: 0;
+  }
+
+  .metric-value {
+    color: var(--color-foreground-active, #fff);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 500;
+  }
+
+  .metric-label {
+    color: var(--color-foreground-tertiary, #747474);
+    font-size: 10px;
+    line-height: 14px;
+  }
+
+  .viewport {
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 8px 0 6px;
+    border: 1px solid var(--color-edge-secondary, #2f2f2f);
+    border-radius: 6px;
+    background: var(--color-surface-primary, #181818);
+    overscroll-behavior-x: contain;
+  }
+
+  .content {
+    display: grid;
+    min-width: 100%;
+    grid-template-columns: 154px minmax(0, 1fr);
+  }
+
+  .axis {
+    position: sticky;
+    left: 0;
+    z-index: 5;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding-right: 8px;
+    padding-left: 10px;
+    background: var(--color-surface-primary, #181818);
+    box-shadow: 6px 0 8px -8px rgba(0, 0, 0, 0.9);
+  }
+
+  .axis-head {
+    box-sizing: border-box;
+    height: 30px;
+    padding-top: 4px;
+    color: var(--color-foreground-tertiary, #747474);
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+
+  .track-label {
+    box-sizing: border-box;
+    width: 100%;
+    height: 18px;
+    padding: 0;
+    color: var(--color-foreground-secondary, #a3a3a3);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 18px;
+    text-align: left;
+  }
+
+  .group-label {
+    justify-content: flex-start;
+    gap: 4px;
+    color: var(--color-foreground-primary, #d1d1d1);
+  }
+
+  .group-label:disabled {
+    opacity: 1;
+  }
+
+  .caret {
+    width: 10px;
+    flex: 0 0 10px;
+    font-size: 13px;
+    transition: transform 0.12s ease;
+  }
+
+  .group-label.expanded .caret {
+    transform: rotate(90deg);
+  }
+
+  .child-label {
+    overflow: hidden;
+    height: 16px;
+    padding-left: 18px;
+    color: var(--color-foreground-tertiary, #747474);
+    font-size: 10px;
+    line-height: 16px;
+    text-overflow: ellipsis;
+  }
+
+  .timeline {
+    min-width: 0;
+  }
+
+  .timeline-head {
+    position: relative;
+    box-sizing: border-box;
+    height: 30px;
+    overflow: hidden;
+    border-bottom: 1px solid var(--color-edge-secondary, #2f2f2f);
+  }
+
+  .time-tick {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    color: var(--color-foreground-tertiary, #747474);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .time-tick.first {
+    transform: none;
+  }
+
+  .time-tick.last {
+    transform: translateX(-100%);
+  }
+
+  .lanes {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    overflow: hidden;
+  }
+
+  .grid-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 0;
+    border-left: 1px solid color-mix(in srgb, var(--muted) 15%, transparent);
+  }
+
+  .track {
+    position: relative;
+    z-index: 1;
+    box-sizing: border-box;
+    width: 100%;
+    height: 18px;
+    border: 1px solid var(--color-edge-secondary, #2f2f2f);
+    border-radius: 3px;
+    background: var(--color-c-gray-2, #1c1c1c);
+  }
+
+  .child-track {
+    height: 16px;
+    border-color: color-mix(
+      in srgb,
+      var(--color-edge-secondary, #2f2f2f) 70%,
+      transparent
+    );
+  }
+
+  .segment {
+    position: absolute;
+    top: 0;
+    z-index: 2;
+    height: 100%;
+    border-left: 1px solid color-mix(in srgb, #000 35%, transparent);
+    cursor: pointer;
+  }
+
+  .segment:hover,
+  .segment.active {
+    filter: brightness(1.25);
+  }
+
+  .segment.active {
+    outline: 1px solid var(--text-bright, #fff);
+    outline-offset: -1px;
+  }
+
+  .segment.summary {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, #fff 24%, transparent);
+    opacity: 0.82;
+  }
+
+  .segment.unrelated {
+    opacity: 0.16;
+  }
+
+  .segment-label {
+    position: absolute;
+    inset: 0 2px;
+    overflow: hidden;
+    color: color-mix(in srgb, #000 72%, transparent);
+    font-size: 8px;
+    font-weight: 700;
+    line-height: 14px;
+    white-space: nowrap;
+  }
+
+  .hint {
+    color: var(--muted);
+    font-size: 10px;
+    opacity: 0.7;
+  }
+
+  .tooltip {
+    position: fixed;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 8px 10px;
+    transform: translate(-50%, calc(-100% - 10px));
+    border: 1px solid var(--color-edge-primary, #464646);
+    border-radius: 6px;
+    background: var(--color-surface-overlay-large, #1c1c1c);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    font-size: 12px;
+    pointer-events: none;
+    white-space: nowrap;
+  }
+
+  .tooltip.pinned {
+    position: static;
+    width: min(560px, 100%);
+    box-sizing: border-box;
+    padding: 12px 14px;
+    transform: none;
+    border-color: var(--color-c-dataviz-primary-7, #648fe0);
+    pointer-events: auto;
+    white-space: normal;
+  }
+
+  .tooltip-step,
+  .tooltip-time,
+  .tooltip-uncertainty {
+    color: var(--color-foreground-tertiary, #747474);
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+
+  .tooltip-name {
+    color: var(--color-foreground-active, #fff);
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .tooltip-duration {
+    color: var(--color-foreground-secondary, #a3a3a3);
+    font-family: var(--font-mono);
+  }
+
+  .tooltip-description {
+    max-width: 300px;
+    margin-top: 4px;
+    color: var(--color-foreground-secondary, #a3a3a3);
+    line-height: 1.35;
+  }
+
+  .tooltip-detail-title {
+    margin-top: 5px;
+    color: var(--color-foreground-tertiary, #747474);
+    font-size: 10px;
+  }
+
+  .tooltip-details {
+    display: flex;
+    min-width: 230px;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .tooltip-detail {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    color: var(--color-foreground-primary, #d1d1d1);
+    font-family: var(--font-mono);
+  }
+
+  .tooltip-retry {
+    color: var(--yellow, #fbbf24);
+    font-size: 10px;
+  }
+</style>

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -166,6 +166,79 @@
 
   let hasData = $derived(steps.length > 0);
 
+  let roles = $derived.by(() => {
+    const seen = new Set(
+      steps.flatMap((step) => step.roles.map((role) => role.role)),
+    );
+    return Array.from(seen).sort((a, b) => {
+      const aIndex = ROLE_ORDER.indexOf(a);
+      const bIndex = ROLE_ORDER.indexOf(b);
+      return (aIndex < 0 ? ROLE_ORDER.length : aIndex)
+        - (bIndex < 0 ? ROLE_ORDER.length : bIndex);
+    });
+  });
+
+  let timeline = $derived.by(() => {
+    const capturedSubsteps = steps.flatMap((step) =>
+      step.substeps
+        .filter(
+          (substep) =>
+            Number.isFinite(Number(substep.start)) &&
+            Number.isFinite(Number(substep.duration)),
+        )
+        .map((substep) => ({
+          ...substep,
+          step: step.n,
+          end: Number(substep.start) + Number(substep.duration),
+        })),
+    );
+    if (!capturedSubsteps.length) {
+      return { duration: 0, roleLanes: [], stepBands: [] };
+    }
+    const start = Math.min(
+      ...capturedSubsteps.map((substep) => Number(substep.start)),
+    );
+    const end = Math.max(...capturedSubsteps.map((substep) => substep.end));
+    const duration = Math.max(end - start, 0.001);
+    const position = (value) => ((value - start) / duration) * 100;
+    const roleLanes = roles.map((role) => ({
+      role,
+      substeps: capturedSubsteps
+        .filter((substep) => substep.role === role)
+        .sort((a, b) => (b.duration ?? 0) - (a.duration ?? 0))
+        .map((substep) => ({
+          ...substep,
+          left: Math.max(0, Math.min(100, position(Number(substep.start)))),
+          width: Math.max(
+            0.15,
+            Math.min(
+              100 - position(Number(substep.start)),
+              (Number(substep.duration) / duration) * 100,
+            ),
+          ),
+        })),
+    }));
+    const stepBands = steps
+      .map((step) => {
+        const driverPhases = capturedSubsteps.filter(
+          (substep) => substep.step === step.n && substep.role === "driver",
+        );
+        if (!driverPhases.length) return null;
+        const bandStart = Math.min(
+          ...driverPhases.map((substep) => Number(substep.start)),
+        );
+        const bandEnd = Math.max(...driverPhases.map((substep) => substep.end));
+        return {
+          step: step.n,
+          left: position(bandStart),
+          width: Math.max(0.15, ((bandEnd - bandStart) / duration) * 100),
+          duration: step.duration,
+        };
+      })
+      .filter(Boolean);
+    return { duration, roleLanes, stepBands };
+  });
+
   let legend = $derived.by(() => {
     const seen = new Set();
     for (const s of steps) for (const sub of s.substeps) seen.add(sub.phase);
@@ -183,20 +256,6 @@
   // ── Timeline zoom / pan state ────────────────────────────────────────
   let zoom = $state(1);
   let viewport = $state(null);
-
-  function stepWeight(step) {
-    if (step.timelineDuration != null && step.timelineDuration > 0) {
-      return step.timelineDuration;
-    }
-    const roleDuration = Math.max(
-      0,
-      ...step.roles.map((role) =>
-        role.substeps.reduce((total, substep) => total + (substep.duration ?? 0), 0),
-      ),
-    );
-    if (roleDuration > 0) return roleDuration;
-    return 1;
-  }
 
   function positionedSubsteps(step, role) {
     const duration = Number(step.timelineDuration);
@@ -230,6 +289,14 @@
       elapsed += substepDuration;
       return { ...substep, left, width };
     });
+  }
+
+  function stepTitle(step) {
+    const driverDuration = `Driver step: ${fmtSecs(step.duration)}`;
+    if (step.timelineDuration > step.duration * 1.05) {
+      return `${driverDuration} · Captured span: ${fmtSecs(step.timelineDuration)}`;
+    }
+    return driverDuration;
   }
 
   function setZoom(next, anchorX = null) {
@@ -399,55 +466,58 @@
 
     {#if layout === "timeline"}
       <div class="tl-viewport" bind:this={viewport} use:wheelZoom>
-        <div class="tl-track" style:width={`${zoom * 100}%`}>
-          {#each steps as step, index (step.key)}
-            <div
-              class="tl-step"
-              class:step-even={index % 2 === 0}
-              class:step-odd={index % 2 !== 0}
-              style:flex-grow={stepWeight(step)}
-            >
-              <div class="tl-step-head">
-                <span class="tl-step-name">Step {step.n}</span>
-                <span class="tl-step-dur">
-                  {fmtSecs(step.duration)}
-                  {#if step.timelineDuration > step.duration * 1.05}
-                    · {fmtSecs(step.timelineDuration)} span
-                  {/if}
+        <div class="tl-content" style:width={`${zoom * 100}%`}>
+          <div class="role-axis">
+            <div class="role-axis-head"></div>
+            {#each roles as role (role)}
+              <div class="role-axis-label">{role === "step" ? "Timing" : role}</div>
+            {/each}
+          </div>
+          <div class="timeline">
+            <div class="timeline-head">
+              {#each timeline.stepBands as band, index (`${band.step}:${band.left}`)}
+                <span
+                  class="step-marker"
+                  class:marker-even={index % 2 === 0}
+                  class:marker-odd={index % 2 !== 0}
+                  style:left={`${band.left}%`}
+                  title={`Step ${band.step}: ${fmtSecs(band.duration)}`}
+                >
+                  S{band.step}
                 </span>
-              </div>
-              {#if step.roles.length}
-                <div class="role-lanes">
-                  {#each step.roles as role (role.role)}
-                    <div class="role-lane">
-                      <span class="role-label">{role.role === "step" ? "Timing" : role.role}</span>
-                      <div class="bar tl-bar">
-                        {#each positionedSubsteps(step, role) as sub (sub.name)}
-                          {@render segment(step, sub)}
-                        {/each}
-                      </div>
-                    </div>
+              {/each}
+            </div>
+            <div class="timeline-lanes">
+              {#each timeline.stepBands as band, index (`${band.step}:${band.left}`)}
+                <div
+                  class="step-band"
+                  class:band-even={index % 2 === 0}
+                  class:band-odd={index % 2 !== 0}
+                  style:left={`${band.left}%`}
+                  style:width={`${band.width}%`}
+                ></div>
+              {/each}
+              {#each timeline.roleLanes as lane (lane.role)}
+                <div class="bar tl-bar">
+                  {#each lane.substeps as sub (`${sub.step}:${sub.name}`)}
+                    {@render segment({ n: sub.step }, sub)}
                   {/each}
                 </div>
-              {:else}
-                <div class="bar tl-bar bar-empty"></div>
-              {/if}
+              {/each}
             </div>
-          {/each}
+          </div>
         </div>
       </div>
-      <div class="tl-hint">Scroll to zoom · shift-scroll or drag the scrollbar to pan</div>
+      <div class="tl-hint">
+        Captured wall-clock span {fmtSecs(timeline.duration)} · scroll to zoom ·
+        shift-scroll or drag the scrollbar to pan
+      </div>
     {:else}
-      {#each steps as step, index (step.key)}
-        <div class="step-row" class:step-even={index % 2 === 0} class:step-odd={index % 2 !== 0}>
+      {#each steps as step (step.key)}
+        <div class="step-row">
           <div class="step-head">
             <span class="step-name">Step {step.n}</span>
-            <span class="step-dur">
-              {fmtSecs(step.duration)}
-              {#if step.timelineDuration > step.duration * 1.05}
-                · {fmtSecs(step.timelineDuration)} span
-              {/if}
-            </span>
+            <span class="step-dur" title={stepTitle(step)}>{fmtSecs(step.duration)}</span>
           </div>
           {#if step.roles.length}
             <div class="role-lanes">
@@ -540,18 +610,6 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    padding: 8px;
-    border-radius: 5px;
-  }
-
-  .step-even {
-    background: color-mix(in srgb, var(--accent, #60a5fa) 5%, transparent);
-    border-top: 1px solid color-mix(in srgb, var(--accent, #60a5fa) 20%, transparent);
-  }
-
-  .step-odd {
-    background: color-mix(in srgb, #a78bfa 6%, transparent);
-    border-top: 1px solid color-mix(in srgb, #a78bfa 22%, transparent);
   }
 
   .step-head {
@@ -673,50 +731,123 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  .tl-track {
-    display: flex;
-    gap: 3px;
+  .tl-content {
+    display: grid;
+    grid-template-columns: 58px minmax(0, 1fr);
     min-width: 100%;
   }
 
-  .tl-step {
+  .role-axis {
+    position: sticky;
+    left: 0;
+    z-index: 5;
     display: flex;
     flex-direction: column;
     gap: 3px;
-    flex-basis: 0;
+    padding-right: 8px;
+    background: var(--color-c-gray-04, #141414);
+    box-shadow: 6px 0 8px -8px rgba(0, 0, 0, 0.9);
+  }
+
+  .role-axis-head {
+    height: 17px;
+  }
+
+  .role-axis-label {
+    height: 14px;
+    color: var(--muted);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    line-height: 14px;
+    text-align: right;
+    text-transform: uppercase;
+  }
+
+  .timeline {
+    min-width: 0;
+  }
+
+  .timeline-head {
+    position: relative;
+    box-sizing: border-box;
+    height: 17px;
     overflow: hidden;
-    padding: 4px;
-    border-radius: 4px;
+    border-bottom: 1px solid var(--border, #2f2f2f);
   }
 
-  @media (max-width: 900px) {
-    .tl-step {
-      min-width: 72px;
-    }
-  }
-
-  .tl-step-head {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
-    font-size: 10px;
+  .step-marker {
+    position: absolute;
+    top: 1px;
+    transform: translateX(3px);
+    color: var(--muted);
+    font-size: 9px;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
     line-height: 14px;
     white-space: nowrap;
+  }
+
+  .step-marker::before {
+    display: inline-block;
+    width: 2px;
+    height: 9px;
+    margin-right: 3px;
+    border-radius: 1px;
+    content: "";
+    vertical-align: -1px;
+  }
+
+  .marker-even::before {
+    background: var(--accent, #60a5fa);
+  }
+
+  .marker-odd::before {
+    background: #a78bfa;
+  }
+
+  .timeline-lanes {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
     overflow: hidden;
+    border-radius: 3px;
+    background: var(--color-c-gray-08, #1c1c1c);
   }
 
-  .tl-step-name {
-    color: var(--text-bright);
-    font-weight: 500;
+  .step-band {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 0;
+    border-left: 1px solid;
+    border-right: 1px solid;
   }
 
-  .tl-step-dur {
-    color: var(--muted);
-    font-variant-numeric: tabular-nums;
+  .band-even {
+    border-color: color-mix(in srgb, var(--accent, #60a5fa) 32%, transparent);
+    background: color-mix(in srgb, var(--accent, #60a5fa) 5%, transparent);
+  }
+
+  .band-odd {
+    border-color: color-mix(in srgb, #a78bfa 32%, transparent);
+    background: color-mix(in srgb, #a78bfa 5%, transparent);
+  }
+
+  .timeline .tl-bar {
+    z-index: 1;
+    flex: none;
+    width: 100%;
+    background: transparent;
+  }
+
+  .timeline .seg {
+    z-index: 2;
   }
 
   .tl-bar {
-    height: 16px;
+    height: 14px;
   }
 
   .role-lanes {
@@ -726,10 +857,7 @@
   }
 
   .role-lane {
-    position: relative;
-    display: flex;
-    align-items: center;
-    gap: 6px;
+    display: block;
     min-width: 0;
   }
 
@@ -745,24 +873,6 @@
     text-overflow: ellipsis;
     text-transform: uppercase;
     white-space: nowrap;
-  }
-
-  .tl-step .role-lane {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .tl-step .role-label {
-    position: absolute;
-    z-index: 2;
-    width: auto;
-    max-width: calc(100% - 8px);
-    margin-left: 3px;
-    color: rgba(255, 255, 255, 0.82);
-    line-height: 16px;
-    text-align: left;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9);
-    pointer-events: none;
   }
 
   .tl-hint {

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -61,6 +61,7 @@
   const MAX_ZOOM = 64;
   const ZOOM_BTN_FACTOR = 1.5;
   const WHEEL_SENSITIVITY = 0.0015;
+  const TIME_TICKS = [0, 0.25, 0.5, 0.75, 1];
 
   const ROLE_ORDER = ["rollout", "driver", "actor", "critic", "step"];
 
@@ -112,15 +113,18 @@
       const st = (stepTimes || {})[k] || null;
       const subs = (substepTimes || {})[k] || {};
       const substeps = Object.entries(subs)
-        .map(([name, v]) => {
+        .flatMap(([name, v]) => {
           const { phase, role } = parseSubstepName(name);
-          return {
-            name,
+          const intervals = v?.intervals?.length
+            ? v.intervals
+            : [{ started_at_unix_s: v?.start, duration_s: v?.duration_s }];
+          return intervals.map((interval, index) => ({
+            name: intervals.length > 1 ? `${name}:${index}` : name,
             phase,
             role,
-            start: v?.start ?? null,
-            duration: v?.duration_s ?? null,
-          };
+            start: interval?.started_at_unix_s ?? null,
+            duration: interval?.duration_s ?? null,
+          }));
         })
         .sort((a, b) => (a.start ?? 0) - (b.start ?? 0));
       const roleNames = Array.from(
@@ -193,7 +197,7 @@
         })),
     );
     if (!capturedSubsteps.length) {
-      return { duration: 0, roleLanes: [], stepBands: [] };
+      return { start: 0, duration: 0, roleLanes: [], stepBands: [] };
     }
     const start = Math.min(
       ...capturedSubsteps.map((substep) => Number(substep.start)),
@@ -210,7 +214,7 @@
           ...substep,
           left: Math.max(0, Math.min(100, position(Number(substep.start)))),
           width: Math.max(
-            0.15,
+            0,
             Math.min(
               100 - position(Number(substep.start)),
               (Number(substep.duration) / duration) * 100,
@@ -231,12 +235,12 @@
         return {
           step: step.n,
           left: position(bandStart),
-          width: Math.max(0.15, ((bandEnd - bandStart) / duration) * 100),
+          width: Math.max(0, ((bandEnd - bandStart) / duration) * 100),
           duration: step.duration,
         };
       })
       .filter(Boolean);
-    return { duration, roleLanes, stepBands };
+    return { start, duration, roleLanes, stepBands };
   });
 
   let legend = $derived.by(() => {
@@ -271,7 +275,7 @@
         }
         const left = Math.max(0, Math.min(100, ((substepStart - start) / duration) * 100));
         const width = Math.max(
-          0.4,
+          0,
           Math.min(100 - left, (substepDuration / duration) * 100),
         );
         return { ...substep, left, width };
@@ -475,6 +479,17 @@
           </div>
           <div class="timeline">
             <div class="timeline-head">
+              {#each TIME_TICKS as tick (tick)}
+                <span
+                  class="time-tick"
+                  class:tick-first={tick === 0}
+                  class:tick-last={tick === 1}
+                  style:left={`${tick * 100}%`}
+                  title={new Date(timeline.start * 1000 + timeline.duration * tick * 1000).toISOString()}
+                >
+                  +{fmtSecs(timeline.duration * tick)}
+                </span>
+              {/each}
               {#each timeline.stepBands as band, index (`${band.step}:${band.left}`)}
                 <span
                   class="step-marker"
@@ -488,6 +503,9 @@
               {/each}
             </div>
             <div class="timeline-lanes">
+              {#each TIME_TICKS as tick (tick)}
+                <div class="time-grid-line" style:left={`${tick * 100}%`}></div>
+              {/each}
               {#each timeline.stepBands as band, index (`${band.step}:${band.left}`)}
                 <div
                   class="step-band"
@@ -646,7 +664,6 @@
   .seg {
     position: absolute;
     top: 0;
-    min-width: 2px;
     height: 100%;
     cursor: pointer;
     border-left: 1px solid color-mix(in srgb, #000 35%, transparent);
@@ -750,7 +767,7 @@
   }
 
   .role-axis-head {
-    height: 17px;
+    height: 30px;
   }
 
   .role-axis-label {
@@ -771,15 +788,33 @@
   .timeline-head {
     position: relative;
     box-sizing: border-box;
-    height: 17px;
+    height: 30px;
     overflow: hidden;
     border-bottom: 1px solid var(--border, #2f2f2f);
   }
 
+  .time-tick {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    color: var(--muted);
+    font-size: 9px;
+    font-variant-numeric: tabular-nums;
+    line-height: 13px;
+    white-space: nowrap;
+  }
+
+  .time-tick.tick-first {
+    transform: none;
+  }
+
+  .time-tick.tick-last {
+    transform: translateX(-100%);
+  }
+
   .step-marker {
     position: absolute;
-    top: 1px;
-    transform: translateX(3px);
+    top: 14px;
     color: var(--muted);
     font-size: 9px;
     font-variant-numeric: tabular-nums;
@@ -823,6 +858,14 @@
     z-index: 0;
     border-left: 1px solid;
     border-right: 1px solid;
+  }
+
+  .time-grid-line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 0;
+    border-left: 1px solid color-mix(in srgb, var(--muted) 15%, transparent);
   }
 
   .band-even {

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -18,6 +18,18 @@
     offload_train: "Offload train",
     weight_sync: "Weight sync",
     evaluate_rollouts_end: "Eval (after)",
+    full_step: "Full step",
+    wait_for_rollout: "Wait for rollout",
+    offload_rollout: "Offload rollout",
+    train_models: "Train models",
+    train_model: "Train model",
+    forward_backward: "Forward/backward",
+    training_cleanup: "Training cleanup",
+    wait_for_next_rollout: "Wait for next rollout",
+    custom_reward: "Custom reward",
+    custom_reward_post_process: "Reward post-process",
+    evaluate_rollouts_before: "Eval (before)",
+    evaluate_rollouts_after: "Eval (after)",
   };
 
   const SUBSTEP_COLORS = {
@@ -30,6 +42,17 @@
     checkpoint_save: "#f472b6",
     offload_train: "#c084fc",
     evaluate_rollouts_end: "#818cf8",
+    full_step: "#64748b",
+    wait_for_rollout: "#38bdf8",
+    train_models: "#4ade80",
+    train_model: "#4ade80",
+    forward_backward: "#22c55e",
+    training_cleanup: "#c084fc",
+    wait_for_next_rollout: "#0ea5e9",
+    custom_reward: "#f59e0b",
+    custom_reward_post_process: "#fbbf24",
+    evaluate_rollouts_before: "#60a5fa",
+    evaluate_rollouts_after: "#818cf8",
   };
 
   const ORDER = Object.keys(SUBSTEP_LABELS);
@@ -41,11 +64,20 @@
   const WHEEL_SENSITIVITY = 0.0015;
 
   function labelFor(name) {
-    return SUBSTEP_LABELS[name] || name.replace(/_/g, " ");
+    const match = name.match(/^(.*) \((.*)\)$/);
+    const phase = match?.[1] || name;
+    const label = SUBSTEP_LABELS[phase] || phase.replace(/_/g, " ");
+    return match ? `${label} (${match[2]})` : label;
   }
 
   function colorFor(name) {
-    return SUBSTEP_COLORS[name] || "var(--color-c-gray-40, #5e5e5e)";
+    const match = name.match(/^(.*) \((.*)\)$/);
+    const phase = match?.[1] || name;
+    const role = match?.[2] || "";
+    if (role === "actor") return "#34d399";
+    if (role === "critic") return "#a78bfa";
+    if (role === "rollout") return SUBSTEP_COLORS[phase] || "#38bdf8";
+    return SUBSTEP_COLORS[phase] || "#fb923c";
   }
 
   // Durations are float seconds; keep up to 3 decimals (trailing zeros trimmed).
@@ -102,7 +134,14 @@
   let legend = $derived.by(() => {
     const seen = new Set();
     for (const s of steps) for (const sub of s.substeps) seen.add(sub.name);
-    return ORDER.filter((n) => seen.has(n));
+    return Array.from(seen).sort((a, b) => {
+      const aPhase = a.replace(/ \([^)]*\)$/, "");
+      const bPhase = b.replace(/ \([^)]*\)$/, "");
+      const aIndex = ORDER.indexOf(aPhase);
+      const bIndex = ORDER.indexOf(bPhase);
+      return (aIndex < 0 ? ORDER.length : aIndex)
+        - (bIndex < 0 ? ORDER.length : bIndex);
+    });
   });
 
   let tip = $state(null);

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -20,7 +20,6 @@
     evaluate_rollouts_end: "Eval (after)",
     full_step: "Full step",
     wait_for_rollout: "Wait for rollout",
-    offload_rollout: "Offload rollout",
     train_models: "Train models",
     train_model: "Train model",
     forward_backward: "Forward/backward",

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -62,20 +62,21 @@
   const ZOOM_BTN_FACTOR = 1.5;
   const WHEEL_SENSITIVITY = 0.0015;
 
-  function labelFor(name) {
+  const ROLE_ORDER = ["rollout", "driver", "actor", "critic", "step"];
+
+  function parseSubstepName(name) {
     const match = name.match(/^(.*) \((.*)\)$/);
-    const phase = match?.[1] || name;
-    const label = SUBSTEP_LABELS[phase] || phase.replace(/_/g, " ");
-    return match ? `${label} (${match[2]})` : label;
+    return {
+      phase: match?.[1] || name,
+      role: match?.[2] || "step",
+    };
   }
 
-  function colorFor(name) {
-    const match = name.match(/^(.*) \((.*)\)$/);
-    const phase = match?.[1] || name;
-    const role = match?.[2] || "";
-    if (role === "actor") return "#34d399";
-    if (role === "critic") return "#a78bfa";
-    if (role === "rollout") return SUBSTEP_COLORS[phase] || "#38bdf8";
+  function labelFor(phase) {
+    return SUBSTEP_LABELS[phase] || phase.replace(/_/g, " ");
+  }
+
+  function colorFor(phase) {
     return SUBSTEP_COLORS[phase] || "#fb923c";
   }
 
@@ -111,17 +112,52 @@
       const st = (stepTimes || {})[k] || null;
       const subs = (substepTimes || {})[k] || {};
       const substeps = Object.entries(subs)
-        .map(([name, v]) => ({
-          name,
-          start: v?.start ?? null,
-          duration: v?.duration_s ?? null,
-        }))
+        .map(([name, v]) => {
+          const { phase, role } = parseSubstepName(name);
+          return {
+            name,
+            phase,
+            role,
+            start: v?.start ?? null,
+            duration: v?.duration_s ?? null,
+          };
+        })
         .sort((a, b) => (a.start ?? 0) - (b.start ?? 0));
+      const roleNames = Array.from(
+        new Set(substeps.map((substep) => substep.role)),
+      ).sort((a, b) => {
+        const aIndex = ROLE_ORDER.indexOf(a);
+        const bIndex = ROLE_ORDER.indexOf(b);
+        return (aIndex < 0 ? ROLE_ORDER.length : aIndex)
+          - (bIndex < 0 ? ROLE_ORDER.length : bIndex);
+      });
+      const roles = roleNames.map((role) => ({
+        role,
+        substeps: substeps.filter((substep) => substep.role === role),
+      }));
+      const phaseStarts = substeps
+        .map((substep) => Number(substep.start))
+        .filter(Number.isFinite);
+      const phaseEnds = substeps
+        .map((substep) => Number(substep.start) + Number(substep.duration))
+        .filter(Number.isFinite);
+      const timelineStart = phaseStarts.length
+        ? Math.min(...phaseStarts)
+        : st?.start ?? null;
+      const timelineEnd = phaseEnds.length
+        ? Math.max(...phaseEnds)
+        : st?.end ?? null;
       return {
         key: k,
         n: Number.isFinite(Number(k)) ? Number(k) : k,
+        timelineStart,
+        timelineDuration:
+          timelineStart != null && timelineEnd != null
+            ? Math.max(timelineEnd - timelineStart, 0)
+            : st?.duration_s ?? null,
         duration: st?.duration_s ?? null,
         substeps,
+        roles,
       };
     });
     out.sort((a, b) => (Number(a.key) || 0) - (Number(b.key) || 0));
@@ -132,12 +168,10 @@
 
   let legend = $derived.by(() => {
     const seen = new Set();
-    for (const s of steps) for (const sub of s.substeps) seen.add(sub.name);
+    for (const s of steps) for (const sub of s.substeps) seen.add(sub.phase);
     return Array.from(seen).sort((a, b) => {
-      const aPhase = a.replace(/ \([^)]*\)$/, "");
-      const bPhase = b.replace(/ \([^)]*\)$/, "");
-      const aIndex = ORDER.indexOf(aPhase);
-      const bIndex = ORDER.indexOf(bPhase);
+      const aIndex = ORDER.indexOf(a);
+      const bIndex = ORDER.indexOf(b);
       return (aIndex < 0 ? ORDER.length : aIndex)
         - (bIndex < 0 ? ORDER.length : bIndex);
     });
@@ -151,10 +185,51 @@
   let viewport = $state(null);
 
   function stepWeight(step) {
-    const subTotal = step.substeps.reduce((acc, s) => acc + (s.duration ?? 0), 0);
-    if (subTotal > 0) return subTotal;
-    if (step.duration != null && step.duration > 0) return step.duration;
+    if (step.timelineDuration != null && step.timelineDuration > 0) {
+      return step.timelineDuration;
+    }
+    const roleDuration = Math.max(
+      0,
+      ...step.roles.map((role) =>
+        role.substeps.reduce((total, substep) => total + (substep.duration ?? 0), 0),
+      ),
+    );
+    if (roleDuration > 0) return roleDuration;
     return 1;
+  }
+
+  function positionedSubsteps(step, role) {
+    const duration = Number(step.timelineDuration);
+    const start = Number(step.timelineStart);
+    const hasWallClockBounds =
+      Number.isFinite(duration) && duration > 0 && Number.isFinite(start);
+    if (hasWallClockBounds) {
+      return role.substeps.map((substep) => {
+        const substepStart = Number(substep.start);
+        const substepDuration = Number(substep.duration);
+        if (!Number.isFinite(substepStart) || !Number.isFinite(substepDuration)) {
+          return { ...substep, left: 0, width: 2 };
+        }
+        const left = Math.max(0, Math.min(100, ((substepStart - start) / duration) * 100));
+        const width = Math.max(
+          0.4,
+          Math.min(100 - left, (substepDuration / duration) * 100),
+        );
+        return { ...substep, left, width };
+      });
+    }
+    const total = role.substeps.reduce(
+      (sum, substep) => sum + Math.max(Number(substep.duration) || 0, 0),
+      0,
+    );
+    let elapsed = 0;
+    return role.substeps.map((substep) => {
+      const substepDuration = Math.max(Number(substep.duration) || 0, 0);
+      const left = total > 0 ? (elapsed / total) * 100 : 0;
+      const width = total > 0 ? (substepDuration / total) * 100 : 100;
+      elapsed += substepDuration;
+      return { ...substep, left, width };
+    });
   }
 
   function setZoom(next, anchorX = null) {
@@ -192,12 +267,20 @@
   }
 
   function isActive(step, sub) {
-    return tip && tip.step === step.n && tip.name === sub.name;
+    return tip && tip.step === step.n && tip.name === sub.name && tip.role === sub.role;
   }
 
   function showTip(e, step, sub) {
     if (pinned) return;
-    tip = { x: e.clientX, y: e.clientY, step: step.n, name: sub.name, dur: sub.duration };
+    tip = {
+      x: e.clientX,
+      y: e.clientY,
+      step: step.n,
+      name: sub.name,
+      phase: sub.phase,
+      role: sub.role,
+      dur: sub.duration,
+    };
   }
 
   function moveTip(e) {
@@ -218,7 +301,15 @@
       return;
     }
     pinned = true;
-    tip = { x: e.clientX, y: e.clientY, step: step.n, name: sub.name, dur: sub.duration };
+    tip = {
+      x: e.clientX,
+      y: e.clientY,
+      step: step.n,
+      name: sub.name,
+      phase: sub.phase,
+      role: sub.role,
+      dur: sub.duration,
+    };
   }
 
   function clearPin() {
@@ -235,8 +326,9 @@
     class="seg"
     class:seg-null={sub.duration == null}
     class:active={pinned && isActive(step, sub)}
-    style:flex-grow={sub.duration == null ? undefined : Math.max(sub.duration, 0.01)}
-    style:background={sub.duration == null ? undefined : colorFor(sub.name)}
+    style:left={`${sub.left}%`}
+    style:width={`${sub.width}%`}
+    style:background={sub.duration == null ? undefined : colorFor(sub.phase)}
     role="button"
     tabindex="0"
     onmouseenter={(e) => showTip(e, step, sub)}
@@ -257,10 +349,10 @@
     {#if legend.length || layout === "timeline"}
       <div class="legend-row">
         <div class="legend">
-          {#each legend as name (name)}
+          {#each legend as phase (phase)}
             <span class="legend-item">
-              <span class="swatch" style:background={colorFor(name)}></span>
-              {labelFor(name)}
+              <span class="swatch" style:background={colorFor(phase)}></span>
+              {labelFor(phase)}
             </span>
           {/each}
         </div>
@@ -308,16 +400,33 @@
     {#if layout === "timeline"}
       <div class="tl-viewport" bind:this={viewport} use:wheelZoom>
         <div class="tl-track" style:width={`${zoom * 100}%`}>
-          {#each steps as step (step.key)}
-            <div class="tl-step" style:flex-grow={stepWeight(step)}>
+          {#each steps as step, index (step.key)}
+            <div
+              class="tl-step"
+              class:step-even={index % 2 === 0}
+              class:step-odd={index % 2 !== 0}
+              style:flex-grow={stepWeight(step)}
+            >
               <div class="tl-step-head">
                 <span class="tl-step-name">Step {step.n}</span>
-                <span class="tl-step-dur">{fmtSecs(step.duration)}</span>
+                <span class="tl-step-dur">
+                  {fmtSecs(step.duration)}
+                  {#if step.timelineDuration > step.duration * 1.05}
+                    · {fmtSecs(step.timelineDuration)} span
+                  {/if}
+                </span>
               </div>
-              {#if step.substeps.length}
-                <div class="bar tl-bar">
-                  {#each step.substeps as sub (sub.name)}
-                    {@render segment(step, sub)}
+              {#if step.roles.length}
+                <div class="role-lanes">
+                  {#each step.roles as role (role.role)}
+                    <div class="role-lane">
+                      <span class="role-label">{role.role === "step" ? "Timing" : role.role}</span>
+                      <div class="bar tl-bar">
+                        {#each positionedSubsteps(step, role) as sub (sub.name)}
+                          {@render segment(step, sub)}
+                        {/each}
+                      </div>
+                    </div>
                   {/each}
                 </div>
               {:else}
@@ -329,16 +438,28 @@
       </div>
       <div class="tl-hint">Scroll to zoom · shift-scroll or drag the scrollbar to pan</div>
     {:else}
-      {#each steps as step (step.key)}
-        <div class="step-row">
+      {#each steps as step, index (step.key)}
+        <div class="step-row" class:step-even={index % 2 === 0} class:step-odd={index % 2 !== 0}>
           <div class="step-head">
             <span class="step-name">Step {step.n}</span>
-            <span class="step-dur">{fmtSecs(step.duration)}</span>
+            <span class="step-dur">
+              {fmtSecs(step.duration)}
+              {#if step.timelineDuration > step.duration * 1.05}
+                · {fmtSecs(step.timelineDuration)} span
+              {/if}
+            </span>
           </div>
-          {#if step.substeps.length}
-            <div class="bar">
-              {#each step.substeps as sub (sub.name)}
-                {@render segment(step, sub)}
+          {#if step.roles.length}
+            <div class="role-lanes">
+              {#each step.roles as role (role.role)}
+                <div class="role-lane">
+                  <span class="role-label">{role.role === "step" ? "Timing" : role.role}</span>
+                  <div class="bar">
+                    {#each positionedSubsteps(step, role) as sub (sub.name)}
+                      {@render segment(step, sub)}
+                    {/each}
+                  </div>
+                </div>
               {/each}
             </div>
           {:else}
@@ -352,7 +473,7 @@
   {#if tip}
     <div class="tg-tip" class:pinned style:left={`${tip.x}px`} style:top={`${tip.y}px`}>
       <span class="tg-tip-step">Step {tip.step}</span>
-      <span class="tg-tip-name">{labelFor(tip.name)}</span>
+      <span class="tg-tip-name">{labelFor(tip.phase)} ({tip.role})</span>
       <span class="tg-tip-dur">
         {tip.dur == null ? "unknown (report dropped)" : fmtSecs(tip.dur)}
       </span>
@@ -419,6 +540,18 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
+    padding: 8px;
+    border-radius: 5px;
+  }
+
+  .step-even {
+    background: color-mix(in srgb, var(--accent, #60a5fa) 5%, transparent);
+    border-top: 1px solid color-mix(in srgb, var(--accent, #60a5fa) 20%, transparent);
+  }
+
+  .step-odd {
+    background: color-mix(in srgb, #a78bfa 6%, transparent);
+    border-top: 1px solid color-mix(in srgb, #a78bfa 22%, transparent);
   }
 
   .step-head {
@@ -440,12 +573,12 @@
   }
 
   .bar {
-    display: flex;
+    position: relative;
+    flex: 1;
     height: 14px;
     border-radius: 3px;
     overflow: hidden;
     background: var(--color-c-gray-08, #1c1c1c);
-    gap: 1px;
   }
 
   .bar-empty {
@@ -453,9 +586,12 @@
   }
 
   .seg {
+    position: absolute;
+    top: 0;
     min-width: 2px;
     height: 100%;
     cursor: pointer;
+    border-left: 1px solid color-mix(in srgb, #000 35%, transparent);
     transition: filter 0.1s ease;
   }
 
@@ -471,7 +607,6 @@
 
   /* Dropped substep: visible but doesn't distort the proportional widths. */
   .seg-null {
-    flex: 0 0 16px;
     background: repeating-linear-gradient(
       45deg,
       var(--color-c-gray-20, #3a3a3a),
@@ -550,6 +685,8 @@
     gap: 3px;
     flex-basis: 0;
     overflow: hidden;
+    padding: 4px;
+    border-radius: 4px;
   }
 
   @media (max-width: 900px) {
@@ -579,7 +716,53 @@
   }
 
   .tl-bar {
-    height: 18px;
+    height: 16px;
+  }
+
+  .role-lanes {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .role-lane {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .role-label {
+    flex: 0 0 45px;
+    overflow: hidden;
+    color: var(--muted);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    line-height: 14px;
+    text-align: right;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .tl-step .role-lane {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .tl-step .role-label {
+    position: absolute;
+    z-index: 2;
+    width: auto;
+    max-width: calc(100% - 8px);
+    margin-left: 3px;
+    color: rgba(255, 255, 255, 0.82);
+    line-height: 16px;
+    text-align: left;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9);
+    pointer-events: none;
   }
 
   .tl-hint {

--- a/dashboards/frontend/src/components/StepTimings.svelte
+++ b/dashboards/frontend/src/components/StepTimings.svelte
@@ -1,14 +1,16 @@
 <script>
-  import { Download, ZoomIn, ZoomOut } from "lucide-svelte";
+  import { Download } from "lucide-svelte";
+  import FrameworkActivityTrace from "./FrameworkActivityTrace.svelte";
 
   let {
     stepTimes = null,
     substepTimes = null,
+    rolloutStats = [],
     layout = "rows",
     downloadName = "step_substep_times.json",
   } = $props();
 
-  const SUBSTEP_LABELS = {
+  const LABELS = {
     evaluate_rollouts: "Eval (before)",
     generate_rollouts: "Generate rollouts",
     offload_rollout: "Offload rollout",
@@ -31,39 +33,51 @@
     evaluate_rollouts_after: "Eval (after)",
   };
 
-  const SUBSTEP_COLORS = {
-    evaluate_rollouts: "#60a5fa",
-    generate_rollouts: "#34d399",
-    offload_rollout: "#a78bfa",
-    compute_log_probs: "#fbbf24",
-    optimizer_step: "#f87171",
-    weight_sync: "#22d3ee",
-    checkpoint_save: "#f472b6",
-    offload_train: "#c084fc",
-    evaluate_rollouts_end: "#818cf8",
-    full_step: "#64748b",
-    wait_for_rollout: "#38bdf8",
-    train_models: "#4ade80",
-    train_model: "#4ade80",
-    forward_backward: "#22c55e",
-    training_cleanup: "#c084fc",
-    wait_for_next_rollout: "#0ea5e9",
-    custom_reward: "#f59e0b",
-    custom_reward_post_process: "#fbbf24",
-    evaluate_rollouts_before: "#60a5fa",
-    evaluate_rollouts_after: "#818cf8",
+  const COLORS = {
+    evaluate_rollouts: "var(--color-c-dataviz-primary-7, #648fe0)",
+    generate_rollouts: "var(--color-c-dataviz-primary-1, #adeaab)",
+    offload_rollout: "var(--color-c-dataviz-paired-6, #859400)",
+    compute_log_probs: "var(--color-c-dataviz-paired-5, #e6b687)",
+    optimizer_step: "var(--color-c-dataviz-paired-7, #8956fa)",
+    weight_sync: "var(--color-c-dataviz-primary-4, #4aa19d)",
+    checkpoint_save: "var(--color-c-dataviz-primary-3, #ffc1f7)",
+    offload_train: "var(--color-c-dataviz-paired-3, #ca70ad)",
+    evaluate_rollouts_end: "var(--color-c-dataviz-primary-7, #648fe0)",
+    full_step: "var(--color-c-gray-40, #747474)",
+    wait_for_rollout: "var(--color-c-dataviz-paired-4, #6cabc1)",
+    train_models: "var(--color-c-dataviz-primary-7, #648fe0)",
+    train_model: "var(--color-c-dataviz-primary-7, #648fe0)",
+    forward_backward: "var(--color-c-dataviz-paired-4, #6cabc1)",
+    training_cleanup: "var(--color-c-dataviz-paired-3, #ca70ad)",
+    wait_for_next_rollout: "var(--color-c-dataviz-paired-4, #6cabc1)",
+    custom_reward: "var(--color-c-dataviz-primary-4, #4aa19d)",
+    custom_reward_post_process: "var(--color-c-dataviz-primary-5, #decb6c)",
+    evaluate_rollouts_before: "var(--color-c-dataviz-primary-7, #648fe0)",
+    evaluate_rollouts_after: "var(--color-c-dataviz-primary-7, #648fe0)",
   };
 
-  const ORDER = Object.keys(SUBSTEP_LABELS);
+  const DESCRIPTIONS = {
+    generate_rollouts: "Generates responses for this source rollout.",
+    custom_reward: "Executes the run's custom reward function.",
+    custom_reward_post_process: "Post-processes custom reward results.",
+    train_models: "Driver wall time dispatching and waiting for model training.",
+    train_model: "Training worker wall time for this rollout.",
+    forward_backward:
+      "Forward pass, loss computation, backward pass, and gradient preparation.",
+    optimizer_step:
+      "Host interval for optimizer.step(); CUDA work may complete asynchronously.",
+    compute_log_probs: "Computes policy log probabilities.",
+    checkpoint_save: "Persists a training checkpoint.",
+    weight_sync: "Synchronizes updated model weights with rollout workers.",
+    offload_rollout: "Offloads the rollout model.",
+    offload_train: "Offloads the training model.",
+    wait_for_rollout: "Driver waiting for the source rollout to finish.",
+    wait_for_next_rollout: "Driver waiting for the next prefetched rollout.",
+  };
 
-  // Timeline zoom bounds: 1 = fit-to-width, MAX_ZOOM = deepest magnification.
-  const MIN_ZOOM = 1;
-  const MAX_ZOOM = 64;
-  const ZOOM_BTN_FACTOR = 1.5;
-  const WHEEL_SENSITIVITY = 0.0015;
-  const TIME_TICKS = [0, 0.25, 0.5, 0.75, 1];
-
+  const PHASE_ORDER = Object.keys(LABELS);
   const ROLE_ORDER = ["rollout", "driver", "actor", "critic", "step"];
+  const WAIT_PHASES = new Set(["wait_for_rollout", "wait_for_next_rollout"]);
 
   function parseSubstepName(name) {
     const match = name.match(/^(.*) \((.*)\)$/);
@@ -74,211 +88,179 @@
   }
 
   function labelFor(phase) {
-    return SUBSTEP_LABELS[phase] || phase.replace(/_/g, " ");
+    return LABELS[phase] || phase.replace(/_/g, " ");
   }
 
   function colorFor(phase) {
-    return SUBSTEP_COLORS[phase] || "#fb923c";
+    return COLORS[phase] || "var(--color-c-dataviz-primary-other, #6d6161)";
   }
 
-  // Durations are float seconds; keep up to 3 decimals (trailing zeros trimmed).
-  function fmtSecs(s) {
-    if (s == null) return "—";
-    const n = Number(s);
-    if (!Number.isFinite(n)) return "—";
-    const trim = (x) => x.toFixed(3).replace(/\.?0+$/, "");
-    if (n >= 60) {
-      const m = Math.floor(n / 60);
-      return `${m}m ${trim(n - m * 60)}s`;
+  function descriptionFor(phase) {
+    return DESCRIPTIONS[phase] || null;
+  }
+
+  function fmtSecs(value) {
+    if (value == null) return "—";
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds)) return "—";
+    const trim = (number) => number.toFixed(3).replace(/\.?0+$/, "");
+    if (seconds >= 60) {
+      const minutes = Math.floor(seconds / 60);
+      return `${minutes}m ${trim(seconds - minutes * 60)}s`;
     }
-    return `${trim(n)}s`;
+    return `${trim(seconds)}s`;
   }
 
   function downloadJson() {
-    const payload = { step_times: stepTimes || {}, substep_times: substepTimes || {} };
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const payload = {
+      step_times: stepTimes || {},
+      substep_times: substepTimes || {},
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = downloadName;
-    a.click();
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = downloadName;
+    anchor.click();
     URL.revokeObjectURL(url);
   }
 
   let steps = $derived.by(() => {
-    const stepKeys = Object.keys(stepTimes || {});
-    const subKeys = Object.keys(substepTimes || {});
-    const keys = Array.from(new Set([...stepKeys, ...subKeys]));
-    const out = keys.map((k) => {
-      const st = (stepTimes || {})[k] || null;
-      const subs = (substepTimes || {})[k] || {};
-      const substeps = Object.entries(subs)
-        .flatMap(([name, v]) => {
+    const keys = Array.from(
+      new Set([
+        ...Object.keys(stepTimes || {}),
+        ...Object.keys(substepTimes || {}),
+      ]),
+    );
+    const parsed = keys.map((key) => {
+      const step = (stepTimes || {})[key] || null;
+      const substeps = Object.entries((substepTimes || {})[key] || {})
+        .flatMap(([name, value]) => {
           const { phase, role } = parseSubstepName(name);
-          const intervals = v?.intervals?.length
-            ? v.intervals
-            : [{ started_at_unix_s: v?.start, duration_s: v?.duration_s }];
+          const intervals = value?.intervals?.length
+            ? value.intervals
+            : [
+                {
+                  started_at_unix_s: value?.start,
+                  duration_s: value?.duration_s,
+                },
+              ];
           return intervals.map((interval, index) => ({
             name: intervals.length > 1 ? `${name}:${index}` : name,
             phase,
             role,
             start: interval?.started_at_unix_s ?? null,
             duration: interval?.duration_s ?? null,
+            timelineGroup: value?.timeline_group ?? null,
+            activityKind: value?.activity_kind ?? null,
+            displayName: value?.display_name ?? null,
+            parentPhase: value?.parent_phase ?? null,
+            activityRolloutId: value?.activity_rollout_id ?? null,
+            activityRolloutKind: value?.activity_rollout_kind ?? null,
+            sourceRolloutId: value?.source_rollout_id ?? null,
+            trainingRolloutId: value?.training_rollout_id ?? null,
+            clockUncertainty: value?.clock_uncertainty_s ?? null,
+            executionSequence: value?.execution_sequence ?? null,
           }));
         })
-        .sort((a, b) => (a.start ?? 0) - (b.start ?? 0));
-      const roleNames = Array.from(
-        new Set(substeps.map((substep) => substep.role)),
-      ).sort((a, b) => {
-        const aIndex = ROLE_ORDER.indexOf(a);
-        const bIndex = ROLE_ORDER.indexOf(b);
-        return (aIndex < 0 ? ROLE_ORDER.length : aIndex)
-          - (bIndex < 0 ? ROLE_ORDER.length : bIndex);
-      });
-      const roles = roleNames.map((role) => ({
-        role,
-        substeps: substeps.filter((substep) => substep.role === role),
-      }));
+        .sort((left, right) => (left.start ?? 0) - (right.start ?? 0));
       const phaseStarts = substeps
         .map((substep) => Number(substep.start))
         .filter(Number.isFinite);
       const phaseEnds = substeps
-        .map((substep) => Number(substep.start) + Number(substep.duration))
+        .map(
+          (substep) => Number(substep.start) + Number(substep.duration),
+        )
         .filter(Number.isFinite);
       const timelineStart = phaseStarts.length
         ? Math.min(...phaseStarts)
-        : st?.start ?? null;
+        : step?.start ?? null;
       const timelineEnd = phaseEnds.length
         ? Math.max(...phaseEnds)
-        : st?.end ?? null;
+        : step?.end ?? null;
+      const roleNames = Array.from(
+        new Set(substeps.map((substep) => substep.role)),
+      ).sort((left, right) => {
+        const leftIndex = ROLE_ORDER.indexOf(left);
+        const rightIndex = ROLE_ORDER.indexOf(right);
+        return (
+          (leftIndex < 0 ? ROLE_ORDER.length : leftIndex) -
+          (rightIndex < 0 ? ROLE_ORDER.length : rightIndex)
+        );
+      });
       return {
-        key: k,
-        n: Number.isFinite(Number(k)) ? Number(k) : k,
+        key,
+        n: Number.isFinite(Number(key)) ? Number(key) : key,
+        duration: step?.duration_s ?? null,
         timelineStart,
         timelineDuration:
           timelineStart != null && timelineEnd != null
             ? Math.max(timelineEnd - timelineStart, 0)
-            : st?.duration_s ?? null,
-        duration: st?.duration_s ?? null,
+            : step?.duration_s ?? null,
         substeps,
-        roles,
+        roles: roleNames.map((role) => ({
+          role,
+          substeps: substeps.filter((substep) => substep.role === role),
+        })),
       };
     });
-    out.sort((a, b) => (Number(a.key) || 0) - (Number(b.key) || 0));
-    return out;
-  });
-
-  let hasData = $derived(steps.length > 0);
-
-  let roles = $derived.by(() => {
-    const seen = new Set(
-      steps.flatMap((step) => step.roles.map((role) => role.role)),
+    return parsed.sort(
+      (left, right) => (Number(left.key) || 0) - (Number(right.key) || 0),
     );
-    return Array.from(seen).sort((a, b) => {
-      const aIndex = ROLE_ORDER.indexOf(a);
-      const bIndex = ROLE_ORDER.indexOf(b);
-      return (aIndex < 0 ? ROLE_ORDER.length : aIndex)
-        - (bIndex < 0 ? ROLE_ORDER.length : bIndex);
-    });
-  });
-
-  let timeline = $derived.by(() => {
-    const capturedSubsteps = steps.flatMap((step) =>
-      step.substeps
-        .filter(
-          (substep) =>
-            Number.isFinite(Number(substep.start)) &&
-            Number.isFinite(Number(substep.duration)),
-        )
-        .map((substep) => ({
-          ...substep,
-          step: step.n,
-          end: Number(substep.start) + Number(substep.duration),
-        })),
-    );
-    if (!capturedSubsteps.length) {
-      return { start: 0, duration: 0, roleLanes: [], stepBands: [] };
-    }
-    const start = Math.min(
-      ...capturedSubsteps.map((substep) => Number(substep.start)),
-    );
-    const end = Math.max(...capturedSubsteps.map((substep) => substep.end));
-    const duration = Math.max(end - start, 0.001);
-    const position = (value) => ((value - start) / duration) * 100;
-    const roleLanes = roles.map((role) => ({
-      role,
-      substeps: capturedSubsteps
-        .filter((substep) => substep.role === role)
-        .sort((a, b) => (b.duration ?? 0) - (a.duration ?? 0))
-        .map((substep) => ({
-          ...substep,
-          left: Math.max(0, Math.min(100, position(Number(substep.start)))),
-          width: Math.max(
-            0,
-            Math.min(
-              100 - position(Number(substep.start)),
-              (Number(substep.duration) / duration) * 100,
-            ),
-          ),
-        })),
-    }));
-    const stepBands = steps
-      .map((step) => {
-        const driverPhases = capturedSubsteps.filter(
-          (substep) => substep.step === step.n && substep.role === "driver",
-        );
-        if (!driverPhases.length) return null;
-        const bandStart = Math.min(
-          ...driverPhases.map((substep) => Number(substep.start)),
-        );
-        const bandEnd = Math.max(...driverPhases.map((substep) => substep.end));
-        return {
-          step: step.n,
-          left: position(bandStart),
-          width: Math.max(0, ((bandEnd - bandStart) / duration) * 100),
-          duration: step.duration,
-        };
-      })
-      .filter(Boolean);
-    return { start, duration, roleLanes, stepBands };
   });
 
   let legend = $derived.by(() => {
-    const seen = new Set();
-    for (const s of steps) for (const sub of s.substeps) seen.add(sub.phase);
-    return Array.from(seen).sort((a, b) => {
-      const aIndex = ORDER.indexOf(a);
-      const bIndex = ORDER.indexOf(b);
-      return (aIndex < 0 ? ORDER.length : aIndex)
-        - (bIndex < 0 ? ORDER.length : bIndex);
+    const phases = new Set();
+    for (const step of steps) {
+      for (const substep of step.substeps) {
+        if (
+          layout === "timeline" &&
+          substep.phase === "full_step" &&
+          step.substeps.some(
+            (candidate) =>
+              candidate.role === substep.role &&
+              candidate.phase !== "full_step",
+          )
+        ) {
+          continue;
+        }
+        phases.add(substep.phase);
+      }
+    }
+    return Array.from(phases).sort((left, right) => {
+      const leftIndex = PHASE_ORDER.indexOf(left);
+      const rightIndex = PHASE_ORDER.indexOf(right);
+      return (
+        (leftIndex < 0 ? PHASE_ORDER.length : leftIndex) -
+        (rightIndex < 0 ? PHASE_ORDER.length : rightIndex)
+      );
     });
   });
-
-  let tip = $state(null);
-  let pinned = $state(false);
-
-  // ── Timeline zoom / pan state ────────────────────────────────────────
-  let zoom = $state(1);
-  let viewport = $state(null);
 
   function positionedSubsteps(step, role) {
     const duration = Number(step.timelineDuration);
     const start = Number(step.timelineStart);
-    const hasWallClockBounds =
-      Number.isFinite(duration) && duration > 0 && Number.isFinite(start);
-    if (hasWallClockBounds) {
+    if (Number.isFinite(duration) && duration > 0 && Number.isFinite(start)) {
       return role.substeps.map((substep) => {
         const substepStart = Number(substep.start);
         const substepDuration = Number(substep.duration);
         if (!Number.isFinite(substepStart) || !Number.isFinite(substepDuration)) {
           return { ...substep, left: 0, width: 2 };
         }
-        const left = Math.max(0, Math.min(100, ((substepStart - start) / duration) * 100));
-        const width = Math.max(
+        const left = Math.max(
           0,
-          Math.min(100 - left, (substepDuration / duration) * 100),
+          Math.min(100, ((substepStart - start) / duration) * 100),
         );
-        return { ...substep, left, width };
+        return {
+          ...substep,
+          left,
+          width: Math.max(
+            0,
+            Math.min(100 - left, (substepDuration / duration) * 100),
+          ),
+        };
       });
     }
     const total = role.substeps.reduce(
@@ -287,284 +269,80 @@
     );
     let elapsed = 0;
     return role.substeps.map((substep) => {
-      const substepDuration = Math.max(Number(substep.duration) || 0, 0);
-      const left = total > 0 ? (elapsed / total) * 100 : 0;
-      const width = total > 0 ? (substepDuration / total) * 100 : 100;
-      elapsed += substepDuration;
-      return { ...substep, left, width };
+      const duration = Math.max(Number(substep.duration) || 0, 0);
+      const positioned = {
+        ...substep,
+        left: total > 0 ? (elapsed / total) * 100 : 0,
+        width: total > 0 ? (duration / total) * 100 : 100,
+      };
+      elapsed += duration;
+      return positioned;
     });
-  }
-
-  function stepTitle(step) {
-    const driverDuration = `Driver step: ${fmtSecs(step.duration)}`;
-    if (step.timelineDuration > step.duration * 1.05) {
-      return `${driverDuration} · Captured span: ${fmtSecs(step.timelineDuration)}`;
-    }
-    return driverDuration;
-  }
-
-  function setZoom(next, anchorX = null) {
-    const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, next));
-    if (clamped === zoom) return;
-    if (viewport) {
-      const rect = viewport.getBoundingClientRect();
-      const cursorX = anchorX == null ? rect.width / 2 : anchorX - rect.left;
-      const contentX = viewport.scrollLeft + cursorX;
-      const scale = clamped / zoom;
-      zoom = clamped;
-      requestAnimationFrame(() => {
-        viewport.scrollLeft = contentX * scale - cursorX;
-      });
-    } else {
-      zoom = clamped;
-    }
-  }
-
-  function handleWheel(e) {
-    // Let horizontal trackpad gestures pan natively; vertical wheel zooms.
-    if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
-    e.preventDefault();
-    setZoom(zoom * Math.exp(-e.deltaY * WHEEL_SENSITIVITY), e.clientX);
-  }
-
-  // Wheel listeners are passive by default; zooming needs preventDefault.
-  function wheelZoom(node) {
-    node.addEventListener("wheel", handleWheel, { passive: false });
-    return {
-      destroy() {
-        node.removeEventListener("wheel", handleWheel);
-      },
-    };
-  }
-
-  function isActive(step, sub) {
-    return tip && tip.step === step.n && tip.name === sub.name && tip.role === sub.role;
-  }
-
-  function showTip(e, step, sub) {
-    if (pinned) return;
-    tip = {
-      x: e.clientX,
-      y: e.clientY,
-      step: step.n,
-      name: sub.name,
-      phase: sub.phase,
-      role: sub.role,
-      dur: sub.duration,
-    };
-  }
-
-  function moveTip(e) {
-    if (pinned || !tip) return;
-    tip = { ...tip, x: e.clientX, y: e.clientY };
-  }
-
-  function hideTip() {
-    if (pinned) return;
-    tip = null;
-  }
-
-  function pinTip(e, step, sub) {
-    e.stopPropagation();
-    if (pinned && isActive(step, sub)) {
-      pinned = false;
-      tip = null;
-      return;
-    }
-    pinned = true;
-    tip = {
-      x: e.clientX,
-      y: e.clientY,
-      step: step.n,
-      name: sub.name,
-      phase: sub.phase,
-      role: sub.role,
-      dur: sub.duration,
-    };
-  }
-
-  function clearPin() {
-    if (!pinned) return;
-    pinned = false;
-    tip = null;
   }
 </script>
 
-<svelte:window onclick={clearPin} />
-
-{#snippet segment(step, sub)}
-  <div
-    class="seg"
-    class:seg-null={sub.duration == null}
-    class:active={pinned && isActive(step, sub)}
-    style:left={`${sub.left}%`}
-    style:width={`${sub.width}%`}
-    style:background={sub.duration == null ? undefined : colorFor(sub.phase)}
-    role="button"
-    tabindex="0"
-    onmouseenter={(e) => showTip(e, step, sub)}
-    onmousemove={moveTip}
-    onmouseleave={hideTip}
-    onclick={(e) => pinTip(e, step, sub)}
-    onkeydown={(e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        pinTip(e, step, sub);
-      }
-    }}
-  ></div>
-{/snippet}
-
-{#if hasData}
-  <div class="step-timings">
-    {#if legend.length || layout === "timeline"}
-      <div class="legend-row">
+{#if steps.length}
+  {#if layout === "timeline"}
+    <FrameworkActivityTrace
+      {steps}
+      {stepTimes}
+      {rolloutStats}
+      {legend}
+      phaseOrder={PHASE_ORDER}
+      {labelFor}
+      {colorFor}
+      {descriptionFor}
+      {downloadJson}
+    />
+  {:else}
+    <div class="step-timings">
+      <div class="header">
         <div class="legend">
           {#each legend as phase (phase)}
             <span class="legend-item">
-              <span class="swatch" style:background={colorFor(phase)}></span>
+              <span
+                class="swatch"
+                class:wait={WAIT_PHASES.has(phase)}
+                style:background={colorFor(phase)}
+              ></span>
               {labelFor(phase)}
             </span>
           {/each}
         </div>
-        {#if layout === "timeline"}
-          <div class="tl-toolbar">
-            <div class="zoom-controls">
-              <button
-                class="zoom-btn"
-                onclick={() => setZoom(zoom / ZOOM_BTN_FACTOR)}
-                disabled={zoom <= MIN_ZOOM}
-                title="Zoom out"
-              >
-                <ZoomOut size={13} />
-              </button>
-              <button
-                class="zoom-level"
-                onclick={() => setZoom(MIN_ZOOM)}
-                disabled={zoom <= MIN_ZOOM}
-                title="Reset zoom to fit"
-              >
-                {zoom >= 10 ? Math.round(zoom) : zoom.toFixed(1).replace(/\.0$/, "")}×
-              </button>
-              <button
-                class="zoom-btn"
-                onclick={() => setZoom(zoom * ZOOM_BTN_FACTOR)}
-                disabled={zoom >= MAX_ZOOM}
-                title="Zoom in"
-              >
-                <ZoomIn size={13} />
-              </button>
-            </div>
-            <button
-              class="dl-btn"
-              onclick={downloadJson}
-              title="Download step + substep times as JSON"
-            >
-              <Download size={13} />
-              Download JSON
-            </button>
-          </div>
-        {/if}
+        <button onclick={downloadJson} title="Download step + substep times as JSON">
+          <Download size={13} />
+          Download JSON
+        </button>
       </div>
-    {/if}
-
-    {#if layout === "timeline"}
-      <div class="tl-viewport" bind:this={viewport} use:wheelZoom>
-        <div class="tl-content" style:width={`${zoom * 100}%`}>
-          <div class="role-axis">
-            <div class="role-axis-head"></div>
-            {#each roles as role (role)}
-              <div class="role-axis-label">{role === "step" ? "Timing" : role}</div>
-            {/each}
-          </div>
-          <div class="timeline">
-            <div class="timeline-head">
-              {#each TIME_TICKS as tick (tick)}
-                <span
-                  class="time-tick"
-                  class:tick-first={tick === 0}
-                  class:tick-last={tick === 1}
-                  style:left={`${tick * 100}%`}
-                  title={new Date(timeline.start * 1000 + timeline.duration * tick * 1000).toISOString()}
-                >
-                  +{fmtSecs(timeline.duration * tick)}
-                </span>
-              {/each}
-              {#each timeline.stepBands as band, index (`${band.step}:${band.left}`)}
-                <span
-                  class="step-marker"
-                  class:marker-even={index % 2 === 0}
-                  class:marker-odd={index % 2 !== 0}
-                  style:left={`${band.left}%`}
-                  title={`Step ${band.step}: ${fmtSecs(band.duration)}`}
-                >
-                  S{band.step}
-                </span>
-              {/each}
-            </div>
-            <div class="timeline-lanes">
-              {#each TIME_TICKS as tick (tick)}
-                <div class="time-grid-line" style:left={`${tick * 100}%`}></div>
-              {/each}
-              {#each timeline.stepBands as band, index (`${band.step}:${band.left}`)}
-                <div
-                  class="step-band"
-                  class:band-even={index % 2 === 0}
-                  class:band-odd={index % 2 !== 0}
-                  style:left={`${band.left}%`}
-                  style:width={`${band.width}%`}
-                ></div>
-              {/each}
-              {#each timeline.roleLanes as lane (lane.role)}
-                <div class="bar tl-bar">
-                  {#each lane.substeps as sub (`${sub.step}:${sub.name}`)}
-                    {@render segment({ n: sub.step }, sub)}
-                  {/each}
-                </div>
-              {/each}
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="tl-hint">
-        Captured wall-clock span {fmtSecs(timeline.duration)} · scroll to zoom ·
-        shift-scroll or drag the scrollbar to pan
-      </div>
-    {:else}
       {#each steps as step (step.key)}
         <div class="step-row">
           <div class="step-head">
-            <span class="step-name">Step {step.n}</span>
-            <span class="step-dur" title={stepTitle(step)}>{fmtSecs(step.duration)}</span>
+            <span>Step {step.n}</span>
+            <span class="duration">{fmtSecs(step.duration)}</span>
           </div>
-          {#if step.roles.length}
-            <div class="role-lanes">
-              {#each step.roles as role (role.role)}
-                <div class="role-lane">
-                  <span class="role-label">{role.role === "step" ? "Timing" : role.role}</span>
-                  <div class="bar">
-                    {#each positionedSubsteps(step, role) as sub (sub.name)}
-                      {@render segment(step, sub)}
-                    {/each}
-                  </div>
-                </div>
-              {/each}
+          {#each step.roles as role (role.role)}
+            <div class="role-row">
+              <span class="role-label">
+                {role.role === "step" ? "Timing" : role.role}
+              </span>
+              <div class="bar">
+                {#each positionedSubsteps(step, role) as substep (substep.name)}
+                  <div
+                    class="segment"
+                    class:wait={substep.activityKind
+                      ? substep.activityKind === "wait"
+                      : WAIT_PHASES.has(substep.phase)}
+                    style:left={`${substep.left}%`}
+                    style:width={`${substep.width}%`}
+                    style:background={colorFor(substep.phase)}
+                    title={`${substep.displayName || labelFor(substep.phase)} (${substep.role}) · ${fmtSecs(substep.duration)}`}
+                  ></div>
+                {/each}
+              </div>
             </div>
-          {:else}
-            <div class="bar bar-empty"></div>
-          {/if}
+          {/each}
         </div>
       {/each}
-    {/if}
-  </div>
-
-  {#if tip}
-    <div class="tg-tip" class:pinned style:left={`${tip.x}px`} style:top={`${tip.y}px`}>
-      <span class="tg-tip-step">Step {tip.step}</span>
-      <span class="tg-tip-name">{labelFor(tip.phase)} ({tip.role})</span>
-      <span class="tg-tip-dur">
-        {tip.dur == null ? "unknown (report dropped)" : fmtSecs(tip.dur)}
-      </span>
     </div>
   {/if}
 {/if}
@@ -576,52 +354,58 @@
     gap: 10px;
   }
 
-  .legend-row {
+  .header,
+  .legend,
+  .legend-item,
+  button {
     display: flex;
+    align-items: center;
+  }
+
+  .header {
     justify-content: space-between;
     align-items: flex-start;
     gap: 12px;
-    margin-bottom: 4px;
   }
 
   .legend {
-    display: flex;
     flex-wrap: wrap;
     gap: 6px 14px;
-    font-size: 11px;
-    color: var(--muted);
-  }
-
-  .dl-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    flex-shrink: 0;
-    background: none;
-    border: 1px solid var(--border, #2f2f2f);
-    border-radius: 4px;
     color: var(--muted);
     font-size: 11px;
-    padding: 3px 8px;
-    cursor: pointer;
-  }
-
-  .dl-btn:hover {
-    color: var(--text);
-    border-color: var(--border-strong, #4a4a4a);
   }
 
   .legend-item {
-    display: inline-flex;
-    align-items: center;
     gap: 5px;
   }
 
   .swatch {
     width: 9px;
     height: 9px;
-    border-radius: 2px;
     flex-shrink: 0;
+    border-radius: 2px;
+  }
+
+  .wait {
+    background: repeating-linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 65%, #181818),
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 65%, #181818) 3px,
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 20%, #181818) 3px,
+      color-mix(in srgb, var(--color-c-dataviz-paired-4, #6cabc1) 20%, #181818) 6px
+    ) !important;
+  }
+
+  button {
+    flex-shrink: 0;
+    gap: 5px;
+    padding: 3px 8px;
+    border: 1px solid var(--border, #2f2f2f);
+    border-radius: 4px;
+    background: none;
+    color: var(--muted);
+    cursor: pointer;
+    font-size: 11px;
   }
 
   .step-row {
@@ -633,279 +417,24 @@
   .step-head {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
-    font-size: 12px;
-  }
-
-  .step-name {
     color: var(--text-bright);
+    font-size: 12px;
     font-weight: 500;
   }
 
-  .step-dur {
+  .duration {
     color: var(--muted);
     font-variant-numeric: tabular-nums;
+    font-weight: 400;
   }
 
-  .bar {
-    position: relative;
-    flex: 1;
-    height: 14px;
-    border-radius: 3px;
-    overflow: hidden;
-    background: var(--color-c-gray-08, #1c1c1c);
-  }
-
-  .bar-empty {
-    background: var(--color-c-gray-10, #2f2f2f);
-  }
-
-  .seg {
-    position: absolute;
-    top: 0;
-    height: 100%;
-    cursor: pointer;
-    border-left: 1px solid color-mix(in srgb, #000 35%, transparent);
-    transition: filter 0.1s ease;
-  }
-
-  .seg:hover {
-    filter: brightness(1.25);
-  }
-
-  .seg.active {
-    outline: 1px solid var(--text-bright, #fff);
-    outline-offset: -1px;
-    filter: brightness(1.3);
-  }
-
-  /* Dropped substep: visible but doesn't distort the proportional widths. */
-  .seg-null {
-    background: repeating-linear-gradient(
-      45deg,
-      var(--color-c-gray-20, #3a3a3a),
-      var(--color-c-gray-20, #3a3a3a) 3px,
-      var(--color-c-gray-10, #2f2f2f) 3px,
-      var(--color-c-gray-10, #2f2f2f) 6px
-    );
-  }
-
-  /* ── Timeline (full-width zoomable bar across all steps) ─────────────── */
-  .tl-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-shrink: 0;
-  }
-
-  .zoom-controls {
-    display: inline-flex;
-    align-items: center;
-    border: 1px solid var(--border, #2f2f2f);
-    border-radius: 4px;
-    overflow: hidden;
-  }
-
-  .zoom-btn,
-  .zoom-level {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: none;
-    border: none;
-    color: var(--muted);
-    font-size: 11px;
-    padding: 3px 7px;
-    cursor: pointer;
-  }
-
-  .zoom-level {
-    min-width: 38px;
-    border-left: 1px solid var(--border, #2f2f2f);
-    border-right: 1px solid var(--border, #2f2f2f);
-    font-variant-numeric: tabular-nums;
-  }
-
-  .zoom-btn:hover:not(:disabled),
-  .zoom-level:hover:not(:disabled) {
-    color: var(--text);
-    background: var(--color-c-gray-08, #1c1c1c);
-  }
-
-  .zoom-btn:disabled,
-  .zoom-level:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-
-  .tl-viewport {
-    overflow-x: auto;
-    overflow-y: hidden;
-    padding-bottom: 6px;
-    overscroll-behavior-x: contain;
-    touch-action: pan-x;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .tl-content {
+  .role-row {
     display: grid;
-    grid-template-columns: 58px minmax(0, 1fr);
-    min-width: 100%;
-  }
-
-  .role-axis {
-    position: sticky;
-    left: 0;
-    z-index: 5;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    padding-right: 8px;
-    background: var(--color-c-gray-04, #141414);
-    box-shadow: 6px 0 8px -8px rgba(0, 0, 0, 0.9);
-  }
-
-  .role-axis-head {
-    height: 30px;
-  }
-
-  .role-axis-label {
-    height: 14px;
-    color: var(--muted);
-    font-size: 9px;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    line-height: 14px;
-    text-align: right;
-    text-transform: uppercase;
-  }
-
-  .timeline {
-    min-width: 0;
-  }
-
-  .timeline-head {
-    position: relative;
-    box-sizing: border-box;
-    height: 30px;
-    overflow: hidden;
-    border-bottom: 1px solid var(--border, #2f2f2f);
-  }
-
-  .time-tick {
-    position: absolute;
-    top: 0;
-    transform: translateX(-50%);
-    color: var(--muted);
-    font-size: 9px;
-    font-variant-numeric: tabular-nums;
-    line-height: 13px;
-    white-space: nowrap;
-  }
-
-  .time-tick.tick-first {
-    transform: none;
-  }
-
-  .time-tick.tick-last {
-    transform: translateX(-100%);
-  }
-
-  .step-marker {
-    position: absolute;
-    top: 14px;
-    color: var(--muted);
-    font-size: 9px;
-    font-variant-numeric: tabular-nums;
-    font-weight: 600;
-    line-height: 14px;
-    white-space: nowrap;
-  }
-
-  .step-marker::before {
-    display: inline-block;
-    width: 2px;
-    height: 9px;
-    margin-right: 3px;
-    border-radius: 1px;
-    content: "";
-    vertical-align: -1px;
-  }
-
-  .marker-even::before {
-    background: var(--accent, #60a5fa);
-  }
-
-  .marker-odd::before {
-    background: #a78bfa;
-  }
-
-  .timeline-lanes {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    overflow: hidden;
-    border-radius: 3px;
-    background: var(--color-c-gray-08, #1c1c1c);
-  }
-
-  .step-band {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    z-index: 0;
-    border-left: 1px solid;
-    border-right: 1px solid;
-  }
-
-  .time-grid-line {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    z-index: 0;
-    border-left: 1px solid color-mix(in srgb, var(--muted) 15%, transparent);
-  }
-
-  .band-even {
-    border-color: color-mix(in srgb, var(--accent, #60a5fa) 32%, transparent);
-    background: color-mix(in srgb, var(--accent, #60a5fa) 5%, transparent);
-  }
-
-  .band-odd {
-    border-color: color-mix(in srgb, #a78bfa 32%, transparent);
-    background: color-mix(in srgb, #a78bfa 5%, transparent);
-  }
-
-  .timeline .tl-bar {
-    z-index: 1;
-    flex: none;
-    width: 100%;
-    background: transparent;
-  }
-
-  .timeline .seg {
-    z-index: 2;
-  }
-
-  .tl-bar {
-    height: 14px;
-  }
-
-  .role-lanes {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-  }
-
-  .role-lane {
-    display: block;
-    min-width: 0;
+    grid-template-columns: 48px minmax(0, 1fr);
+    gap: 6px;
   }
 
   .role-label {
-    flex: 0 0 45px;
     overflow: hidden;
     color: var(--muted);
     font-size: 9px;
@@ -915,51 +444,20 @@
     text-align: right;
     text-overflow: ellipsis;
     text-transform: uppercase;
-    white-space: nowrap;
   }
 
-  .tl-hint {
-    font-size: 10px;
-    color: var(--muted);
-    opacity: 0.7;
+  .bar {
+    position: relative;
+    height: 14px;
+    overflow: hidden;
+    border-radius: 3px;
+    background: var(--color-c-gray-08, #1c1c1c);
   }
 
-  /* ── Pinnable tooltip ────────────────────────────────────────────────── */
-  .tg-tip {
-    position: fixed;
-    z-index: 1000;
-    transform: translate(-50%, calc(-100% - 10px));
-    pointer-events: none;
-    display: flex;
-    flex-direction: column;
-    gap: 1px;
-    padding: 6px 9px;
-    border-radius: 6px;
-    background: var(--color-c-gray-02, #0d0d0d);
-    border: 1px solid var(--border, #3a3a3a);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
-    font-size: 11px;
-    white-space: nowrap;
-  }
-
-  .tg-tip.pinned {
-    border-color: var(--accent, #60a5fa);
-  }
-
-  .tg-tip-step {
-    color: var(--muted);
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
-  .tg-tip-name {
-    color: var(--text-bright, #fff);
-    font-weight: 600;
-  }
-
-  .tg-tip-dur {
-    color: var(--muted);
-    font-variant-numeric: tabular-nums;
+  .segment {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-left: 1px solid color-mix(in srgb, #000 35%, transparent);
   }
 </style>

--- a/dashboards/frontend/src/components/frameworkActivityTrace.js
+++ b/dashboards/frontend/src/components/frameworkActivityTrace.js
@@ -1,0 +1,317 @@
+const ROLE_ORDER = ["rollout", "driver", "actor", "critic", "step"];
+const WAIT_PHASES = new Set(["wait_for_rollout", "wait_for_next_rollout"]);
+const REWARD_PHASES = new Set([
+  "custom_reward",
+  "custom_reward_post_process",
+]);
+const ROOT_PHASES = {
+  rollout: new Set([
+    "generate_rollouts",
+    "evaluate_rollouts",
+    "evaluate_rollouts_before",
+    "evaluate_rollouts_after",
+  ]),
+  training: new Set(["train_model"]),
+};
+
+const GROUPS = [
+  {
+    key: "rollout",
+    label: "Rollout pipeline",
+    summaryLabel: "Generation",
+  },
+  {
+    key: "training",
+    label: "Training pipeline",
+    summaryLabel: "Training",
+  },
+  {
+    key: "system",
+    label: "System / waits",
+    summaryLabel: "Coordination / I/O",
+  },
+  {
+    key: "legacy",
+    label: "Timing",
+    summaryLabel: "Timing",
+  },
+];
+
+export const TRACE_GROUP_COLORS = {
+  rollout: "var(--color-c-dataviz-primary-1, #adeaab)",
+  training: "var(--color-c-dataviz-primary-7, #648fe0)",
+  system: "var(--color-c-gray-40, #747474)",
+  legacy: "var(--color-c-dataviz-primary-other, #6d6161)",
+};
+
+export function timelineGroup(substep) {
+  if (substep.timelineGroup) return substep.timelineGroup;
+  if (substep.role === "step") return "legacy";
+  if (REWARD_PHASES.has(substep.phase) || substep.role === "rollout") {
+    return "rollout";
+  }
+  if (substep.role === "actor" || substep.role === "critic") {
+    return "training";
+  }
+  return "system";
+}
+
+export function isWait(substep) {
+  return substep.activityKind
+    ? substep.activityKind === "wait"
+    : WAIT_PHASES.has(substep.phase);
+}
+
+function mergeIntervals(intervals) {
+  const ordered = intervals
+    .filter(
+      (interval) =>
+        Number.isFinite(interval.start) &&
+        Number.isFinite(interval.end) &&
+        interval.end >= interval.start,
+    )
+    .sort((left, right) => left.start - right.start);
+  const merged = [];
+  for (const interval of ordered) {
+    const current = merged.at(-1);
+    if (!current || interval.start > current.end) {
+      merged.push({ ...interval });
+    } else {
+      current.end = Math.max(current.end, interval.end);
+    }
+  }
+  return merged;
+}
+
+function totalDuration(intervals) {
+  return intervals.reduce(
+    (total, interval) => total + interval.end - interval.start,
+    0,
+  );
+}
+
+function overlappingDuration(left, right) {
+  let leftIndex = 0;
+  let rightIndex = 0;
+  let total = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const start = Math.max(left[leftIndex].start, right[rightIndex].start);
+    const end = Math.min(left[leftIndex].end, right[rightIndex].end);
+    total += Math.max(0, end - start);
+    if (left[leftIndex].end < right[rightIndex].end) {
+      leftIndex += 1;
+    } else {
+      rightIndex += 1;
+    }
+  }
+  return total;
+}
+
+export function buildActivityMetrics(steps, rolloutStats) {
+  const substeps = steps.flatMap((step) =>
+    step.substeps.map((substep) => ({
+      ...substep,
+      step: step.n,
+      start: Number(substep.start),
+      end: Number(substep.start) + Number(substep.duration),
+    })),
+  );
+  const rolloutIntervals = mergeIntervals(
+    substeps.filter(
+      (substep) =>
+        timelineGroup(substep) === "rollout" &&
+        substep.phase === "generate_rollouts",
+    ),
+  );
+  const trainingIntervals = mergeIntervals(
+    substeps.filter(
+      (substep) =>
+        timelineGroup(substep) === "training" &&
+        substep.phase === "train_model",
+    ),
+  );
+  const sourceRolloutIds = new Set(
+    substeps
+      .filter(
+        (substep) =>
+          substep.phase === "generate_rollouts" &&
+          substep.activityRolloutId != null,
+      )
+      .map((substep) => Number(substep.activityRolloutId)),
+  );
+  const samples = (rolloutStats || [])
+    .filter((rollout) => sourceRolloutIds.has(Number(rollout.rollout_id)))
+    .reduce((total, rollout) => total + (Number(rollout.total) || 0), 0);
+  const rolloutDuration = totalDuration(rolloutIntervals);
+  const trainingDuration = totalDuration(trainingIntervals);
+  const overlap = overlappingDuration(rolloutIntervals, trainingIntervals);
+  const executions = new Map();
+  for (const substep of substeps) {
+    const sequence = Number(substep.executionSequence);
+    if (!Number.isFinite(sequence)) continue;
+    const key = `${substep.step}:${substep.role}`;
+    executions.set(key, Math.max(executions.get(key) || 0, sequence));
+  }
+  return {
+    hasFrameworkActivity: substeps.some(
+      (substep) =>
+        substep.timelineGroup ||
+        (substep.role !== "step" && ROLE_ORDER.includes(substep.role)),
+    ),
+    rolloutCount: sourceRolloutIds.size,
+    throughput:
+      samples > 0 && rolloutDuration > 0 ? samples / rolloutDuration : null,
+    overlap:
+      trainingDuration > 0 ? Math.min(1, overlap / trainingDuration) : null,
+    retries: Array.from(executions.values()).reduce(
+      (total, sequence) => total + Math.max(0, sequence - 1),
+      0,
+    ),
+  };
+}
+
+function trackLabel(group, substep, labelFor) {
+  const phase = substep.displayName || labelFor(substep.phase);
+  if (group !== "training") return phase;
+  const role = substep.role;
+  return `${phase} · ${role[0].toUpperCase()}${role.slice(1)}`;
+}
+
+function isSummaryPhase(group, substep) {
+  if (group === "system" || group === "legacy") return true;
+  if (substep.parentPhase) return false;
+  return ROOT_PHASES[group]?.has(substep.phase) ?? false;
+}
+
+export function buildFrameworkTimeline(
+  steps,
+  stepTimes,
+  expandedGroups,
+  labelFor,
+  phaseOrder,
+) {
+  const substeps = steps.flatMap((step) =>
+    step.substeps
+      .filter(
+        (substep) =>
+          Number.isFinite(Number(substep.start)) &&
+          Number.isFinite(Number(substep.duration)),
+      )
+      .map((substep) => ({
+        ...substep,
+        step: step.n,
+        end: Number(substep.start) + Number(substep.duration),
+      })),
+  );
+  if (!substeps.length) {
+    return { start: 0, duration: 0, groups: [], tracks: [] };
+  }
+  const stepStarts = steps
+    .map((step) => Number((stepTimes || {})[step.key]?.start))
+    .filter(Number.isFinite);
+  const stepEnds = steps
+    .map((step) => Number((stepTimes || {})[step.key]?.end))
+    .filter(Number.isFinite);
+  const start = Math.min(
+    ...substeps.map((substep) => Number(substep.start)),
+    ...stepStarts,
+  );
+  const end = Math.max(
+    ...substeps.map((substep) => substep.end),
+    ...stepEnds,
+  );
+  const duration = Math.max(end - start, 0.001);
+  const position = (value) => ((value - start) / duration) * 100;
+  const positionSubsteps = (items) =>
+    items
+      .sort((left, right) => (right.duration ?? 0) - (left.duration ?? 0))
+      .map((substep) => ({
+        ...substep,
+        left: Math.max(0, Math.min(100, position(Number(substep.start)))),
+        width: Math.max(
+          0,
+          Math.min(
+            100 - position(Number(substep.start)),
+            (Number(substep.duration) / duration) * 100,
+          ),
+        ),
+      }));
+  const groups = [];
+  for (const definition of GROUPS) {
+    const groupSubsteps = substeps.filter(
+      (substep) =>
+        timelineGroup(substep) === definition.key &&
+        substep.phase !== "full_step",
+    );
+    if (!groupSubsteps.length) continue;
+    const summaryCandidates = groupSubsteps.filter((substep) =>
+      isSummaryPhase(definition.key, substep),
+    );
+    const summarySubsteps = summaryCandidates.length
+      ? summaryCandidates
+      : groupSubsteps;
+    const childSubsteps =
+      definition.key === "system" || definition.key === "legacy"
+        ? groupSubsteps
+        : groupSubsteps.filter(
+            (substep) => !isSummaryPhase(definition.key, substep),
+          );
+    const children = Array.from(
+      childSubsteps.reduce((tracks, substep) => {
+        const key = `${substep.role}:${substep.phase}`;
+        if (!tracks.has(key)) {
+          tracks.set(key, {
+            key: `${definition.key}:${key}`,
+            label: trackLabel(definition.key, substep, labelFor),
+            substeps: [],
+          });
+        }
+        tracks.get(key).substeps.push(substep);
+        return tracks;
+      }, new Map()).values(),
+    )
+      .sort((left, right) => {
+        const leftPhase = left.key.split(":").at(-1);
+        const rightPhase = right.key.split(":").at(-1);
+        const leftIndex = phaseOrder.indexOf(leftPhase);
+        const rightIndex = phaseOrder.indexOf(rightPhase);
+        return (
+          (leftIndex < 0 ? phaseOrder.length : leftIndex) -
+            (rightIndex < 0 ? phaseOrder.length : rightIndex) ||
+          left.label.localeCompare(right.label)
+        );
+      })
+      .map((track) => ({
+        ...track,
+        group: definition.key,
+        isSummary: false,
+        substeps: positionSubsteps(track.substeps),
+      }));
+    groups.push({
+      ...definition,
+      expanded: expandedGroups.has(definition.key),
+      summary: {
+        key: `${definition.key}:summary`,
+        label: definition.label,
+        group: definition.key,
+        expanded: expandedGroups.has(definition.key),
+        expandable: children.length > 0,
+        isSummary: true,
+        substeps: positionSubsteps(summarySubsteps).map((substep) => ({
+          ...substep,
+          summaryColor: TRACE_GROUP_COLORS[definition.key],
+        })),
+      },
+      children,
+    });
+  }
+  return {
+    start,
+    duration,
+    groups,
+    tracks: groups.flatMap((group) => [
+      group.summary,
+      ...(group.expanded ? group.children : []),
+    ]),
+  };
+}

--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -122,6 +122,7 @@ export async function fetchRunRollouts(trainingRunId, { signal } = {}) {
     .filter((item) => item && typeof item === "object")
     .map((item) => ({
       rollout_id: Number(item.rollout_id) || 0,
+      training_attempt: Number(item.training_attempt) || null,
       created_at: Number(item.created_at) || 0,
       total: Number(item.total) || 0,
       mean: typeof item.mean === "number" ? item.mean : Number(item.mean) || 0,
@@ -134,12 +135,31 @@ export async function fetchRunRollouts(trainingRunId, { signal } = {}) {
     .sort((a, b) => a.rollout_id - b.rollout_id);
 }
 
-export async function fetchRollout(trainingRunId, rolloutId) {
+export async function fetchRollout(trainingRunId, rolloutId, trainingAttempt = null) {
+  const query = trainingAttempt == null
+    ? ""
+    : `?training_attempt=${encodeURIComponent(trainingAttempt)}`;
   const res = await fetch(
-    `${SERVER}/runs/${encodeURIComponent(trainingRunId)}/rollouts/${encodeURIComponent(rolloutId)}`,
+    `${SERVER}/runs/${encodeURIComponent(trainingRunId)}/rollouts/${encodeURIComponent(rolloutId)}${query}`,
   );
   if (!res.ok) return null;
   return await res.json();
+}
+
+export async function fetchSubstepTimings(trainingRunId, keys, { signal } = {}) {
+  if (!keys.length) return [];
+  const res = await fetch(
+    `${SERVER}/runs/${encodeURIComponent(trainingRunId)}/substep-timings/query`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keys }),
+      signal,
+    },
+  );
+  if (!res.ok) return [];
+  const data = await res.json();
+  return Array.isArray(data) ? data : [];
 }
 
 // Historical Modal logs for a run, served from the durable storage.

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -21,6 +21,7 @@
     fetchRunAdvantages,
     fetchRunAdvantageStep,
     fetchRunLogs,
+    fetchSubstepTimings,
   } from "../lib/api.js";
 
   // Number of historical log lines requested per page.
@@ -136,8 +137,8 @@
   // Map a rollout to its step timing. Step keys are 1-indexed; rollout ids are
   // 0-indexed, so step N corresponds to rollout N-1 (fall back to a direct match).
   function stepTimingForRollout(rolloutId) {
-    const st = run?.step_times || null;
-    const sub = run?.substep_times || null;
+    const st = displayedStepTimes;
+    const sub = displayedSubstepTimes;
     if (!st && !sub) return null;
     const candidates = [String(Number(rolloutId) + 1), String(rolloutId)];
     const key = candidates.find((k) => (st && st[k]) || (sub && sub[k]));
@@ -165,11 +166,98 @@
 
   // ── Rollouts (auto-refresh while run is running) ─────────────────────
   let rolloutSummaries = $state([]);
+  let substepTimingByAttemptAndRollout = $state({});
+  let rolloutLoadVersion = 0;
   let rolloutsLoading = $state(false);
   let rolloutsError = $state("");
   let expandedRolloutId = $state(null);
+  let expandedRolloutAttempt = $state(null);
   let expandedRollout = $state(null);
   let expandedRolloutLoading = $state(false);
+  let liveStepTimes = $derived.by(() => {
+    const steps = {};
+    for (const rollout of rolloutSummaries) {
+      const timing =
+        substepTimingByAttemptAndRollout[
+          `${rollout.training_attempt}:${rollout.rollout_id}`
+        ];
+      if (!timing) continue;
+      const key = String(Number(rollout.rollout_id) + 1);
+      steps[key] = {
+        start: timing.started_at_unix_s,
+        end: timing.started_at_unix_s + timing.duration_s,
+        duration_s: timing.duration_s,
+      };
+    }
+    return steps;
+  });
+  let liveSubstepTimes = $derived.by(() => {
+    const steps = {};
+    for (const rollout of rolloutSummaries) {
+      const timing =
+        substepTimingByAttemptAndRollout[
+          `${rollout.training_attempt}:${rollout.rollout_id}`
+        ];
+      if (!timing) continue;
+      const phases = {};
+      for (const role of timing.roles || []) {
+        for (const phase of role.phases || []) {
+          if (phase.phase === "full_step") continue;
+          phases[`${phase.phase} (${role.role})`] = {
+            start: phase.started_at_unix_s,
+            end: phase.started_at_unix_s + phase.duration_s,
+            duration_s: phase.duration_s,
+          };
+        }
+      }
+      steps[String(Number(rollout.rollout_id) + 1)] = phases;
+    }
+    return steps;
+  });
+  let visibleLegacyTimingKeys = $derived.by(() => {
+    const hasAttemptScopedRollouts = rolloutSummaries.some(
+      (rollout) => rollout.training_attempt != null,
+    );
+    const retryHasNoVisibleRollouts =
+      rolloutSummaries.length === 0 &&
+      Number(run?.resume_state?.attempt_count) > 1;
+    if (!hasAttemptScopedRollouts && !retryHasNoVisibleRollouts) return null;
+    const keys = new Set();
+    for (const rollout of rolloutSummaries) {
+      if (rollout.training_attempt != null) continue;
+      const nextKey = String(Number(rollout.rollout_id) + 1);
+      const directKey = String(rollout.rollout_id);
+      if (run?.step_times?.[nextKey] || run?.substep_times?.[nextKey]) {
+        keys.add(nextKey);
+      } else if (
+        run?.step_times?.[directKey] ||
+        run?.substep_times?.[directKey]
+      ) {
+        keys.add(directKey);
+      }
+    }
+    return keys;
+  });
+  let displayedStepTimes = $derived.by(() => {
+    const legacy = Object.fromEntries(
+      Object.entries(run?.step_times || {}).filter(
+        ([key]) =>
+          visibleLegacyTimingKeys === null || visibleLegacyTimingKeys.has(key),
+      ),
+    );
+    const merged = { ...legacy, ...liveStepTimes };
+    return Object.keys(merged).length ? merged : null;
+  });
+  let displayedSubstepTimes = $derived.by(() => {
+    const legacy = Object.fromEntries(
+      Object.entries(run?.substep_times || {}).filter(
+        ([key]) =>
+          visibleLegacyTimingKeys === null || visibleLegacyTimingKeys.has(key),
+      ),
+    );
+    const merged = { ...legacy, ...liveSubstepTimes };
+    return Object.keys(merged).length ? merged : null;
+  });
   const rolloutColumns = [
     { key: "step", label: "Step", width: 72, minWidth: 56 },
     { key: "mean", label: "Mean reward", width: 118, minWidth: 96 },
@@ -319,11 +407,60 @@
 
   async function loadRollouts(signal) {
     if (!runId) return;
+    const loadVersion = ++rolloutLoadVersion;
     try {
       const wasEmpty = rolloutSummaries.length === 0;
       const rows = await fetchRunRollouts(runId, { signal });
-      if (signal?.aborted) return;
+      if (signal?.aborted || loadVersion !== rolloutLoadVersion) return;
       rolloutSummaries = rows;
+      if (expandedRolloutId !== null) {
+        const selected = rows.find(
+          (row) => row.rollout_id === expandedRolloutId,
+        );
+        if (!selected) {
+          expandedRolloutId = null;
+          expandedRolloutAttempt = null;
+          expandedRollout = null;
+        } else if (
+          (selected.training_attempt ?? null) !== expandedRolloutAttempt
+        ) {
+          void loadExpandedRollout(
+            expandedRolloutId,
+            selected.training_attempt,
+          );
+        }
+      }
+      const missing = rows
+        .filter((row) => row.training_attempt != null)
+        .filter(
+          (row) =>
+            !substepTimingByAttemptAndRollout[
+              `${row.training_attempt}:${row.rollout_id}`
+            ],
+        )
+        .map((row) => ({
+          training_attempt: row.training_attempt,
+          rollout_id: row.rollout_id,
+        }));
+      for (let offset = 0; offset < missing.length; offset += 512) {
+        const timings = await fetchSubstepTimings(
+          runId,
+          missing.slice(offset, offset + 512),
+          { signal },
+        );
+        if (signal?.aborted || loadVersion !== rolloutLoadVersion) return;
+        if (timings.length) {
+          substepTimingByAttemptAndRollout = {
+            ...substepTimingByAttemptAndRollout,
+            ...Object.fromEntries(
+              timings.map((timing) => [
+                `${timing.training_attempt}:${timing.rollout_id}`,
+                timing,
+              ]),
+            ),
+          };
+        }
+      }
       rolloutsError = "";
 
       // Reveal the first rollout
@@ -331,13 +468,13 @@
         toggleRolloutDetail(rolloutSummaries[0].rollout_id);
       }
     } catch (err) {
-      if (signal?.aborted) return;
+      if (signal?.aborted || loadVersion !== rolloutLoadVersion) return;
       // Keep the rollouts we already have on a transient poll failure — only
       // surface the error when there's nothing to show, so the charts/table
       // don't flip to an error message (and back) every flaky 5s poll.
       if (!rolloutSummaries.length) rolloutsError = String(err?.message || err);
     } finally {
-      rolloutsLoading = false;
+      if (loadVersion === rolloutLoadVersion) rolloutsLoading = false;
     }
   }
 
@@ -357,9 +494,12 @@
   // so flipping between the summary/rollouts tabs doesn't clear what's loaded).
   $effect(() => {
     runId;
+    rolloutLoadVersion += 1;
     rolloutSummaries = [];
+    substepTimingByAttemptAndRollout = {};
     rolloutsError = "";
     expandedRolloutId = null;
+    expandedRolloutAttempt = null;
     expandedRollout = null;
     advantageSteps = [];
     closeBucket();
@@ -413,25 +553,40 @@
     if (!runId) return;
     if (expandedRolloutId === rolloutId) {
       expandedRolloutId = null;
+      expandedRolloutAttempt = null;
       expandedRollout = null;
       closeBucket();
       return;
     }
     expandedRolloutId = rolloutId;
+    const summary = rolloutSummaries.find(
+      (rollout) => rollout.rollout_id === rolloutId,
+    );
+    await loadExpandedRollout(rolloutId, summary?.training_attempt);
+  }
+
+  async function loadExpandedRollout(rolloutId, trainingAttempt) {
+    if (!runId || expandedRolloutId !== rolloutId) return;
+    expandedRolloutAttempt = trainingAttempt ?? null;
     expandedRollout = null;
     closeBucket();
     expandedRolloutLoading = true;
     try {
-      const detail = await fetchRollout(runId, rolloutId);
-      if (expandedRolloutId === rolloutId) {
+      const detail = await fetchRollout(runId, rolloutId, trainingAttempt);
+      if (
+        expandedRolloutId === rolloutId &&
+        expandedRolloutAttempt === (trainingAttempt ?? null)
+      ) {
         expandedRollout = detail;
-        // Preselect the first populated bucket so a sample is shown right away.
         const d = sampleDist;
         const first = d ? d.buckets.findIndex((b) => b.length > 0) : -1;
         if (first >= 0) openBucket(first);
       }
     } finally {
-      if (expandedRolloutId === rolloutId) {
+      if (
+        expandedRolloutId === rolloutId &&
+        expandedRolloutAttempt === (trainingAttempt ?? null)
+      ) {
         expandedRolloutLoading = false;
       }
     }
@@ -1132,8 +1287,17 @@
     let cancelled = false;
     (async () => {
       try {
-        const first = await fetchRollout(id, fId);
-        const last = fId === lId ? first : await fetchRollout(id, lId);
+        const firstAttempt = rolloutSummaries.find(
+          (rollout) => rollout.rollout_id === fId,
+        )?.training_attempt;
+        const lastAttempt = rolloutSummaries.find(
+          (rollout) => rollout.rollout_id === lId,
+        )?.training_attempt;
+        const first = await fetchRollout(id, fId, firstAttempt);
+        const last =
+          fId === lId
+            ? first
+            : await fetchRollout(id, lId, lastAttempt);
         if (cancelled) return;
         scoreDist = buildScoreDist(first?.samples || [], last?.samples || [], fId, lId);
       } catch {
@@ -1259,13 +1423,13 @@
               <pre class="[border:1px_solid_color-mix(in_srgb,var(--red,#f87171)_45%,transparent)] rounded-[8px] bg-[color-mix(in_srgb,var(--red,#f87171)_12%,transparent)] text-(--red,#f87171) [font-family:var(--font-mono)] text-[12px] leading-[17px] m-0 max-h-[320px] overflow-auto p-[12px_14px] whitespace-pre-wrap [word-break:break-word]">{run.error_message}</pre>
             </div>
           {/if}
-          {#if run.step_times || run.substep_times}
+          {#if displayedStepTimes || displayedSubstepTimes}
             <div class="rollout-chart">
               <div class="rollout-chart-title">Step &amp; substep timeline</div>
               <div class="chart-scroll">
                 <StepTimings
-                  stepTimes={run.step_times}
-                  substepTimes={run.substep_times}
+                  stepTimes={displayedStepTimes}
+                  substepTimes={displayedSubstepTimes}
                   layout="timeline"
                   downloadName={`step_substep_times_${runId}.json`}
                 />
@@ -1873,4 +2037,3 @@
     {/if}
   {/if}
 </section>
-

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -167,6 +167,7 @@
   // ── Rollouts (auto-refresh while run is running) ─────────────────────
   let rolloutSummaries = $state([]);
   let substepTimingByAttemptAndRollout = $state({});
+  let pendingSubstepTimingKeys = new Set();
   let rolloutLoadVersion = 0;
   let rolloutsLoading = $state(false);
   let rolloutsError = $state("");
@@ -409,9 +410,9 @@
     if (!runId) return;
     const loadVersion = ++rolloutLoadVersion;
     try {
-      const wasEmpty = rolloutSummaries.length === 0;
       const rows = await fetchRunRollouts(runId, { signal });
       if (signal?.aborted || loadVersion !== rolloutLoadVersion) return;
+      const wasEmpty = rolloutSummaries.length === 0;
       rolloutSummaries = rows;
       if (expandedRolloutId !== null) {
         const selected = rows.find(
@@ -428,37 +429,6 @@
             expandedRolloutId,
             selected.training_attempt,
           );
-        }
-      }
-      const missing = rows
-        .filter((row) => row.training_attempt != null)
-        .filter(
-          (row) =>
-            !substepTimingByAttemptAndRollout[
-              `${row.training_attempt}:${row.rollout_id}`
-            ],
-        )
-        .map((row) => ({
-          training_attempt: row.training_attempt,
-          rollout_id: row.rollout_id,
-        }));
-      for (let offset = 0; offset < missing.length; offset += 512) {
-        const timings = await fetchSubstepTimings(
-          runId,
-          missing.slice(offset, offset + 512),
-          { signal },
-        );
-        if (signal?.aborted || loadVersion !== rolloutLoadVersion) return;
-        if (timings.length) {
-          substepTimingByAttemptAndRollout = {
-            ...substepTimingByAttemptAndRollout,
-            ...Object.fromEntries(
-              timings.map((timing) => [
-                `${timing.training_attempt}:${timing.rollout_id}`,
-                timing,
-              ]),
-            ),
-          };
         }
       }
       rolloutsError = "";
@@ -497,6 +467,7 @@
     rolloutLoadVersion += 1;
     rolloutSummaries = [];
     substepTimingByAttemptAndRollout = {};
+    pendingSubstepTimingKeys = new Set();
     rolloutsError = "";
     expandedRolloutId = null;
     expandedRolloutAttempt = null;
@@ -547,6 +518,61 @@
       controller.abort();
       window.clearInterval(interval);
     };
+  });
+
+  $effect(() => {
+    const id = runId;
+    const pendingKeys = pendingSubstepTimingKeys;
+    const missing = rolloutSummaries
+      .filter((rollout) => rollout.training_attempt != null)
+      .filter(
+        (rollout) =>
+          !substepTimingByAttemptAndRollout[
+            `${rollout.training_attempt}:${rollout.rollout_id}`
+          ] &&
+          !pendingKeys.has(
+            `${rollout.training_attempt}:${rollout.rollout_id}`,
+          ),
+      )
+      .map((rollout) => ({
+        key: `${rollout.training_attempt}:${rollout.rollout_id}`,
+        training_attempt: rollout.training_attempt,
+        rollout_id: rollout.rollout_id,
+      }));
+    if (!id || !missing.length) return;
+
+    for (const item of missing) pendingKeys.add(item.key);
+    void (async () => {
+      try {
+        const requests = [];
+        for (let offset = 0; offset < missing.length; offset += 512) {
+          requests.push(
+            fetchSubstepTimings(
+              id,
+              missing.slice(offset, offset + 512).map((item) => ({
+                training_attempt: item.training_attempt,
+                rollout_id: item.rollout_id,
+              })),
+            ),
+          );
+        }
+        const timings = (await Promise.all(requests)).flat();
+        if (id !== runId || !timings.length) return;
+        substepTimingByAttemptAndRollout = {
+          ...substepTimingByAttemptAndRollout,
+          ...Object.fromEntries(
+            timings.map((timing) => [
+              `${timing.training_attempt}:${timing.rollout_id}`,
+              timing,
+            ]),
+          ),
+        };
+      } catch {
+        return;
+      } finally {
+        for (const item of missing) pendingKeys.delete(item.key);
+      }
+    })();
   });
 
   async function toggleRolloutDetail(rolloutId) {

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -209,6 +209,22 @@
             end: phase.started_at_unix_s + phase.duration_s,
             duration_s: phase.duration_s,
             intervals: phase.intervals || [],
+            timeline_group: phase.timeline_group,
+            activity_kind: phase.activity_kind,
+            display_name: phase.display_name,
+            parent_phase: phase.parent_phase,
+            activity_rollout_id:
+              role.role === "rollout"
+                ? timing.source_rollout_id ?? timing.rollout_id
+                : timing.training_rollout_id ?? timing.rollout_id,
+            activity_rollout_kind:
+              role.role === "rollout" ? "source" : "training",
+            source_rollout_id:
+              timing.source_rollout_id ?? timing.rollout_id,
+            training_rollout_id:
+              timing.training_rollout_id ?? timing.rollout_id,
+            clock_uncertainty_s: role.clock_uncertainty_s,
+            execution_sequence: role.execution_sequence,
           };
         }
       }
@@ -1457,6 +1473,7 @@
                 <StepTimings
                   stepTimes={displayedStepTimes}
                   substepTimes={displayedSubstepTimes}
+                  rolloutStats={rolloutSummaries}
                   layout="timeline"
                   downloadName={`step_substep_times_${runId}.json`}
                 />

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -208,6 +208,7 @@
             start: phase.started_at_unix_s,
             end: phase.started_at_unix_s + phase.duration_s,
             duration_s: phase.duration_s,
+            intervals: phase.intervals || [],
           };
         }
       }
@@ -1451,7 +1452,7 @@
           {/if}
           {#if displayedStepTimes || displayedSubstepTimes}
             <div class="rollout-chart">
-              <div class="rollout-chart-title">Step &amp; substep timeline</div>
+              <div class="rollout-chart-title">Framework activity timeline</div>
               <div class="chart-scroll">
                 <StepTimings
                   stepTimes={displayedStepTimes}

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -825,7 +825,14 @@ def fastapi_app():
             and update.training_attempt < _current_attempt(run)
         ):
             return JSONResponse({"status": "stale"})
-        if update.timing_protocol == SUBSTEP_TIMING_PROTOCOL:
+        boundary = (
+            update.training_attempt,
+            update.first_rollout_id,
+            update.rollout_id_stop_exclusive,
+        )
+        if update.timing_protocol == SUBSTEP_TIMING_PROTOCOL and all(
+            value is not None for value in boundary
+        ):
             await _store_boundary(
                 update.training_run_id,
                 update.training_attempt,

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -43,7 +43,24 @@ from modal_training_gym.common.run_summary import (
     RunSummary,
     build_run_summaries,
 )
-from modal_training_gym.common.training_rollout import TrainingRolloutResult
+from modal_training_gym.common.substep_timing import (
+    SUBSTEP_TIMING_PROTOCOL,
+    SUBSTEP_TIMING_SCHEMA_VERSION,
+    SubstepTiming,
+    SubstepTimingQuery,
+    TrainingAttemptBoundary,
+)
+from modal_training_gym.common.substep_timing_store import (
+    StoredValueConflictError,
+    list_attempt_boundaries,
+    read_substep_timings,
+    store_attempt_boundary,
+    store_substep_timing,
+)
+from modal_training_gym.common.training_rollout import (
+    TrainingRolloutResult,
+    select_rollout_summaries,
+)
 
 SummaryLoader = Callable[[], Awaitable[list[JsonDict]]]
 
@@ -116,6 +133,7 @@ DASHBOARD_PASSWORD_SECRET_NAME = "_training-gym-dashboard-password"
 PASSWORD_EXEMPT_PATHS = frozenset(
     {
         "/api/framework-status",
+        "/api/timing-events",
         "/api/training-rollouts",
         "/api/advantage-distributions",
     }
@@ -743,6 +761,46 @@ def fastapi_app():
                 detail=f"TrainingRun {training_run_id!r} not found",
             )
 
+    def _current_attempt(run: TrainingRun) -> int:
+        try:
+            return int((run.metadata or {}).get("attempt_count") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    async def _store_boundary(
+        training_run_id: str,
+        training_attempt: int | None,
+        first_rollout_id: int | None,
+        rollout_id_stop_exclusive: int | None,
+    ) -> None:
+        values = (
+            training_attempt,
+            first_rollout_id,
+            rollout_id_stop_exclusive,
+        )
+        if all(value is None for value in values):
+            return
+        if any(value is None for value in values):
+            raise HTTPException(
+                status_code=422,
+                detail="Attempt-scoped reports require a complete boundary",
+            )
+        assert training_attempt is not None
+        assert first_rollout_id is not None
+        assert rollout_id_stop_exclusive is not None
+        try:
+            await run_in_threadpool(
+                store_attempt_boundary,
+                TrainingAttemptBoundary(
+                    training_run_id=training_run_id,
+                    training_attempt=training_attempt,
+                    first_rollout_id=first_rollout_id,
+                    rollout_id_stop_exclusive=rollout_id_stop_exclusive,
+                ),
+            )
+        except StoredValueConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+
     # ── Training runs ────────────────────────────────────────────────────
 
     @web.get("/api/runs", response_model=list[RunSummary])
@@ -762,6 +820,18 @@ def fastapi_app():
     ):
         run = await _get_run_or_404(update.training_run_id)
         await _require_framework_status_token(update.training_run_id, authorization)
+        if (
+            update.training_attempt is not None
+            and update.training_attempt < _current_attempt(run)
+        ):
+            return JSONResponse({"status": "stale"})
+        if update.timing_protocol == SUBSTEP_TIMING_PROTOCOL:
+            await _store_boundary(
+                update.training_run_id,
+                update.training_attempt,
+                update.first_rollout_id,
+                update.rollout_id_stop_exclusive,
+            )
 
         status = await run_in_threadpool(run.apply_framework_status, update)
         if status is None:
@@ -776,6 +846,43 @@ def fastapi_app():
         invalidate_cache("runs")
         return JSONResponse({"status": "ok", "framework_status": status.value})
 
+    @web.get("/api/timing-events")
+    async def timing_events_capability():
+        return JSONResponse(
+            {
+                "protocol": SUBSTEP_TIMING_PROTOCOL,
+                "schema_version": SUBSTEP_TIMING_SCHEMA_VERSION,
+            }
+        )
+
+    @web.post("/api/timing-events")
+    async def timing_event(
+        timing: SubstepTiming,
+        authorization: str | None = Header(default=None),
+    ):
+        run = await _get_run_or_404(timing.training_run_id)
+        await _require_framework_status_token(timing.training_run_id, authorization)
+        if timing.training_attempt < _current_attempt(run):
+            return JSONResponse({"status": "stale"})
+        try:
+            result = await run_in_threadpool(store_substep_timing, timing)
+        except StoredValueConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        return JSONResponse({"status": result.value})
+
+    @web.post("/api/runs/{training_run_id}/substep-timings/query")
+    async def query_substep_timings(
+        training_run_id: str,
+        query: SubstepTimingQuery,
+    ):
+        await _get_run_or_404(training_run_id)
+        timings = await run_in_threadpool(
+            read_substep_timings,
+            training_run_id,
+            query.keys,
+        )
+        return JSONResponse([timing.model_dump(mode="json") for timing in timings])
+
     # ── Training rollouts ────────────────────────────────────────────────
 
     @web.post("/api/training-rollouts")
@@ -785,10 +892,22 @@ def fastapi_app():
     ):
         run = await _get_run_or_404(result.training_run_id)
         await _require_framework_status_token(result.training_run_id, authorization)
+        if (
+            result.training_attempt is not None
+            and result.training_attempt < _current_attempt(run)
+        ):
+            return JSONResponse({"status": "stale"})
+        await _store_boundary(
+            result.training_run_id,
+            result.training_attempt,
+            result.first_rollout_id,
+            result.rollout_id_stop_exclusive,
+        )
 
         await result.save(is_async=True)
-        run.record_latest_rollout(result)
-        await run.save(is_async=True)
+        if result.training_attempt is None:
+            run.record_latest_rollout(result)
+            await run.save(is_async=True)
         invalidate_cache("runs")
 
         return JSONResponse(
@@ -800,11 +919,30 @@ def fastapi_app():
         summaries = await run_in_threadpool(
             TrainingRolloutResult.list_summaries_for_run, training_run_id
         )
-        return JSONResponse(summaries)
+        boundaries = await run_in_threadpool(list_attempt_boundaries, training_run_id)
+        selected = select_rollout_summaries(
+            summaries,
+            [
+                (
+                    boundary.training_attempt,
+                    boundary.first_rollout_id,
+                    boundary.rollout_id_stop_exclusive,
+                )
+                for boundary in boundaries
+            ],
+        )
+        return JSONResponse(selected)
 
     @web.get("/api/runs/{training_run_id}/rollouts/{rollout_id}")
-    async def get_run_rollout(training_run_id: str, rollout_id: int):
-        key = f"{training_run_id}__{int(rollout_id):08d}"
+    async def get_run_rollout(
+        training_run_id: str,
+        rollout_id: int,
+        training_attempt: int | None = None,
+    ):
+        if training_attempt is None:
+            key = f"{training_run_id}__{int(rollout_id):08d}"
+        else:
+            key = f"{training_run_id}/{training_attempt:08d}/{int(rollout_id):08d}"
         try:
             data = await run_in_threadpool(
                 vol_get, MetadataStore.TRAINING_ROLLOUTS, key

--- a/modal_training_gym/cli/cleanup.py
+++ b/modal_training_gym/cli/cleanup.py
@@ -10,6 +10,7 @@ from modal_training_gym.utils.metadata import (
     vol_get_summary_items,
     vol_put_summary_items,
     vol_remove,
+    vol_remove_tree,
 )
 
 TERMINAL_STATUSES = frozenset({TrainingRunStatus.FAILED, TrainingRunStatus.CANCELLED})
@@ -65,6 +66,13 @@ def cleanup(*, older_than_days: int = 7, dry_run: bool = False) -> None:
         if vol_remove(MetadataStore.TRAINING_RUNS, rid):
             deleted_runs += 1
         vol_remove(MetadataStore.FRAMEWORK_STATUS_TOKENS, rid)
+        for store in (
+            MetadataStore.TRAINING_ROLLOUTS,
+            MetadataStore.TRAINING_ROLLOUTS_SUMMARY,
+            MetadataStore.TRAINING_ATTEMPTS,
+            MetadataStore.SUBSTEP_TIMING,
+        ):
+            vol_remove_tree(store, rid)
         deleted_tokens += 1
 
     rollout_summary = (

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -237,6 +237,7 @@ async def init_training_run_record(
     wandb_cfg: "WandbConfig | None",
     wandb_entity: str,
     framework_status_token: str,
+    minimum_previous_attempt: int = 0,
 ) -> tuple[Any, str, str]:
     """Create or resume the ``TrainingRun`` record for this attempt and persist
     the framework-status token. Returns
@@ -265,7 +266,9 @@ async def init_training_run_record(
             started_at=created_at,
         )
     attempt_count = mark_training_attempt_started(
-        run_record, started_at=int(time.time())
+        run_record,
+        started_at=int(time.time()),
+        minimum_previous_attempt=minimum_previous_attempt,
     )
     wandb_run_id = ""
     if wandb_cfg is not None:

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, PrivateAttr, computed_field, field_validator
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.status import FrameworkStatus, resolve_framework_status
 from modal_training_gym.common.step_timing import record_step_time_event
+from modal_training_gym.common.substep_timing import SUBSTEP_TIMING_PROTOCOL
 from modal_training_gym.utils.metadata import (
     MetadataStore,
     _step_times_dict,
@@ -51,9 +52,19 @@ class FrameworkStatusUpdate(BaseModel):
     # Client-side timestamp of the event (time.time() in the reporting
     # process); step timings use it so queue/network latency doesn't skew them.
     event_ts: float | None = None
+    training_attempt: int | None = None
+    timing_protocol: str = ""
+    first_rollout_id: int | None = None
+    rollout_id_stop_exclusive: int | None = None
 
     @field_validator(
-        "progress_current", "progress_total", "rollout_id", "step_id", mode="before"
+        "progress_current",
+        "progress_total",
+        "rollout_id",
+        "step_id",
+        "first_rollout_id",
+        "rollout_id_stop_exclusive",
+        mode="before",
     )
     @classmethod
     def _non_negative_int_or_none(cls, value: object) -> int | None:
@@ -64,6 +75,17 @@ class FrameworkStatusUpdate(BaseModel):
         except ValueError:
             return None
         return parsed if parsed >= 0 else None
+
+    @field_validator("training_attempt", mode="before")
+    @classmethod
+    def _positive_int_or_none(cls, value: object) -> int | None:
+        if not isinstance(value, (int, float, str)):
+            return None
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+        return parsed if parsed > 0 else None
 
 
 class TrainingRunStatus(Enum):
@@ -226,15 +248,16 @@ class TrainingRun(BaseModel):
         metadata["framework_progress"] = progress
         self.metadata = metadata
 
-        current_step = progress.get("current")
-        record_step_time_event(
-            cast(MutableMapping[str, Any], _step_times_dict()),
-            self.training_run_id,
-            current_step,
-            status.value,
-            update.step_event.strip(),
-            update.event_ts or time.time(),
-        )
+        if update.timing_protocol != SUBSTEP_TIMING_PROTOCOL:
+            current_step = progress.get("current")
+            record_step_time_event(
+                cast(MutableMapping[str, object], _step_times_dict()),
+                self.training_run_id,
+                current_step,
+                status.value,
+                update.step_event.strip(),
+                update.event_ts or time.time(),
+            )
         return status
 
     def record_latest_rollout(self, rollout: TrainingRolloutResult) -> None:
@@ -360,10 +383,17 @@ def mark_training_attempt_started(
     run: TrainingRun,
     *,
     started_at: int,
+    minimum_previous_attempt: int = 0,
 ) -> int:
     metadata = dict(run.metadata or {})
     try:
-        attempt_count = int(metadata.get("attempt_count") or 0) + 1
+        attempt_count = (
+            max(
+                int(metadata.get("attempt_count") or 0),
+                minimum_previous_attempt,
+            )
+            + 1
+        )
     except (TypeError, ValueError):
         attempt_count = 1
 

--- a/modal_training_gym/common/substep_timing.py
+++ b/modal_training_gym/common/substep_timing.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+SUBSTEP_TIMING_PROTOCOL = "substep_timing"
+SUBSTEP_TIMING_SCHEMA_VERSION = 1
+
+
+class TimingRole(str, Enum):
+    DRIVER = "driver"
+    ROLLOUT = "rollout"
+    ACTOR = "actor"
+    CRITIC = "critic"
+
+
+class TimingCaptureStatus(str, Enum):
+    CAPTURED = "captured"
+    NOT_RUN = "not_run"
+    UNAVAILABLE = "unavailable"
+
+
+class TimingPhase(str, Enum):
+    FULL_STEP = "full_step"
+    WAIT_FOR_ROLLOUT = "wait_for_rollout"
+    OFFLOAD_ROLLOUT = "offload_rollout"
+    TRAIN_MODELS = "train_models"
+    CHECKPOINT_SAVE = "checkpoint_save"
+    TRAINING_CLEANUP = "training_cleanup"
+    WAIT_FOR_NEXT_ROLLOUT = "wait_for_next_rollout"
+    WEIGHT_SYNC = "weight_sync"
+    EVALUATE_ROLLOUTS_BEFORE = "evaluate_rollouts_before"
+    EVALUATE_ROLLOUTS_AFTER = "evaluate_rollouts_after"
+    GENERATE_ROLLOUTS = "generate_rollouts"
+    CUSTOM_REWARD = "custom_reward"
+    CUSTOM_REWARD_POST_PROCESS = "custom_reward_post_process"
+    TRAIN_MODEL = "train_model"
+    FORWARD_BACKWARD = "forward_backward"
+    OPTIMIZER_STEP = "optimizer_step"
+
+
+class TimingModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    @field_validator("training_run_id", check_fields=False)
+    @classmethod
+    def validate_training_run_id(cls, value: str) -> str:
+        if "/" in value or value in {".", ".."}:
+            raise ValueError("training_run_id is not path-safe")
+        return value
+
+
+class TrainingAttemptStarted(TimingModel):
+    schema_version: Literal[1] = SUBSTEP_TIMING_SCHEMA_VERSION
+    training_run_id: str = Field(min_length=1)
+    training_attempt: int = Field(gt=0)
+    started_at_unix_s: float = Field(ge=0)
+
+
+class TrainingAttemptBoundary(TimingModel):
+    schema_version: Literal[1] = SUBSTEP_TIMING_SCHEMA_VERSION
+    training_run_id: str = Field(min_length=1)
+    training_attempt: int = Field(gt=0)
+    first_rollout_id: int = Field(ge=0)
+    rollout_id_stop_exclusive: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_rollout_range(self) -> TrainingAttemptBoundary:
+        if self.first_rollout_id > self.rollout_id_stop_exclusive:
+            raise ValueError("first_rollout_id exceeds rollout_id_stop_exclusive")
+        return self
+
+
+class PhaseTiming(TimingModel):
+    phase: TimingPhase
+    started_at_unix_s: float = Field(ge=0)
+    duration_s: float = Field(ge=0)
+    count: int = Field(gt=0)
+
+    @model_validator(mode="after")
+    def validate_durations(self) -> PhaseTiming:
+        if not all(
+            math.isfinite(value) for value in (self.started_at_unix_s, self.duration_s)
+        ):
+            raise ValueError("timing values must be finite")
+        return self
+
+
+class RoleTiming(TimingModel):
+    role: TimingRole
+    status: TimingCaptureStatus
+    phases: tuple[PhaseTiming, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_capture(self) -> RoleTiming:
+        if self.status is TimingCaptureStatus.CAPTURED and not self.phases:
+            raise ValueError("captured roles require phase timings")
+        if self.status is not TimingCaptureStatus.CAPTURED and self.phases:
+            raise ValueError("uncaptured roles cannot contain phase timings")
+        phases = [timing.phase for timing in self.phases]
+        if len(phases) != len(set(phases)):
+            raise ValueError("role phase timings must be unique")
+        return self
+
+
+class SubstepTiming(TimingModel):
+    schema_version: Literal[1] = SUBSTEP_TIMING_SCHEMA_VERSION
+    event_type: Literal["substep_timing"] = "substep_timing"
+    training_run_id: str = Field(min_length=1)
+    training_attempt: int = Field(gt=0)
+    first_rollout_id: int = Field(ge=0)
+    rollout_id_stop_exclusive: int = Field(ge=0)
+    rollout_id: int = Field(ge=0)
+    started_at_unix_s: float = Field(ge=0)
+    duration_s: float = Field(ge=0)
+    roles: tuple[RoleTiming, ...]
+
+    @model_validator(mode="after")
+    def validate_step(self) -> SubstepTiming:
+        if not math.isfinite(self.started_at_unix_s) or not math.isfinite(
+            self.duration_s
+        ):
+            raise ValueError("step timing values must be finite")
+        if not (
+            self.first_rollout_id <= self.rollout_id < self.rollout_id_stop_exclusive
+        ):
+            raise ValueError("rollout_id is outside the attempt boundary")
+        roles = [capture.role for capture in self.roles]
+        if len(roles) != len(set(roles)):
+            raise ValueError("step role timings must be unique")
+        if TimingRole.DRIVER not in roles or TimingRole.ROLLOUT not in roles:
+            raise ValueError("step timing requires driver and rollout roles")
+        return self
+
+
+class SubstepTimingKey(TimingModel):
+    training_attempt: int = Field(gt=0)
+    rollout_id: int = Field(ge=0)
+
+
+class SubstepTimingQuery(TimingModel):
+    keys: tuple[SubstepTimingKey, ...] = Field(max_length=512)
+
+
+@dataclass(frozen=True)
+class TimingInterval:
+    phase: TimingPhase
+    started_at_unix_s: float
+    started_at_monotonic_s: float
+    ended_at_monotonic_s: float
+
+
+def aggregate_timing_intervals(
+    intervals: list[TimingInterval],
+) -> tuple[PhaseTiming, ...]:
+    intervals_by_phase: dict[TimingPhase, list[TimingInterval]] = {}
+    for interval in intervals:
+        if interval.ended_at_monotonic_s < interval.started_at_monotonic_s:
+            continue
+        intervals_by_phase.setdefault(interval.phase, []).append(interval)
+
+    aggregated: list[PhaseTiming] = []
+    for phase, phase_intervals in intervals_by_phase.items():
+        ordered = sorted(
+            phase_intervals,
+            key=lambda interval: interval.started_at_monotonic_s,
+        )
+        active_s = 0.0
+        range_start = ordered[0].started_at_monotonic_s
+        range_end = ordered[0].ended_at_monotonic_s
+        for interval in ordered[1:]:
+            if interval.started_at_monotonic_s > range_end:
+                active_s += range_end - range_start
+                range_start = interval.started_at_monotonic_s
+                range_end = interval.ended_at_monotonic_s
+            else:
+                range_end = max(range_end, interval.ended_at_monotonic_s)
+        active_s += range_end - range_start
+        aggregated.append(
+            PhaseTiming(
+                phase=phase,
+                started_at_unix_s=min(
+                    interval.started_at_unix_s for interval in ordered
+                ),
+                duration_s=active_s,
+                count=len(ordered),
+            )
+        )
+    return tuple(sorted(aggregated, key=lambda timing: timing.started_at_unix_s))

--- a/modal_training_gym/common/substep_timing.py
+++ b/modal_training_gym/common/substep_timing.py
@@ -55,6 +55,19 @@ class TimingModel(BaseModel):
         return value
 
 
+class PhaseTimingInterval(TimingModel):
+    started_at_unix_s: float = Field(ge=0)
+    duration_s: float = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_interval(self) -> PhaseTimingInterval:
+        if not all(
+            math.isfinite(value) for value in (self.started_at_unix_s, self.duration_s)
+        ):
+            raise ValueError("timing interval values must be finite")
+        return self
+
+
 class TrainingAttemptStarted(TimingModel):
     schema_version: Literal[1] = SUBSTEP_TIMING_SCHEMA_VERSION
     training_run_id: str = Field(min_length=1)
@@ -81,6 +94,7 @@ class PhaseTiming(TimingModel):
     started_at_unix_s: float = Field(ge=0)
     duration_s: float = Field(ge=0)
     count: int = Field(gt=0)
+    intervals: tuple[PhaseTimingInterval, ...] = ()
 
     @model_validator(mode="after")
     def validate_durations(self) -> PhaseTiming:
@@ -170,25 +184,38 @@ def aggregate_timing_intervals(
             phase_intervals,
             key=lambda interval: interval.started_at_monotonic_s,
         )
-        active_s = 0.0
         range_start = ordered[0].started_at_monotonic_s
         range_end = ordered[0].ended_at_monotonic_s
+        range_start_unix_s = ordered[0].started_at_unix_s
+        merged_intervals: list[PhaseTimingInterval] = []
         for interval in ordered[1:]:
             if interval.started_at_monotonic_s > range_end:
-                active_s += range_end - range_start
+                merged_intervals.append(
+                    PhaseTimingInterval(
+                        started_at_unix_s=range_start_unix_s,
+                        duration_s=range_end - range_start,
+                    )
+                )
                 range_start = interval.started_at_monotonic_s
                 range_end = interval.ended_at_monotonic_s
+                range_start_unix_s = interval.started_at_unix_s
             else:
                 range_end = max(range_end, interval.ended_at_monotonic_s)
-        active_s += range_end - range_start
+        merged_intervals.append(
+            PhaseTimingInterval(
+                started_at_unix_s=range_start_unix_s,
+                duration_s=range_end - range_start,
+            )
+        )
         aggregated.append(
             PhaseTiming(
                 phase=phase,
                 started_at_unix_s=min(
-                    interval.started_at_unix_s for interval in ordered
+                    interval.started_at_unix_s for interval in merged_intervals
                 ),
-                duration_s=active_s,
+                duration_s=sum(interval.duration_s for interval in merged_intervals),
                 count=len(ordered),
+                intervals=tuple(merged_intervals),
             )
         )
     return tuple(sorted(aggregated, key=lambda timing: timing.started_at_unix_s))

--- a/modal_training_gym/common/substep_timing.py
+++ b/modal_training_gym/common/substep_timing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -23,6 +23,18 @@ class TimingCaptureStatus(str, Enum):
     CAPTURED = "captured"
     NOT_RUN = "not_run"
     UNAVAILABLE = "unavailable"
+
+
+class TimelineGroup(str, Enum):
+    ROLLOUT = "rollout"
+    TRAINING = "training"
+    SYSTEM = "system"
+
+
+class TimingActivityKind(str, Enum):
+    ACTIVITY = "activity"
+    WAIT = "wait"
+    CONTAINER = "container"
 
 
 class TimingPhase(str, Enum):
@@ -91,6 +103,10 @@ class TrainingAttemptBoundary(TimingModel):
 
 class PhaseTiming(TimingModel):
     phase: TimingPhase
+    timeline_group: TimelineGroup | None = None
+    activity_kind: TimingActivityKind | None = None
+    display_name: str | None = None
+    parent_phase: TimingPhase | None = None
     started_at_unix_s: float = Field(ge=0)
     duration_s: float = Field(ge=0)
     count: int = Field(gt=0)
@@ -109,9 +125,15 @@ class RoleTiming(TimingModel):
     role: TimingRole
     status: TimingCaptureStatus
     phases: tuple[PhaseTiming, ...] = ()
+    execution_sequence: int | None = Field(default=None, gt=0)
+    clock_uncertainty_s: float | None = Field(default=None, ge=0)
 
     @model_validator(mode="after")
     def validate_capture(self) -> RoleTiming:
+        if self.clock_uncertainty_s is not None and not math.isfinite(
+            self.clock_uncertainty_s
+        ):
+            raise ValueError("clock uncertainty must be finite")
         if self.status is TimingCaptureStatus.CAPTURED and not self.phases:
             raise ValueError("captured roles require phase timings")
         if self.status is not TimingCaptureStatus.CAPTURED and self.phases:
@@ -122,6 +144,35 @@ class RoleTiming(TimingModel):
         return self
 
 
+@dataclass(frozen=True)
+class TimingLease:
+    execution_sequence: int
+    clock_offset_s: float
+    clock_uncertainty_s: float
+
+
+class TimingCollectorClient(Protocol):
+    def begin_role(
+        self,
+        rollout_id: int,
+        role: TimingRole,
+    ) -> TimingLease: ...
+
+    def record_role(
+        self,
+        rollout_id: int,
+        lease: TimingLease,
+        timing: RoleTiming,
+    ) -> bool: ...
+
+    def read_step(
+        self,
+        rollout_id: int,
+    ) -> dict[TimingRole, RoleTiming]: ...
+
+    def close_step(self, rollout_id: int) -> None: ...
+
+
 class SubstepTiming(TimingModel):
     schema_version: Literal[1] = SUBSTEP_TIMING_SCHEMA_VERSION
     event_type: Literal["substep_timing"] = "substep_timing"
@@ -130,6 +181,8 @@ class SubstepTiming(TimingModel):
     first_rollout_id: int = Field(ge=0)
     rollout_id_stop_exclusive: int = Field(ge=0)
     rollout_id: int = Field(ge=0)
+    source_rollout_id: int | None = Field(default=None, ge=0)
+    training_rollout_id: int | None = Field(default=None, ge=0)
     started_at_unix_s: float = Field(ge=0)
     duration_s: float = Field(ge=0)
     roles: tuple[RoleTiming, ...]

--- a/modal_training_gym/common/substep_timing_store.py
+++ b/modal_training_gym/common/substep_timing_store.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import io
+import json
+from enum import Enum
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from modal_training_gym.common.substep_timing import (
+    SubstepTiming,
+    SubstepTimingKey,
+    TrainingAttemptBoundary,
+    TrainingAttemptStarted,
+)
+from modal_training_gym.utils.metadata import (
+    MetadataStore,
+    _metadata_volume,
+    _safe_reload,
+    vol_get,
+)
+
+
+StoredModel = TypeVar("StoredModel", bound=BaseModel)
+
+
+class StoreResult(str, Enum):
+    STORED = "stored"
+    DUPLICATE = "duplicate"
+
+
+class StoredValueConflictError(ValueError):
+    pass
+
+
+def _serialized(model: BaseModel) -> bytes:
+    return json.dumps(
+        model.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+def _key_path(store: MetadataStore, key: str) -> str:
+    return f"{store.value}/{key}.json"
+
+
+def _read_model(
+    store: MetadataStore,
+    key: str,
+    model_type: type[StoredModel],
+) -> StoredModel | None:
+    try:
+        value = vol_get(store, key)
+    except KeyError:
+        return None
+    return model_type.model_validate(value)
+
+
+def _store_once(
+    store: MetadataStore,
+    key: str,
+    model: BaseModel,
+) -> StoreResult:
+    data = _serialized(model)
+    volume = _metadata_volume()
+    try:
+        with volume.batch_upload(force=False) as batch:
+            batch.put_file(io.BytesIO(data), _key_path(store, key))
+        return StoreResult.STORED
+    except FileExistsError:
+        _safe_reload(volume)
+        existing = _read_model(store, key, type(model))
+        if existing is not None and _serialized(existing) == data:
+            return StoreResult.DUPLICATE
+        raise StoredValueConflictError(f"Conflicting value for {key}") from None
+
+
+def _attempt_key(
+    training_run_id: str,
+    training_attempt: int,
+    record_name: str,
+) -> str:
+    return f"{training_run_id}/{training_attempt:08d}/{record_name}"
+
+
+def _timing_key(
+    training_run_id: str,
+    training_attempt: int,
+    rollout_id: int,
+) -> str:
+    return f"{training_run_id}/{training_attempt:08d}/{rollout_id:08d}"
+
+
+def store_attempt_started(
+    attempt: TrainingAttemptStarted,
+) -> StoreResult:
+    return _store_once(
+        MetadataStore.TRAINING_ATTEMPTS,
+        _attempt_key(
+            attempt.training_run_id,
+            attempt.training_attempt,
+            "started",
+        ),
+        attempt,
+    )
+
+
+def store_attempt_boundary(
+    boundary: TrainingAttemptBoundary,
+) -> StoreResult:
+    return _store_once(
+        MetadataStore.TRAINING_ATTEMPTS,
+        _attempt_key(
+            boundary.training_run_id,
+            boundary.training_attempt,
+            "boundary",
+        ),
+        boundary,
+    )
+
+
+def list_attempt_boundaries(
+    training_run_id: str,
+) -> list[TrainingAttemptBoundary]:
+    from modal.exception import NotFoundError
+
+    volume = _metadata_volume()
+    _safe_reload(volume)
+    directory = f"{MetadataStore.TRAINING_ATTEMPTS.value}/{training_run_id}"
+    boundaries: list[TrainingAttemptBoundary] = []
+    try:
+        for entry in volume.iterdir(directory):
+            if not entry.path.endswith("/boundary.json"):
+                continue
+            data = b"".join(volume.read_file(entry.path))
+            boundaries.append(TrainingAttemptBoundary.model_validate_json(data))
+    except (FileNotFoundError, NotFoundError):
+        return []
+    return sorted(boundaries, key=lambda boundary: boundary.training_attempt)
+
+
+def latest_recorded_attempt(training_run_id: str) -> int:
+    from modal.exception import NotFoundError
+
+    volume = _metadata_volume()
+    _safe_reload(volume)
+    directory = f"{MetadataStore.TRAINING_ATTEMPTS.value}/{training_run_id}"
+    attempts: list[int] = []
+    try:
+        for entry in volume.iterdir(directory):
+            if not entry.path.endswith("/started.json"):
+                continue
+            data = b"".join(volume.read_file(entry.path))
+            attempts.append(
+                TrainingAttemptStarted.model_validate_json(data).training_attempt
+            )
+    except (FileNotFoundError, NotFoundError):
+        return 0
+    return max(attempts, default=0)
+
+
+def store_substep_timing(
+    timing: SubstepTiming,
+) -> StoreResult:
+    boundary = _read_model(
+        MetadataStore.TRAINING_ATTEMPTS,
+        _attempt_key(
+            timing.training_run_id,
+            timing.training_attempt,
+            "boundary",
+        ),
+        TrainingAttemptBoundary,
+    )
+    event_boundary = TrainingAttemptBoundary(
+        training_run_id=timing.training_run_id,
+        training_attempt=timing.training_attempt,
+        first_rollout_id=timing.first_rollout_id,
+        rollout_id_stop_exclusive=timing.rollout_id_stop_exclusive,
+    )
+    if boundary is None:
+        store_attempt_boundary(event_boundary)
+    elif boundary != event_boundary:
+        raise StoredValueConflictError("Timing event does not match attempt boundary")
+    return _store_once(
+        MetadataStore.SUBSTEP_TIMING,
+        _timing_key(
+            timing.training_run_id,
+            timing.training_attempt,
+            timing.rollout_id,
+        ),
+        timing,
+    )
+
+
+def read_substep_timings(
+    training_run_id: str,
+    keys: tuple[SubstepTimingKey, ...],
+) -> list[SubstepTiming]:
+    timings: list[SubstepTiming] = []
+    for key in keys:
+        timing = _read_model(
+            MetadataStore.SUBSTEP_TIMING,
+            _timing_key(
+                training_run_id,
+                key.training_attempt,
+                key.rollout_id,
+            ),
+            SubstepTiming,
+        )
+        if timing is not None:
+            timings.append(timing)
+    return timings

--- a/modal_training_gym/common/substep_timing_store.py
+++ b/modal_training_gym/common/substep_timing_store.py
@@ -130,7 +130,7 @@ def list_attempt_boundaries(
     directory = f"{MetadataStore.TRAINING_ATTEMPTS.value}/{training_run_id}"
     boundaries: list[TrainingAttemptBoundary] = []
     try:
-        for entry in volume.iterdir(directory):
+        for entry in volume.iterdir(directory, recursive=True):
             if not entry.path.endswith("/boundary.json"):
                 continue
             data = b"".join(volume.read_file(entry.path))
@@ -148,7 +148,7 @@ def latest_recorded_attempt(training_run_id: str) -> int:
     directory = f"{MetadataStore.TRAINING_ATTEMPTS.value}/{training_run_id}"
     attempts: list[int] = []
     try:
-        for entry in volume.iterdir(directory):
+        for entry in volume.iterdir(directory, recursive=True):
             if not entry.path.endswith("/started.json"):
                 continue
             data = b"".join(volume.read_file(entry.path))

--- a/modal_training_gym/common/training_rollout.py
+++ b/modal_training_gym/common/training_rollout.py
@@ -13,13 +13,15 @@ import time
 from collections.abc import Awaitable
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from modal_training_gym.common.coerce import safe_int
 from modal_training_gym.common.sample import Sample
 from modal_training_gym.utils.metadata import (
     MetadataStore,
     vol_get_summary_items,
+    vol_list_tree,
+    vol_put_items,
     vol_put_with_summary,
 )
 
@@ -75,10 +77,32 @@ class TrainingRolloutResult(BaseModel):
 
     training_run_id: str
     rollout_id: int
+    training_attempt: int | None = Field(default=None, gt=0)
+    first_rollout_id: int | None = Field(default=None, ge=0)
+    rollout_id_stop_exclusive: int | None = Field(default=None, ge=0)
     created_at: int = 0
     samples: list[Sample] = Field(default_factory=list)
     metrics: dict[str, Any] = Field(default_factory=dict)
     rollout_time: float | None = None
+
+    @model_validator(mode="after")
+    def validate_attempt_boundary(self) -> TrainingRolloutResult:
+        values = (
+            self.training_attempt,
+            self.first_rollout_id,
+            self.rollout_id_stop_exclusive,
+        )
+        if all(value is None for value in values):
+            return self
+        if any(value is None for value in values):
+            raise ValueError("attempt-scoped rollouts require a complete boundary")
+        assert self.first_rollout_id is not None
+        assert self.rollout_id_stop_exclusive is not None
+        if not (
+            self.first_rollout_id <= self.rollout_id < self.rollout_id_stop_exclusive
+        ):
+            raise ValueError("rollout_id is outside the attempt boundary")
+        return self
 
     @property
     def total(self) -> int:
@@ -92,8 +116,11 @@ class TrainingRolloutResult(BaseModel):
 
     @property
     def storage_key(self) -> str:
-        # One canonical file per (run, rollout). Zero-padded rollout id so
-        # listings return them in step order without needing a sort.
+        if self.training_attempt is not None:
+            return (
+                f"{self.training_run_id}/{self.training_attempt:08d}/"
+                f"{self.rollout_id:08d}"
+            )
         return f"{self.training_run_id}__{self.rollout_id:08d}"
 
     @property
@@ -159,6 +186,12 @@ class TrainingRolloutResult(BaseModel):
             "total": self.total,
             "mean": self.mean,
         }
+        if self.training_attempt is not None:
+            summary["training_attempt"] = self.training_attempt
+        if self.first_rollout_id is not None:
+            summary["first_rollout_id"] = self.first_rollout_id
+        if self.rollout_id_stop_exclusive is not None:
+            summary["rollout_id_stop_exclusive"] = self.rollout_id_stop_exclusive
         if self.rollout_time is not None:
             summary["rollout_time"] = self.rollout_time
         err = self.error_summary
@@ -186,6 +219,22 @@ class TrainingRolloutResult(BaseModel):
 
     def save(self, *, is_async: bool = False) -> None | Awaitable[None]:
         self._touch_created_at()
+        if self.training_attempt is not None:
+            return vol_put_items(
+                [
+                    (
+                        MetadataStore.TRAINING_ROLLOUTS,
+                        self.storage_key,
+                        self.model_dump(mode="json"),
+                    ),
+                    (
+                        MetadataStore.TRAINING_ROLLOUTS_SUMMARY,
+                        self.storage_key,
+                        self._summary_item(),
+                    ),
+                ],
+                is_async=is_async,
+            )
         return vol_put_with_summary(
             MetadataStore.TRAINING_ROLLOUTS,
             self.storage_key,
@@ -200,8 +249,13 @@ class TrainingRolloutResult(BaseModel):
 
     @classmethod
     def list_summaries_for_run(cls, training_run_id: str) -> list[dict[str, Any]]:
-        """Lightweight per-rollout summaries for one run, sorted by rollout_id."""
-        items = vol_get_summary_items(MetadataStore.TRAINING_ROLLOUTS_SUMMARY) or []
+        items = [
+            *(vol_get_summary_items(MetadataStore.TRAINING_ROLLOUTS_SUMMARY) or []),
+            *vol_list_tree(
+                MetadataStore.TRAINING_ROLLOUTS_SUMMARY,
+                training_run_id,
+            ),
+        ]
         return sorted(
             (
                 item
@@ -211,3 +265,47 @@ class TrainingRolloutResult(BaseModel):
             ),
             key=lambda item: int(item.get("rollout_id", 0) or 0),
         )
+
+
+def select_rollout_summaries(
+    summaries: list[dict[str, object]],
+    boundaries: list[tuple[int, int, int]],
+) -> list[dict[str, object]]:
+    if not boundaries:
+        return [
+            summary for summary in summaries if summary.get("training_attempt") is None
+        ]
+
+    selected: dict[int, dict[str, object]] = {}
+    for summary in summaries:
+        rollout_id = _summary_int(summary.get("rollout_id"))
+        if rollout_id is None:
+            continue
+        attempt_value = summary.get("training_attempt")
+        training_attempt = _summary_int(attempt_value)
+        if attempt_value is not None and training_attempt is None:
+            continue
+        controlling_attempt = max(
+            (
+                attempt
+                for attempt, first_rollout_id, rollout_id_stop_exclusive in boundaries
+                if first_rollout_id <= rollout_id < rollout_id_stop_exclusive
+            ),
+            default=None,
+        )
+        if (
+            training_attempt == controlling_attempt
+            or training_attempt is None
+            and controlling_attempt is None
+        ):
+            selected[rollout_id] = summary
+    return [selected[rollout_id] for rollout_id in sorted(selected)]
+
+
+def _summary_int(value: object) -> int | None:
+    if not isinstance(value, (int, float, str)):
+        return None
+    try:
+        return int(value)
+    except (OverflowError, ValueError):
+        return None

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -65,6 +65,11 @@ from modal_training_gym.common.launcher_helpers import (
 from modal_training_gym.common.wandb import WandbConfig
 from modal_training_gym.common.status import SlimeStatus
 from modal_training_gym.common.step_timing import Substep
+from modal_training_gym.common.substep_timing import TrainingAttemptStarted
+from modal_training_gym.common.substep_timing_store import (
+    latest_recorded_attempt,
+    store_attempt_started,
+)
 
 from modal_training_gym.train_recipes.slime_recipe.recipe import (
     CHECKPOINTS_PATH,
@@ -79,6 +84,7 @@ from .modal_helpers.utils import (
     prepare_slime_config,
     resolve_checkpoint_ref,
 )
+from .substep_timing import supports_substep_timing
 from modal_training_gym.common.patches import encode_patch
 from modal_training_gym.common.checkpoint import Checkpoint
 from modal_training_gym.common.framework import Framework
@@ -127,6 +133,7 @@ _PATCH_QWEN3_VL_TORCH_DIST_B64 = encode_patch(
 _PATCH_ROLLOUT_STATUS_B64 = encode_patch(
     "patch_rollout_status_reporting", _SLIME_PATCHES
 )
+_PATCH_SUBSTEP_TIMING_B64 = encode_patch("patch_substep_timing", _SLIME_PATCHES)
 _PATCH_ADVANTAGE_DIST_B64 = encode_patch("patch_advantage_distribution", _SLIME_PATCHES)
 _PATCH_LOG_ELIDE_B64 = encode_patch("patch_log_elide", _SLIME_PATCHES)
 # Backport of NVIDIA/Megatron-LM #3845: dequantize quantized CUDA tensors in the
@@ -158,6 +165,7 @@ def _build_slime_base_image() -> "Image":
             f"echo {_PATCH_QWEN3_VL_EXPORT_B64} | base64 -d | python3",
             f"echo {_PATCH_QWEN3_VL_TORCH_DIST_B64} | base64 -d | python3",
             f"echo {_PATCH_ROLLOUT_STATUS_B64} | base64 -d | python3",
+            f"echo {_PATCH_SUBSTEP_TIMING_B64} | base64 -d | python3",
             f"echo {_PATCH_ADVANTAGE_DIST_B64} | base64 -d | python3",
             f"echo {_PATCH_LOG_ELIDE_B64} | base64 -d | python3",
             f"echo {_PATCH_DIST_CKPT_QUANTIZED_B64} | base64 -d | python3",
@@ -1078,6 +1086,18 @@ def build_slime_app(
             "lr": slime.lr,
             "global_batch_size": slime.global_batch_size,
         }
+        substep_timing_enabled = await asyncio.to_thread(
+            supports_substep_timing, framework_status_url
+        )
+        previous_attempt = 0
+        if substep_timing_enabled:
+            try:
+                previous_attempt = await asyncio.to_thread(
+                    latest_recorded_attempt, training_run_id
+                )
+            except Exception:
+                substep_timing_enabled = False
+
         (
             run_record,
             wandb_run_id,
@@ -1092,7 +1112,21 @@ def build_slime_app(
             wandb_cfg=slime.wandb,
             wandb_entity=wandb_entity,
             framework_status_token=framework_status_token,
+            minimum_previous_attempt=previous_attempt,
         )
+        training_attempt = int((run_record.metadata or {}).get("attempt_count") or 1)
+        if substep_timing_enabled:
+            try:
+                await asyncio.to_thread(
+                    store_attempt_started,
+                    TrainingAttemptStarted(
+                        training_run_id=training_run_id,
+                        training_attempt=training_attempt,
+                        started_at_unix_s=time.time(),
+                    ),
+                )
+            except Exception:
+                substep_timing_enabled = False
 
         try:  # Wraps all post-setup work so any failure marks the run terminal.
             # In-flight status updates are fire-and-forget via the dashboard's
@@ -1232,6 +1266,12 @@ def build_slime_app(
                     "TRAINING_GYM_TRAINING_RUN_ID": training_run_id,
                     "TRAINING_GYM_APP_NAME": app_name,
                     "TRAINING_GYM_TOTAL_STEPS": str(slime.num_rollout),
+                    "TRAINING_GYM_SUBSTEP_TIMING": (
+                        "1" if substep_timing_enabled else ""
+                    ),
+                    "TRAINING_GYM_TRAINING_ATTEMPT": (
+                        str(training_attempt) if substep_timing_enabled else ""
+                    ),
                     "TRAINING_GYM_RESPONSE_PARSER_PATH": _response_parser_path(model),
                     "TRAINING_GYM_CAPTURE_TRACE": (
                         "1" if getattr(slime, "capture_trace", False) else ""
@@ -1304,7 +1344,7 @@ def build_slime_app(
             )
 
             step_times_read = False
-            if not slime.async_mode:
+            if not slime.async_mode and not substep_timing_enabled:
                 try:
                     (
                         latest_run_record.step_times,

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_substep_timing.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_substep_timing.py
@@ -1,0 +1,288 @@
+from pathlib import Path
+
+
+ROOT = Path("/root/slime")
+IMPORT = (
+    "from modal_training_gym.frameworks.slime.substep_timing import "
+    "begin_phase as _tg_begin_timing, "
+    "create_driver_timing as _tg_create_timing, "
+    "finish_phase as _tg_finish_timing, "
+    "finish_role_timing as _tg_finish_role_timing, "
+    "start_role_timing as _tg_start_role_timing, "
+    "timed_await as _tg_timed_await\n"
+)
+
+
+def replace_once(source: str, old: str, new: str, path: Path) -> str:
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError(f"{path}: expected one occurrence, found {count}")
+    return source.replace(old, new, 1)
+
+
+def patch_entrypoint(path: Path, asynchronous: bool) -> None:
+    source = path.read_text()
+    if "_tg_create_timing" in source:
+        return
+    source = replace_once(source, "import ray\n", f"import ray\n\n{IMPORT}", path)
+    source = replace_once(
+        source,
+        "    init_tracking(args)\n",
+        "    init_tracking(args)\n    _tg_timing = _tg_create_timing(args)\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "    actor_model, critic_model = create_training_models(args, pgs, rollout_manager)\n",
+        "    actor_model, critic_model = create_training_models(args, pgs, rollout_manager)\n"
+        "    _tg_timing.configure(args.start_rollout_id, args.num_rollout)\n"
+        "    _tg_timing.configure_rollout_manager(rollout_manager)\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "    for rollout_id in range(args.start_rollout_id, args.num_rollout):\n",
+        "    for rollout_id in range(args.start_rollout_id, args.num_rollout):\n"
+        "        _tg_timing.start_step()\n",
+        path,
+    )
+    step_boundary = (
+        "        _tg_report('weight_sync', args, rollout_id, 'substep_finish')\n"
+    )
+    publish = (
+        step_boundary
+        + "\n"
+        + "        _tg_timing.publish_step(\n"
+        + "            rollout_id,\n"
+        + "            actor_ran=not args.debug_rollout_only and "
+        "((not args.use_critic) or rollout_id >= args.num_critic_only_steps),\n"
+        + "            critic_ran=not args.debug_rollout_only and args.use_critic,\n"
+        + "            rollout_ran=not args.debug_train_only,\n"
+        + "        )\n"
+    )
+    source = replace_once(source, step_boundary, publish, path)
+    if asynchronous:
+        source = replace_once(
+            source,
+            "            rollout_data_curr_ref = ray.get(rollout_data_next_future)\n",
+            '            _tg_wait_timing = _tg_begin_timing("wait_for_rollout")\n'
+            "            rollout_data_curr_ref = ray.get(rollout_data_next_future)\n"
+            "            _tg_finish_timing(_tg_wait_timing)\n",
+            path,
+        )
+        source = replace_once(
+            source,
+            "        if args.use_critic:\n"
+            "            actor_trains_this_step = "
+            "rollout_id >= args.num_critic_only_steps\n",
+            '        _tg_training_timing = _tg_begin_timing("train_models")\n'
+            "        if args.use_critic:\n"
+            "            actor_trains_this_step = "
+            "rollout_id >= args.num_critic_only_steps\n",
+            path,
+        )
+        source = replace_once(
+            source,
+            "        # PATCHED_TRAINING_GYM_STEP_FINISH: training step finish\n",
+            "        _tg_finish_timing(_tg_training_timing)\n\n"
+            "        # PATCHED_TRAINING_GYM_STEP_FINISH: training step finish\n",
+            path,
+        )
+        source = replace_once(
+            source,
+            "        if should_run_periodic_action(rollout_id, args.save_interval, "
+            "num_rollout_per_epoch, args.num_rollout):\n",
+            "        _tg_checkpoint_timing = None\n"
+            "        if should_run_periodic_action(rollout_id, args.save_interval, "
+            "num_rollout_per_epoch, args.num_rollout):\n"
+            '            _tg_checkpoint_timing = _tg_begin_timing("checkpoint_save")\n'
+            "            _tg_report('checkpoint_save', args, rollout_id)\n",
+            path,
+        )
+        source = replace_once(
+            source,
+            "        if (rollout_id + 1) % args.update_weights_interval == 0:\n",
+            "        _tg_finish_timing(_tg_checkpoint_timing)\n"
+            "        _tg_report('weight_sync', args, rollout_id)\n\n"
+            "        if (rollout_id + 1) % args.update_weights_interval == 0:\n",
+            path,
+        )
+        source = replace_once(
+            source,
+            "            # sync generate before update weights to prevent update "
+            "weight in the middle of generation\n"
+            "            rollout_data_curr_ref = ray.get(x) if "
+            "(x := rollout_data_next_future) is not None else None\n",
+            "            # sync generate before update weights to prevent update "
+            "weight in the middle of generation\n"
+            '            _tg_timing.transition("wait_for_next_rollout")\n'
+            "            rollout_data_curr_ref = ray.get(x) if "
+            "(x := rollout_data_next_future) is not None else None\n"
+            '            _tg_timing.transition("weight_sync")\n',
+            path,
+        )
+    path.write_text(source)
+
+
+def patch_actor(path: Path) -> None:
+    source = path.read_text()
+    if "_tg_start_role_timing" in source:
+        return
+    source = replace_once(source, "import torch\n", f"import torch\n\n{IMPORT}", path)
+    source = replace_once(
+        source,
+        "    def train(self, rollout_id: int, rollout_data_ref: Box, "
+        "external_data=None):\n"
+        "        if self.args.debug_rollout_only:\n"
+        "            return None\n\n"
+        "        if self.args.offload_train:\n"
+        "            self.wake_up()\n",
+        "    def train(self, rollout_id: int, rollout_data_ref: Box, "
+        "external_data=None):\n"
+        "        if self.args.debug_rollout_only:\n"
+        "            return None\n\n"
+        "        _tg_role_timing = (\n"
+        "            _tg_start_role_timing(self.args, rollout_id, self.role)\n"
+        "            if is_megatron_main_rank()\n"
+        "            else None\n"
+        "        )\n\n"
+        "        if self.args.offload_train:\n"
+        "            self.wake_up()\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "        return result\n\n    def train_critic",
+        "        _tg_finish_role_timing(self.args, rollout_id, _tg_role_timing)\n"
+        "        return result\n\n"
+        "    def train_critic",
+        path,
+    )
+    path.write_text(source)
+
+
+def patch_model(path: Path) -> None:
+    source = path.read_text()
+    if "_tg_forward_backward_timing" in source:
+        return
+    source = replace_once(source, "import torch\n", f"import torch\n\n{IMPORT}", path)
+    source = replace_once(
+        source,
+        "    losses_reduced = forward_backward_func(\n",
+        '    _tg_forward_backward_timing = _tg_begin_timing("forward_backward")\n'
+        "    losses_reduced = forward_backward_func(\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "        forward_only=False,\n    )\n\n    valid_step = True",
+        "        forward_only=False,\n"
+        "    )\n"
+        "    _tg_finish_timing(_tg_forward_backward_timing)\n\n"
+        "    valid_step = True",
+        path,
+    )
+    source = replace_once(
+        source,
+        "        update_successful, grad_norm, num_zeros_in_grad = optimizer.step()\n",
+        '        _tg_optimizer_timing = _tg_begin_timing("optimizer_step")\n'
+        "        update_successful, grad_norm, num_zeros_in_grad = optimizer.step()\n"
+        "        _tg_finish_timing(_tg_optimizer_timing)\n",
+        path,
+    )
+    path.write_text(source)
+
+
+def patch_rollout(path: Path) -> None:
+    source = path.read_text()
+    if "_tg_rollout_timing" in source:
+        return
+    source = replace_once(source, "import torch\n", f"import torch\n\n{IMPORT}", path)
+    source = replace_once(
+        source,
+        "    def generate(self, rollout_id):\n",
+        "    def configure_training_gym_timing(\n"
+        "        self, first_rollout_id, rollout_id_stop_exclusive\n"
+        "    ):\n"
+        "        self.args.first_rollout_id = first_rollout_id\n"
+        "        self.args.rollout_id_stop_exclusive = rollout_id_stop_exclusive\n"
+        "        self.args.training_gym_timing_boundary_ready = True\n\n"
+        "    def generate(self, rollout_id):\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "    def generate(self, rollout_id):\n        start_time = time.time()\n",
+        "    def generate(self, rollout_id):\n"
+        "        _tg_rollout_timing = _tg_start_role_timing("
+        'self.args, rollout_id, "rollout")\n'
+        "        start_time = time.time()\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "        data, metrics = self._get_rollout_data(rollout_id=rollout_id)\n",
+        '        _tg_generate_timing = _tg_begin_timing("generate_rollouts")\n'
+        "        data, metrics = self._get_rollout_data(rollout_id=rollout_id)\n"
+        "        _tg_finish_timing(_tg_generate_timing)\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "            return\n        data = self._convert_samples_to_train_data(data)\n",
+        "            _tg_finish_role_timing("
+        "self.args, rollout_id, _tg_rollout_timing)\n"
+        "            return\n"
+        "        data = self._convert_samples_to_train_data(data)\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "        return self._split_train_data_by_dp(data)\n",
+        "        result = self._split_train_data_by_dp(data)\n"
+        "        _tg_finish_role_timing(self.args, rollout_id, _tg_rollout_timing)\n"
+        "        return result\n",
+        path,
+    )
+    source = replace_once(
+        source,
+        "            return self.custom_reward_post_process_func(self.args, samples)\n",
+        "            _tg_reward_post_process_timing = _tg_begin_timing("
+        '"custom_reward_post_process")\n'
+        "            result = self.custom_reward_post_process_func(self.args, samples)\n"
+        "            _tg_finish_timing(_tg_reward_post_process_timing)\n"
+        "            return result\n",
+        path,
+    )
+    path.write_text(source)
+
+
+def patch_reward(path: Path) -> None:
+    source = path.read_text()
+    if "_tg_timed_await" in source:
+        return
+    source = replace_once(source, "import random\n", f"import random\n\n{IMPORT}", path)
+    source = source.replace(
+        "return await rm_function(args, sample, **kwargs)",
+        "return await _tg_timed_await("
+        '"custom_reward", rm_function(args, sample, **kwargs))',
+    )
+    source = source.replace(
+        "return await rm_function(args, samples, **kwargs)",
+        "return await _tg_timed_await("
+        '"custom_reward", rm_function(args, samples, **kwargs))',
+    )
+    path.write_text(source)
+
+
+def main() -> None:
+    patch_entrypoint(ROOT / "train.py", asynchronous=False)
+    patch_entrypoint(ROOT / "train_async.py", asynchronous=True)
+    patch_actor(ROOT / "slime/backends/megatron_utils/actor.py")
+    patch_model(ROOT / "slime/backends/megatron_utils/model.py")
+    patch_rollout(ROOT / "slime/ray/rollout.py")
+    patch_reward(ROOT / "slime/rollout/rm_hub/__init__.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/modal_training_gym/frameworks/slime/phase_reporting.py
+++ b/modal_training_gym/frameworks/slime/phase_reporting.py
@@ -15,6 +15,7 @@ This module keeps the reporting entry points (``report_*``, ``log_*``,
 
 from __future__ import annotations
 
+import os
 import time
 from typing import Any
 
@@ -53,6 +54,7 @@ from .sample_extraction import (
     _trace_sample_limit,
     _trajectory_sample_limit,
 )
+from .substep_timing import transition_driver_phase
 from .sample_extraction import (
     CAPTURE_TRACE_ENV as CAPTURE_TRACE_ENV,
     IMAGE_SAMPLE_LIMIT_ENV as IMAGE_SAMPLE_LIMIT_ENV,
@@ -282,6 +284,10 @@ def report_step_event(
     ``status`` may be a plain string — the patched slime train.py passes phase
     names as literals so the injected code stays stdlib-only.
     """
+    transition_driver_phase(
+        status.value if isinstance(status, SlimeStatus) else str(status),
+        step_event,
+    )
     payload = {
         **_run_context(args),
         "phase": status.value if isinstance(status, SlimeStatus) else str(status),
@@ -291,6 +297,10 @@ def report_step_event(
     }
     if step_event:
         payload["step_event"] = step_event
+    if os.environ.get("TRAINING_GYM_SUBSTEP_TIMING") == "1":
+        if step_event in {"start", "substep_finish"}:
+            _post_framework_status(payload, _STEP_EVENT_TIMEOUT_SECONDS)
+        return
     match step_event:
         case "start":
             _post_framework_status(payload, _STEP_EVENT_TIMEOUT_SECONDS)

--- a/modal_training_gym/frameworks/slime/reporting.py
+++ b/modal_training_gym/frameworks/slime/reporting.py
@@ -16,6 +16,8 @@ from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
+from modal_training_gym.common.substep_timing import SUBSTEP_TIMING_PROTOCOL
+
 PHASE_REPORT_URL_ENV = "SLIME_PHASE_REPORT_URL"
 PHASE_REPORT_TOKEN_ENV = "SLIME_PHASE_REPORT_TOKEN"
 
@@ -49,7 +51,7 @@ def _arg_value(args: Any, key: str) -> Any:
 
 
 def _run_context(args: Any) -> dict[str, Any]:
-    return {
+    context = {
         "training_run_id": _arg_value(args, "training_run_id")
         or _arg_value(args, "training_gym_training_run_id")
         or os.environ.get("TRAINING_GYM_TRAINING_RUN_ID", "")
@@ -60,6 +62,23 @@ def _run_context(args: Any) -> dict[str, Any]:
         or "",
         "modal_app_id": os.environ.get("MODAL_APP_ID", ""),
     }
+    if os.environ.get("TRAINING_GYM_SUBSTEP_TIMING") == "1":
+        context.update(
+            {
+                "training_attempt": os.environ.get("TRAINING_GYM_TRAINING_ATTEMPT"),
+                "timing_protocol": SUBSTEP_TIMING_PROTOCOL,
+            }
+        )
+        if _arg_value(args, "training_gym_timing_boundary_ready"):
+            context.update(
+                {
+                    "first_rollout_id": _arg_value(args, "first_rollout_id"),
+                    "rollout_id_stop_exclusive": _arg_value(
+                        args, "rollout_id_stop_exclusive"
+                    ),
+                }
+            )
+    return context
 
 
 def _positive_int(value: Any) -> int | None:

--- a/modal_training_gym/frameworks/slime/substep_timing.py
+++ b/modal_training_gym/frameworks/slime/substep_timing.py
@@ -15,10 +15,14 @@ from modal_training_gym.common.substep_timing import (
     SUBSTEP_TIMING_PROTOCOL,
     RoleTiming,
     SubstepTiming,
+    TimingActivityKind,
     TimingCaptureStatus,
+    TimingCollectorClient,
     TimingInterval,
+    TimingLease,
     TimingPhase,
     TimingRole,
+    TimelineGroup,
     aggregate_timing_intervals,
 )
 
@@ -29,6 +33,105 @@ _CURRENT_RECORDER: contextvars.ContextVar[RoleTimingRecorder | None] = (
     contextvars.ContextVar("training_gym_role_timing", default=None)
 )
 
+_PHASE_PRESENTATION = {
+    TimingPhase.FULL_STEP: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.CONTAINER,
+        "Full step",
+        None,
+    ),
+    TimingPhase.WAIT_FOR_ROLLOUT: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.WAIT,
+        "Wait for rollout",
+        None,
+    ),
+    TimingPhase.OFFLOAD_ROLLOUT: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.ACTIVITY,
+        "Offload rollout",
+        None,
+    ),
+    TimingPhase.TRAIN_MODELS: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.CONTAINER,
+        "Train models",
+        None,
+    ),
+    TimingPhase.CHECKPOINT_SAVE: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.ACTIVITY,
+        "Checkpoint save",
+        None,
+    ),
+    TimingPhase.TRAINING_CLEANUP: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.ACTIVITY,
+        "Training cleanup",
+        None,
+    ),
+    TimingPhase.WAIT_FOR_NEXT_ROLLOUT: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.WAIT,
+        "Wait for next rollout",
+        None,
+    ),
+    TimingPhase.WEIGHT_SYNC: (
+        TimelineGroup.SYSTEM,
+        TimingActivityKind.ACTIVITY,
+        "Weight sync",
+        None,
+    ),
+    TimingPhase.EVALUATE_ROLLOUTS_BEFORE: (
+        TimelineGroup.ROLLOUT,
+        TimingActivityKind.ACTIVITY,
+        "Eval (before)",
+        None,
+    ),
+    TimingPhase.EVALUATE_ROLLOUTS_AFTER: (
+        TimelineGroup.ROLLOUT,
+        TimingActivityKind.ACTIVITY,
+        "Eval (after)",
+        None,
+    ),
+    TimingPhase.GENERATE_ROLLOUTS: (
+        TimelineGroup.ROLLOUT,
+        TimingActivityKind.ACTIVITY,
+        "Generate rollouts",
+        None,
+    ),
+    TimingPhase.CUSTOM_REWARD: (
+        TimelineGroup.ROLLOUT,
+        TimingActivityKind.ACTIVITY,
+        "Custom reward",
+        TimingPhase.GENERATE_ROLLOUTS,
+    ),
+    TimingPhase.CUSTOM_REWARD_POST_PROCESS: (
+        TimelineGroup.ROLLOUT,
+        TimingActivityKind.ACTIVITY,
+        "Reward post-process",
+        TimingPhase.GENERATE_ROLLOUTS,
+    ),
+    TimingPhase.TRAIN_MODEL: (
+        TimelineGroup.TRAINING,
+        TimingActivityKind.ACTIVITY,
+        "Train model",
+        None,
+    ),
+    TimingPhase.FORWARD_BACKWARD: (
+        TimelineGroup.TRAINING,
+        TimingActivityKind.ACTIVITY,
+        "Forward/backward",
+        TimingPhase.TRAIN_MODEL,
+    ),
+    TimingPhase.OPTIMIZER_STEP: (
+        TimelineGroup.TRAINING,
+        TimingActivityKind.ACTIVITY,
+        "Optimizer step",
+        TimingPhase.TRAIN_MODEL,
+    ),
+}
+
 
 def _ray():
     return importlib.import_module("ray")
@@ -37,13 +140,16 @@ def _ray():
 @dataclass
 class RoleTimingRecorder:
     role: TimingRole
+    execution_sequence: int | None = None
+    clock_offset_s: float = 0.0
+    clock_uncertainty_s: float | None = None
     intervals: list[TimingInterval] = field(default_factory=list)
     full_step: AbstractContextManager[None] | None = None
     primary_phase: AbstractContextManager[None] | None = None
 
     @contextmanager
     def phase(self, phase: TimingPhase):
-        started_at_unix_s = time.time()
+        started_at_unix_s = time.time() + self.clock_offset_s
         started_at_monotonic_s = time.monotonic()
         try:
             yield
@@ -58,7 +164,19 @@ class RoleTimingRecorder:
             )
 
     def result(self) -> RoleTiming:
-        phases = aggregate_timing_intervals(self.intervals)
+        phases = []
+        for phase in aggregate_timing_intervals(self.intervals):
+            group, kind, display_name, parent_phase = _PHASE_PRESENTATION[phase.phase]
+            phases.append(
+                phase.model_copy(
+                    update={
+                        "timeline_group": group,
+                        "activity_kind": kind,
+                        "display_name": display_name,
+                        "parent_phase": parent_phase,
+                    }
+                )
+            )
         return RoleTiming(
             role=self.role,
             status=(
@@ -66,30 +184,57 @@ class RoleTimingRecorder:
                 if phases
                 else TimingCaptureStatus.UNAVAILABLE
             ),
-            phases=phases,
+            phases=tuple(phases),
+            execution_sequence=self.execution_sequence,
+            clock_uncertainty_s=self.clock_uncertainty_s,
         )
 
 
 class StepTimingCollector:
     def __init__(self) -> None:
-        self._role_timings: dict[tuple[int, str], str] = {}
+        self._execution_sequences: dict[tuple[int, str], int] = {}
+        self._role_timings: dict[tuple[int, str], tuple[int, str]] = {}
         self._closed_rollouts: set[int] = set()
 
-    def record_role_timing(self, rollout_id: int, timing_json: str) -> bool:
+    def begin_role_timing(self, rollout_id: int, role: str) -> tuple[int, float]:
+        if rollout_id in self._closed_rollouts:
+            raise RuntimeError("rollout timing is already closed")
+        key = (rollout_id, TimingRole(role).value)
+        sequence = self._execution_sequences.get(key, 0) + 1
+        self._execution_sequences[key] = sequence
+        return sequence, time.time()
+
+    def synchronize_clock(self) -> float:
+        return time.time()
+
+    def record_role_timing(
+        self,
+        rollout_id: int,
+        execution_sequence: int,
+        timing_json: str,
+    ) -> bool:
         timing = RoleTiming.model_validate_json(timing_json)
         key = (rollout_id, timing.role.value)
         if rollout_id in self._closed_rollouts:
             return False
+        if (
+            timing.execution_sequence != execution_sequence
+            or execution_sequence != self._execution_sequences.get(key)
+        ):
+            return False
         existing = self._role_timings.get(key)
-        if existing == timing_json:
+        if existing == (execution_sequence, timing_json):
             return True
-        self._role_timings[key] = timing_json
+        self._role_timings[key] = (execution_sequence, timing_json)
         return True
 
     def read_step_timings(self, rollout_id: int) -> dict[str, str]:
         return {
-            role: timing
-            for (stored_rollout_id, role), timing in self._role_timings.items()
+            role: timing_json
+            for (stored_rollout_id, role), (
+                _,
+                timing_json,
+            ) in self._role_timings.items()
             if stored_rollout_id == rollout_id
         }
 
@@ -98,6 +243,11 @@ class StepTimingCollector:
         self._role_timings = {
             key: timing
             for key, timing in self._role_timings.items()
+            if key[0] != rollout_id
+        }
+        self._execution_sequences = {
+            key: sequence
+            for key, sequence in self._execution_sequences.items()
             if key[0] != rollout_id
         }
 
@@ -115,22 +265,127 @@ def _role(value: object) -> TimingRole:
     return TimingRole(str(normalized).lower())
 
 
+def _clock_calibration(
+    local_time_s: float,
+    started_at_monotonic_s: float,
+    collector_time_s: float,
+) -> tuple[float, float]:
+    round_trip_s = time.monotonic() - started_at_monotonic_s
+    return collector_time_s - (local_time_s + round_trip_s / 2), round_trip_s / 2
+
+
+@dataclass(frozen=True)
+class RayTimingCollectorClient:
+    actor: object
+
+    def begin_role(
+        self,
+        rollout_id: int,
+        role: TimingRole,
+    ) -> TimingLease:
+        ray = _ray()
+        local_time_s = time.time()
+        started_at_monotonic_s = time.monotonic()
+        execution_sequence, collector_time_s = ray.get(
+            getattr(self.actor, "begin_role_timing").remote(
+                rollout_id,
+                role.value,
+            )
+        )
+        clock_offset_s, clock_uncertainty_s = _clock_calibration(
+            local_time_s,
+            started_at_monotonic_s,
+            collector_time_s,
+        )
+        return TimingLease(
+            execution_sequence=execution_sequence,
+            clock_offset_s=clock_offset_s,
+            clock_uncertainty_s=clock_uncertainty_s,
+        )
+
+    def record_role(
+        self,
+        rollout_id: int,
+        lease: TimingLease,
+        timing: RoleTiming,
+    ) -> bool:
+        return bool(
+            _ray().get(
+                getattr(self.actor, "record_role_timing").remote(
+                    rollout_id,
+                    lease.execution_sequence,
+                    timing.model_dump_json(),
+                )
+            )
+        )
+
+    def read_step(
+        self,
+        rollout_id: int,
+    ) -> dict[TimingRole, RoleTiming]:
+        recorded = _ray().get(
+            getattr(self.actor, "read_step_timings").remote(rollout_id)
+        )
+        return {
+            TimingRole(role): RoleTiming.model_validate_json(timing_json)
+            for role, timing_json in recorded.items()
+        }
+
+    def close_step(self, rollout_id: int) -> None:
+        _ray().get(getattr(self.actor, "close_step").remote(rollout_id))
+
+    def synchronize_clock(self) -> tuple[float, float]:
+        ray = _ray()
+        synchronize_clock = getattr(self.actor, "synchronize_clock")
+        calibrations = []
+        for _ in range(5):
+            local_time_s = time.time()
+            started_at_monotonic_s = time.monotonic()
+            collector_time_s = ray.get(synchronize_clock.remote())
+            calibrations.append(
+                _clock_calibration(
+                    local_time_s,
+                    started_at_monotonic_s,
+                    collector_time_s,
+                )
+            )
+        return min(calibrations, key=lambda calibration: calibration[1])
+
+
 def start_role_timing(
     args: object,
     rollout_id: int,
     role: object,
-) -> tuple[RoleTimingRecorder, contextvars.Token[RoleTimingRecorder | None]] | None:
+) -> (
+    tuple[
+        RoleTimingRecorder,
+        contextvars.Token[RoleTimingRecorder | None],
+        TimingLease,
+    ]
+    | None
+):
     if not _enabled(args):
         return None
     try:
-        recorder = RoleTimingRecorder(_role(role))
+        timing_role = _role(role)
+        collector: TimingCollectorClient = getattr(
+            args,
+            "training_gym_timing_collector",
+        )
+        lease = collector.begin_role(rollout_id, timing_role)
+        recorder = RoleTimingRecorder(
+            timing_role,
+            execution_sequence=lease.execution_sequence,
+            clock_offset_s=lease.clock_offset_s,
+            clock_uncertainty_s=lease.clock_uncertainty_s,
+        )
         token = _CURRENT_RECORDER.set(recorder)
         recorder.full_step = recorder.phase(TimingPhase.FULL_STEP)
         recorder.full_step.__enter__()
         if recorder.role in {TimingRole.ACTOR, TimingRole.CRITIC}:
             recorder.primary_phase = recorder.phase(TimingPhase.TRAIN_MODEL)
             recorder.primary_phase.__enter__()
-        return recorder, token
+        return recorder, token, lease
     except Exception:
         return None
 
@@ -138,29 +393,26 @@ def start_role_timing(
 def finish_role_timing(
     args: object,
     rollout_id: int,
-    state: tuple[RoleTimingRecorder, contextvars.Token[RoleTimingRecorder | None]]
+    state: tuple[
+        RoleTimingRecorder,
+        contextvars.Token[RoleTimingRecorder | None],
+        TimingLease,
+    ]
     | None,
 ) -> None:
     if state is None:
         return
-    recorder, token = state
+    recorder, token, lease = state
     if recorder.primary_phase is not None:
         recorder.primary_phase.__exit__(None, None, None)
     if recorder.full_step is not None:
         recorder.full_step.__exit__(None, None, None)
     _CURRENT_RECORDER.reset(token)
     collector = getattr(args, "training_gym_timing_collector", None)
-    if collector is None:
+    if collector is None or recorder.execution_sequence is None:
         return
     try:
-        ray = _ray()
-        record_role_timing = getattr(collector, "record_role_timing")
-        ray.get(
-            record_role_timing.remote(
-                rollout_id,
-                recorder.result().model_dump_json(),
-            )
-        )
+        collector.record_role(rollout_id, lease, recorder.result())
     except Exception:
         return
 
@@ -182,7 +434,9 @@ def finish_phase(timing: AbstractContextManager[None] | None) -> None:
 @dataclass
 class DriverTimingSession:
     args: object
-    collector: object | None = None
+    collector: TimingCollectorClient | None = None
+    clock_offset_s: float = 0.0
+    clock_uncertainty_s: float | None = None
     first_rollout_id: int = 0
     rollout_id_stop_exclusive: int = 0
     recorder: RoleTimingRecorder | None = None
@@ -220,7 +474,11 @@ class DriverTimingSession:
         if self.collector is None:
             return
         try:
-            self.recorder = RoleTimingRecorder(TimingRole.DRIVER)
+            self.recorder = RoleTimingRecorder(
+                TimingRole.DRIVER,
+                clock_offset_s=self.clock_offset_s,
+                clock_uncertainty_s=self.clock_uncertainty_s,
+            )
             self.recorder_token = _CURRENT_RECORDER.set(self.recorder)
             self.full_step = self.recorder.phase(TimingPhase.FULL_STEP)
             self.full_step.__enter__()
@@ -272,9 +530,7 @@ class DriverTimingSession:
             _CURRENT_RECORDER.reset(self.recorder_token)
         roles = {TimingRole.DRIVER: self.recorder.result()}
         try:
-            ray = _ray()
-            read_step_timings = getattr(self.collector, "read_step_timings")
-            recorded = ray.get(read_step_timings.remote(rollout_id))
+            recorded = self.collector.read_step(rollout_id)
         except Exception:
             recorded = {}
         for role in (TimingRole.ROLLOUT, TimingRole.ACTOR, TimingRole.CRITIC):
@@ -288,36 +544,33 @@ class DriverTimingSession:
                     role=role,
                     status=TimingCaptureStatus.NOT_RUN,
                 )
-            elif role.value in recorded:
-                roles[role] = RoleTiming.model_validate_json(recorded[role.value])
+            elif role in recorded:
+                roles[role] = recorded[role]
             else:
                 roles[role] = RoleTiming(
                     role=role,
                     status=TimingCaptureStatus.UNAVAILABLE,
                 )
+        driver_step = next(
+            phase
+            for phase in roles[TimingRole.DRIVER].phases
+            if phase.phase is TimingPhase.FULL_STEP
+        )
         timing = SubstepTiming(
             training_run_id=os.environ.get("TRAINING_GYM_TRAINING_RUN_ID", ""),
             training_attempt=int(os.environ[_TRAINING_ATTEMPT_ENV]),
             first_rollout_id=self.first_rollout_id,
             rollout_id_stop_exclusive=self.rollout_id_stop_exclusive,
             rollout_id=rollout_id,
-            started_at_unix_s=min(
-                phase.started_at_unix_s
-                for role_timing in roles.values()
-                for phase in role_timing.phases
-            ),
-            duration_s=next(
-                phase.duration_s
-                for phase in roles[TimingRole.DRIVER].phases
-                if phase.phase is TimingPhase.FULL_STEP
-            ),
+            source_rollout_id=rollout_id,
+            training_rollout_id=rollout_id,
+            started_at_unix_s=driver_step.started_at_unix_s,
+            duration_s=driver_step.duration_s,
             roles=tuple(roles.values()),
         )
         if _post_timing(timing):
             try:
-                ray = _ray()
-                close_step = getattr(self.collector, "close_step")
-                ray.get(close_step.remote(rollout_id))
+                self.collector.close_step(rollout_id)
             except Exception:
                 pass
         self.recorder = None
@@ -331,8 +584,12 @@ def create_driver_timing(args: object) -> DriverTimingSession:
         return session
     try:
         ray = _ray()
-        collector_type = ray.remote(num_cpus=0, max_restarts=1)(StepTimingCollector)
-        session.collector = collector_type.remote()
+        collector_type = ray.remote(num_cpus=0, max_restarts=0)(StepTimingCollector)
+        session.collector = RayTimingCollectorClient(collector_type.remote())
+        (
+            session.clock_offset_s,
+            session.clock_uncertainty_s,
+        ) = session.collector.synchronize_clock()
         setattr(args, "training_gym_timing_collector", session.collector)
     except Exception:
         session.collector = None

--- a/modal_training_gym/frameworks/slime/substep_timing.py
+++ b/modal_training_gym/frameworks/slime/substep_timing.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import contextvars
+import importlib
+import json
+import os
+import time
+from collections.abc import Awaitable
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from modal_training_gym.common.substep_timing import (
+    SUBSTEP_TIMING_PROTOCOL,
+    RoleTiming,
+    SubstepTiming,
+    TimingCaptureStatus,
+    TimingInterval,
+    TimingPhase,
+    TimingRole,
+    aggregate_timing_intervals,
+)
+
+
+_TIMING_ENABLED_ENV = "TRAINING_GYM_SUBSTEP_TIMING"
+_TRAINING_ATTEMPT_ENV = "TRAINING_GYM_TRAINING_ATTEMPT"
+_CURRENT_RECORDER: contextvars.ContextVar[RoleTimingRecorder | None] = (
+    contextvars.ContextVar("training_gym_role_timing", default=None)
+)
+
+
+def _ray():
+    return importlib.import_module("ray")
+
+
+@dataclass
+class RoleTimingRecorder:
+    role: TimingRole
+    intervals: list[TimingInterval] = field(default_factory=list)
+    full_step: AbstractContextManager[None] | None = None
+    primary_phase: AbstractContextManager[None] | None = None
+
+    @contextmanager
+    def phase(self, phase: TimingPhase):
+        started_at_unix_s = time.time()
+        started_at_monotonic_s = time.monotonic()
+        try:
+            yield
+        finally:
+            self.intervals.append(
+                TimingInterval(
+                    phase=phase,
+                    started_at_unix_s=started_at_unix_s,
+                    started_at_monotonic_s=started_at_monotonic_s,
+                    ended_at_monotonic_s=time.monotonic(),
+                )
+            )
+
+    def result(self) -> RoleTiming:
+        phases = aggregate_timing_intervals(self.intervals)
+        return RoleTiming(
+            role=self.role,
+            status=(
+                TimingCaptureStatus.CAPTURED
+                if phases
+                else TimingCaptureStatus.UNAVAILABLE
+            ),
+            phases=phases,
+        )
+
+
+class StepTimingCollector:
+    def __init__(self) -> None:
+        self._role_timings: dict[tuple[int, str], str] = {}
+        self._closed_rollouts: set[int] = set()
+
+    def record_role_timing(self, rollout_id: int, timing_json: str) -> bool:
+        timing = RoleTiming.model_validate_json(timing_json)
+        key = (rollout_id, timing.role.value)
+        if rollout_id in self._closed_rollouts:
+            return False
+        existing = self._role_timings.get(key)
+        if existing == timing_json:
+            return True
+        self._role_timings[key] = timing_json
+        return True
+
+    def read_step_timings(self, rollout_id: int) -> dict[str, str]:
+        return {
+            role: timing
+            for (stored_rollout_id, role), timing in self._role_timings.items()
+            if stored_rollout_id == rollout_id
+        }
+
+    def close_step(self, rollout_id: int) -> None:
+        self._closed_rollouts.add(rollout_id)
+        self._role_timings = {
+            key: timing
+            for key, timing in self._role_timings.items()
+            if key[0] != rollout_id
+        }
+
+
+def _enabled(args: object | None = None) -> bool:
+    if os.environ.get(_TIMING_ENABLED_ENV) != "1":
+        return False
+    return (
+        args is None or getattr(args, "training_gym_timing_collector", None) is not None
+    )
+
+
+def _role(value: object) -> TimingRole:
+    normalized = getattr(value, "value", value)
+    return TimingRole(str(normalized).lower())
+
+
+def start_role_timing(
+    args: object,
+    rollout_id: int,
+    role: object,
+) -> tuple[RoleTimingRecorder, contextvars.Token[RoleTimingRecorder | None]] | None:
+    if not _enabled(args):
+        return None
+    try:
+        recorder = RoleTimingRecorder(_role(role))
+        token = _CURRENT_RECORDER.set(recorder)
+        recorder.full_step = recorder.phase(TimingPhase.FULL_STEP)
+        recorder.full_step.__enter__()
+        if recorder.role in {TimingRole.ACTOR, TimingRole.CRITIC}:
+            recorder.primary_phase = recorder.phase(TimingPhase.TRAIN_MODEL)
+            recorder.primary_phase.__enter__()
+        return recorder, token
+    except Exception:
+        return None
+
+
+def finish_role_timing(
+    args: object,
+    rollout_id: int,
+    state: tuple[RoleTimingRecorder, contextvars.Token[RoleTimingRecorder | None]]
+    | None,
+) -> None:
+    if state is None:
+        return
+    recorder, token = state
+    if recorder.primary_phase is not None:
+        recorder.primary_phase.__exit__(None, None, None)
+    if recorder.full_step is not None:
+        recorder.full_step.__exit__(None, None, None)
+    _CURRENT_RECORDER.reset(token)
+    collector = getattr(args, "training_gym_timing_collector", None)
+    if collector is None:
+        return
+    try:
+        ray = _ray()
+        record_role_timing = getattr(collector, "record_role_timing")
+        ray.get(
+            record_role_timing.remote(
+                rollout_id,
+                recorder.result().model_dump_json(),
+            )
+        )
+    except Exception:
+        return
+
+
+def begin_phase(phase: str):
+    recorder = _CURRENT_RECORDER.get()
+    if recorder is None:
+        return None
+    timing = recorder.phase(TimingPhase(phase))
+    timing.__enter__()
+    return timing
+
+
+def finish_phase(timing: AbstractContextManager[None] | None) -> None:
+    if timing is not None:
+        timing.__exit__(None, None, None)
+
+
+@dataclass
+class DriverTimingSession:
+    args: object
+    collector: object | None = None
+    first_rollout_id: int = 0
+    rollout_id_stop_exclusive: int = 0
+    recorder: RoleTimingRecorder | None = None
+    recorder_token: contextvars.Token[RoleTimingRecorder | None] | None = None
+    full_step: AbstractContextManager[None] | None = None
+    active_phase: AbstractContextManager[None] | None = None
+
+    def configure(self, first_rollout_id: int, rollout_id_stop_exclusive: int) -> None:
+        self.first_rollout_id = first_rollout_id
+        self.rollout_id_stop_exclusive = rollout_id_stop_exclusive
+        setattr(self.args, "first_rollout_id", first_rollout_id)
+        setattr(
+            self.args,
+            "rollout_id_stop_exclusive",
+            rollout_id_stop_exclusive,
+        )
+        setattr(self.args, "training_gym_timing_boundary_ready", True)
+
+    def configure_rollout_manager(self, rollout_manager: object) -> None:
+        if self.collector is None:
+            return
+        try:
+            ray = _ray()
+            configure_timing = getattr(rollout_manager, "configure_training_gym_timing")
+            ray.get(
+                configure_timing.remote(
+                    self.first_rollout_id,
+                    self.rollout_id_stop_exclusive,
+                )
+            )
+        except Exception:
+            self.collector = None
+
+    def start_step(self) -> None:
+        if self.collector is None:
+            return
+        try:
+            self.recorder = RoleTimingRecorder(TimingRole.DRIVER)
+            self.recorder_token = _CURRENT_RECORDER.set(self.recorder)
+            self.full_step = self.recorder.phase(TimingPhase.FULL_STEP)
+            self.full_step.__enter__()
+        except Exception:
+            self.recorder = None
+
+    def transition(self, phase: str) -> None:
+        if self.active_phase is not None:
+            finish_phase(self.active_phase)
+        try:
+            self.active_phase = begin_phase(phase)
+        except ValueError:
+            self.active_phase = None
+
+    def finish_active_phase(self) -> None:
+        finish_phase(self.active_phase)
+        self.active_phase = None
+
+    def publish_step(
+        self,
+        rollout_id: int,
+        actor_ran: bool,
+        critic_ran: bool,
+        rollout_ran: bool = True,
+    ) -> None:
+        try:
+            self._publish_step(
+                rollout_id,
+                actor_ran,
+                critic_ran,
+                rollout_ran,
+            )
+        except Exception:
+            self.recorder = None
+
+    def _publish_step(
+        self,
+        rollout_id: int,
+        actor_ran: bool,
+        critic_ran: bool,
+        rollout_ran: bool,
+    ) -> None:
+        if self.collector is None or self.recorder is None:
+            return
+        self.finish_active_phase()
+        if self.full_step is not None:
+            self.full_step.__exit__(None, None, None)
+        if self.recorder_token is not None:
+            _CURRENT_RECORDER.reset(self.recorder_token)
+        roles = {TimingRole.DRIVER: self.recorder.result()}
+        try:
+            ray = _ray()
+            read_step_timings = getattr(self.collector, "read_step_timings")
+            recorded = ray.get(read_step_timings.remote(rollout_id))
+        except Exception:
+            recorded = {}
+        for role in (TimingRole.ROLLOUT, TimingRole.ACTOR, TimingRole.CRITIC):
+            ran = {
+                TimingRole.ROLLOUT: rollout_ran,
+                TimingRole.ACTOR: actor_ran,
+                TimingRole.CRITIC: critic_ran,
+            }[role]
+            if not ran:
+                roles[role] = RoleTiming(
+                    role=role,
+                    status=TimingCaptureStatus.NOT_RUN,
+                )
+            elif role.value in recorded:
+                roles[role] = RoleTiming.model_validate_json(recorded[role.value])
+            else:
+                roles[role] = RoleTiming(
+                    role=role,
+                    status=TimingCaptureStatus.UNAVAILABLE,
+                )
+        timing = SubstepTiming(
+            training_run_id=os.environ.get("TRAINING_GYM_TRAINING_RUN_ID", ""),
+            training_attempt=int(os.environ[_TRAINING_ATTEMPT_ENV]),
+            first_rollout_id=self.first_rollout_id,
+            rollout_id_stop_exclusive=self.rollout_id_stop_exclusive,
+            rollout_id=rollout_id,
+            started_at_unix_s=min(
+                phase.started_at_unix_s
+                for role_timing in roles.values()
+                for phase in role_timing.phases
+            ),
+            duration_s=next(
+                phase.duration_s
+                for phase in roles[TimingRole.DRIVER].phases
+                if phase.phase is TimingPhase.FULL_STEP
+            ),
+            roles=tuple(roles.values()),
+        )
+        if _post_timing(timing):
+            try:
+                ray = _ray()
+                close_step = getattr(self.collector, "close_step")
+                ray.get(close_step.remote(rollout_id))
+            except Exception:
+                pass
+        self.recorder = None
+
+
+def create_driver_timing(args: object) -> DriverTimingSession:
+    global _DRIVER_SESSION
+    session = DriverTimingSession(args)
+    _DRIVER_SESSION = session
+    if not _enabled():
+        return session
+    try:
+        ray = _ray()
+        collector_type = ray.remote(num_cpus=0, max_restarts=1)(StepTimingCollector)
+        session.collector = collector_type.remote()
+        setattr(args, "training_gym_timing_collector", session.collector)
+    except Exception:
+        session.collector = None
+    return session
+
+
+_DRIVER_SESSION: DriverTimingSession | None = None
+
+
+def transition_driver_phase(phase: str, step_event: str = "") -> None:
+    if _DRIVER_SESSION is None:
+        return
+    mapped = {
+        "generate_rollouts": TimingPhase.WAIT_FOR_ROLLOUT,
+        "compute_log_probs": TimingPhase.TRAIN_MODELS,
+        "optimizer_step": TimingPhase.TRAIN_MODELS,
+        "checkpoint_save": TimingPhase.CHECKPOINT_SAVE,
+        "offload_rollout": TimingPhase.OFFLOAD_ROLLOUT,
+        "offload_train": TimingPhase.TRAINING_CLEANUP,
+        "weight_sync": TimingPhase.WEIGHT_SYNC,
+        "evaluate_rollouts": (
+            TimingPhase.EVALUATE_ROLLOUTS_BEFORE
+            if step_event == "eval_begin"
+            else TimingPhase.EVALUATE_ROLLOUTS_AFTER
+        ),
+    }.get(phase)
+    if mapped is not None:
+        try:
+            _DRIVER_SESSION.transition(mapped.value)
+        except Exception:
+            return
+
+
+async def timed_await(phase: str, awaitable: Awaitable[object]) -> object:
+    timing = begin_phase(phase)
+    try:
+        return await awaitable
+    finally:
+        finish_phase(timing)
+
+
+def _timing_url() -> str:
+    status_url = os.environ.get("TRAINING_GYM_FRAMEWORK_STATUS_URL", "").strip()
+    if status_url.endswith("/api/framework-status"):
+        return status_url.removesuffix("/api/framework-status") + "/api/timing-events"
+    return ""
+
+
+def _post_timing(timing: SubstepTiming) -> bool:
+    url = _timing_url()
+    if not url:
+        return False
+    request = Request(
+        url,
+        data=timing.model_dump_json().encode(),
+        headers={
+            "Authorization": (
+                "Bearer " + os.environ.get("TRAINING_GYM_FRAMEWORK_STATUS_TOKEN", "")
+            ),
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    for timeout_s in (2.0, 5.0, 10.0):
+        try:
+            with urlopen(request, timeout=timeout_s) as response:
+                payload = json.loads(response.read())
+            return payload.get("status") in {"stored", "duplicate", "stale"}
+        except (HTTPError, OSError, URLError, ValueError):
+            continue
+    return False
+
+
+def supports_substep_timing(status_url: str) -> bool:
+    if not status_url.endswith("/api/framework-status"):
+        return False
+    url = status_url.removesuffix("/api/framework-status") + "/api/timing-events"
+    try:
+        with urlopen(url, timeout=2.0) as response:
+            payload = json.loads(response.read())
+    except (HTTPError, OSError, URLError, ValueError):
+        return False
+    return payload.get("protocol") == SUBSTEP_TIMING_PROTOCOL

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import json
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from enum import Enum
 from functools import partial
 from typing import Any
@@ -21,6 +21,8 @@ class MetadataStore(Enum):
     TRAIN_RESULTS_SUMMARY = "train-results-summary"
     TRAINING_ROLLOUTS = "training-rollouts"
     TRAINING_ROLLOUTS_SUMMARY = "training-rollouts-summary"
+    TRAINING_ATTEMPTS = "training-attempts"
+    SUBSTEP_TIMING = "substep-timing"
     # Per-step, per-group advantage distributions. slime only logs the mean
     # advantage per step; this store keeps the full per-sample distribution so
     # the dashboard can render per-group spread. Written one shard file per
@@ -170,6 +172,22 @@ def vol_remove(store: MetadataStore | str, key: str) -> bool:
         raise
 
 
+def vol_remove_tree(store: MetadataStore | str, key: str) -> bool:
+    from modal.exception import InvalidError, NotFoundError
+
+    vol = _metadata_volume()
+    path = f"{_store_path(store)}/{key}"
+    try:
+        vol.remove_file(path, recursive=True)
+        return True
+    except (FileNotFoundError, NotFoundError):
+        return False
+    except InvalidError as exc:
+        if "No such file or directory" in str(exc):
+            return False
+        raise
+
+
 def vol_put(
     store: MetadataStore | str,
     key: str,
@@ -193,6 +211,33 @@ def vol_put(
         return _run()
     with vol.batch_upload(force=True) as batch:
         batch.put_file(io.BytesIO(data), path)
+
+
+def vol_put_items(
+    items: list[tuple[MetadataStore | str, str, Mapping[str, object]]],
+    *,
+    is_async: bool = False,
+) -> None | Awaitable[None]:
+    vol = _metadata_volume()
+    uploads = [
+        (
+            json.dumps(value).encode(),
+            f"{_store_path(store)}/{key}.json",
+        )
+        for store, key, value in items
+    ]
+    if is_async:
+
+        async def _run() -> None:
+            async with vol.batch_upload(force=True) as batch:
+                for data, path in uploads:
+                    batch.put_file(io.BytesIO(data), path)
+
+        return _run()
+    with vol.batch_upload(force=True) as batch:
+        for data, path in uploads:
+            batch.put_file(io.BytesIO(data), path)
+    return None
 
 
 def vol_get(
@@ -289,6 +334,27 @@ def vol_list_prefix(store: MetadataStore | str, prefix: str) -> list[dict[str, A
             if not name.startswith(prefix):
                 continue
             results.append(json.loads(b"".join(vol.read_file(entry.path))))
+    except (FileNotFoundError, NotFoundError):
+        return results
+    return results
+
+
+def vol_list_tree(
+    store: MetadataStore | str,
+    key: str,
+) -> list[dict[str, object]]:
+    from modal.exception import NotFoundError
+
+    vol = _metadata_volume()
+    _safe_reload(vol)
+    results: list[dict[str, object]] = []
+    try:
+        for entry in vol.iterdir(f"{_store_path(store)}/{key}"):
+            if not entry.path.endswith(".json"):
+                continue
+            value = json.loads(b"".join(vol.read_file(entry.path)))
+            if isinstance(value, dict):
+                results.append(value)
     except (FileNotFoundError, NotFoundError):
         return results
     return results
@@ -528,11 +594,14 @@ __all__ = [
     "vol_get",
     "vol_list",
     "vol_list_prefix",
+    "vol_list_tree",
     "vol_count_items",
     "compact_summary_store",
     "vol_get_summary_items_healed",
     "vol_put",
+    "vol_put_items",
     "vol_remove",
+    "vol_remove_tree",
     "vol_get_summary_items",
     "vol_put_summary_items",
     "vol_put_with_summary",

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -349,7 +349,7 @@ def vol_list_tree(
     _safe_reload(vol)
     results: list[dict[str, object]] = []
     try:
-        for entry in vol.iterdir(f"{_store_path(store)}/{key}"):
+        for entry in vol.iterdir(f"{_store_path(store)}/{key}", recursive=True):
             if not entry.path.endswith(".json"):
                 continue
             value = json.loads(b"".join(vol.read_file(entry.path)))

--- a/tests/test_live_substep_timing.py
+++ b/tests/test_live_substep_timing.py
@@ -1,0 +1,66 @@
+from modal_training_gym.common.substep_timing import (
+    RoleTiming,
+    TimingCaptureStatus,
+    TimingInterval,
+    TimingPhase,
+    TimingRole,
+    aggregate_timing_intervals,
+)
+from modal_training_gym.common.training_rollout import select_rollout_summaries
+from modal_training_gym.frameworks.slime.substep_timing import StepTimingCollector
+
+
+def test_aggregate_timing_intervals_tracks_active_time() -> None:
+    intervals = [
+        TimingInterval(TimingPhase.CUSTOM_REWARD, 10.0, 1.0, 4.0),
+        TimingInterval(TimingPhase.CUSTOM_REWARD, 11.0, 2.0, 5.0),
+        TimingInterval(TimingPhase.CUSTOM_REWARD, 15.0, 8.0, 9.0),
+    ]
+
+    timing = aggregate_timing_intervals(intervals)[0]
+
+    assert timing.duration_s == 5.0
+    assert timing.count == 3
+
+
+def test_collector_replaces_a_retried_role_before_step_closes() -> None:
+    collector = StepTimingCollector()
+    first = RoleTiming(
+        role=TimingRole.ACTOR,
+        status=TimingCaptureStatus.UNAVAILABLE,
+    )
+    retried = RoleTiming(
+        role=TimingRole.ACTOR,
+        status=TimingCaptureStatus.NOT_RUN,
+    )
+
+    assert collector.record_role_timing(4, first.model_dump_json())
+    assert collector.record_role_timing(4, retried.model_dump_json())
+    assert (
+        collector.read_step_timings(4)[TimingRole.ACTOR.value]
+        == retried.model_dump_json()
+    )
+
+    collector.close_step(4)
+
+    assert not collector.record_role_timing(4, first.model_dump_json())
+    assert collector.read_step_timings(4) == {}
+
+
+def test_rollout_selection_uses_retry_boundaries_and_legacy_prefix() -> None:
+    summaries = [
+        {"rollout_id": 0},
+        {"rollout_id": 1},
+        {"rollout_id": 2, "training_attempt": 1},
+        {"rollout_id": 2, "training_attempt": 2},
+        {"rollout_id": 3, "training_attempt": 2},
+    ]
+
+    selected = select_rollout_summaries(summaries, [(2, 2, 4)])
+
+    assert [(row["rollout_id"], row.get("training_attempt")) for row in selected] == [
+        (0, None),
+        (1, None),
+        (2, 2),
+        (3, 2),
+    ]

--- a/tests/test_live_substep_timing.py
+++ b/tests/test_live_substep_timing.py
@@ -21,6 +21,10 @@ def test_aggregate_timing_intervals_tracks_active_time() -> None:
 
     assert timing.duration_s == 5.0
     assert timing.count == 3
+    assert [
+        (interval.started_at_unix_s, interval.duration_s)
+        for interval in timing.intervals
+    ] == [(10.0, 4.0), (15.0, 1.0)]
 
 
 def test_collector_replaces_a_retried_role_before_step_closes() -> None:

--- a/tests/test_live_substep_timing.py
+++ b/tests/test_live_substep_timing.py
@@ -1,5 +1,7 @@
 from modal_training_gym.common.substep_timing import (
     RoleTiming,
+    TimelineGroup,
+    TimingActivityKind,
     TimingCaptureStatus,
     TimingInterval,
     TimingPhase,
@@ -7,7 +9,10 @@ from modal_training_gym.common.substep_timing import (
     aggregate_timing_intervals,
 )
 from modal_training_gym.common.training_rollout import select_rollout_summaries
-from modal_training_gym.frameworks.slime.substep_timing import StepTimingCollector
+from modal_training_gym.frameworks.slime.substep_timing import (
+    RoleTimingRecorder,
+    StepTimingCollector,
+)
 
 
 def test_aggregate_timing_intervals_tracks_active_time() -> None:
@@ -27,19 +32,38 @@ def test_aggregate_timing_intervals_tracks_active_time() -> None:
     ] == [(10.0, 4.0), (15.0, 1.0)]
 
 
-def test_collector_replaces_a_retried_role_before_step_closes() -> None:
+def test_role_timing_includes_framework_activity_presentation() -> None:
+    recorder = RoleTimingRecorder(TimingRole.ACTOR)
+    with recorder.phase(TimingPhase.TRAIN_MODEL):
+        pass
+    with recorder.phase(TimingPhase.FORWARD_BACKWARD):
+        pass
+
+    phases = {phase.phase: phase for phase in recorder.result().phases}
+
+    assert phases[TimingPhase.TRAIN_MODEL].timeline_group is TimelineGroup.TRAINING
+    assert phases[TimingPhase.TRAIN_MODEL].activity_kind is TimingActivityKind.ACTIVITY
+    assert phases[TimingPhase.TRAIN_MODEL].display_name == "Train model"
+    assert phases[TimingPhase.FORWARD_BACKWARD].parent_phase is TimingPhase.TRAIN_MODEL
+
+
+def test_collector_rejects_a_late_execution_after_retry_starts() -> None:
     collector = StepTimingCollector()
+    first_sequence, _ = collector.begin_role_timing(4, TimingRole.ACTOR.value)
     first = RoleTiming(
         role=TimingRole.ACTOR,
         status=TimingCaptureStatus.UNAVAILABLE,
+        execution_sequence=first_sequence,
     )
+    assert collector.record_role_timing(4, first_sequence, first.model_dump_json())
+    retry_sequence, _ = collector.begin_role_timing(4, TimingRole.ACTOR.value)
     retried = RoleTiming(
         role=TimingRole.ACTOR,
         status=TimingCaptureStatus.NOT_RUN,
+        execution_sequence=retry_sequence,
     )
-
-    assert collector.record_role_timing(4, first.model_dump_json())
-    assert collector.record_role_timing(4, retried.model_dump_json())
+    assert collector.record_role_timing(4, retry_sequence, retried.model_dump_json())
+    assert not collector.record_role_timing(4, first_sequence, first.model_dump_json())
     assert (
         collector.read_step_timings(4)[TimingRole.ACTOR.value]
         == retried.model_dump_json()
@@ -47,7 +71,9 @@ def test_collector_replaces_a_retried_role_before_step_closes() -> None:
 
     collector.close_step(4)
 
-    assert not collector.record_role_timing(4, first.model_dump_json())
+    assert not collector.record_role_timing(
+        4, retry_sequence, retried.model_dump_json()
+    )
     assert collector.read_step_timings(4) == {}
 
 


### PR DESCRIPTION
## Summary

Persist and display substep timings after each completed rollout step instead of reconciling an entire run at terminal completion.

This adds a negotiated `substep_timing` protocol. A new package probes `/api/timing-events` before launch; when the dashboard supports the protocol, sync and async Slime runs use the new path. If the endpoint is unavailable, the launcher keeps the released legacy reporting and terminal aggregation behavior, so new packages continue to work with already-deployed dashboards. New dashboards continue to accept legacy reporters and display existing runs.

## Collection flow

- The driver creates a zero-CPU Ray timing collector and passes its handle through the existing Slime arguments.
- Rollout, actor, and critic workers buffer local intervals and acknowledge one completed role batch to the collector immediately before their existing successful return.
- Actor and critic return values are unchanged, including the critic-to-actor `external_data` dependency path.
- The collector keeps the latest role batch until the driver closes the step, so a successful Ray retry replaces timing from a worker that recorded and then died.
- At the bottom of the existing sync or async iteration, after training, checkpointing, offload, weight sync, and evaluation have completed, the driver combines its intervals with the available role batches and sends one authenticated `/api/timing-events` request.
- Timing failures are fail-open. They do not fail or change training, and an incomplete training iteration is never published as a completed timing step.

The recorded phases include driver lifecycle work, rollout generation, custom reward execution and post-processing, actor/critic train model, forward/backward, optimizer step, checkpointing, evaluation, and weight sync. Missing participating roles are represented as unavailable; roles that intentionally did not run are represented as not run.

## Persistence and retry semantics

Completed timings are immutable files keyed by `(training_run_id, training_attempt, rollout_id)`. Identical retries are accepted and conflicting duplicate values are rejected. Each timing write is O(1) in the number of completed steps.

Attempt boundaries use Slime's actual `start_rollout_id` and `num_rollout` loop bounds. Rollout details, rollout summaries, and substep timings carry the same attempt and boundary fields and are selected together:

- A full retry covers the complete rollout range, so rows from the previous attempt remain stored but are no longer selected by the dashboard.
- A checkpoint resume covers only the resumed suffix, so the dashboard selects the previous attempt's prefix and the current attempt's suffix for both rollout data and timings.
- Runs created before this protocol can contribute a legacy prefix when resumed under the new implementation.
- Stale writes from an older attempt are ignored after a newer attempt becomes current.

Attempt-scoped rollout details and summaries are uploaded in one volume batch. The dashboard reads only the requested timing keys and the current run's rollout subtree; it does not reread or rewrite the full history after each step.

## Dashboard

- The summary timeline gains completed steps during a running job.
- Expanded rollout rows use the timing record from the exact same attempt as the displayed rollout.
- The client requests only missing `(attempt, rollout)` timing keys and tracks in-flight keys so normal rollout polling cannot cancel and restart a slow timing query.
- Retried rows replace the currently displayed attempt while previous attempts remain durable.
- Existing direct and one-indexed legacy timing keys remain supported.
- Timeline labels include the role in parentheses.
- Actor, critic, rollout, and driver phases have distinct colors.
- Custom reward execution and reward post-processing are shown separately.

## Compatibility

| Package | Dashboard | Behavior |
| --- | --- | --- |
| Released | Released | Unchanged |
| New | Released | Capability probe fails and released legacy behavior is used |
| Released | New | Legacy status, rollout, and timing data remain accepted and displayed |
| New | New | Per-step sync and async timing protocol is used |

This change is based only on `main`. PR #258 can rebase afterward and drop its overlapping timing transport/persistence code while retaining any additional async-specific visualization work.

## Validation

### Live training

- [10-step synchronous Qwen3-0.6B run](https://modal-labs-melody-dev--training-gym-dashboard-fastapi-app.modal.run/training/internal-amberjack-ca98725a3e72): completed successfully with 10 rollout summaries and 10 attempt-scoped timing records. Records appeared before terminal completion, actor/rollout/driver timings were captured for every step, and checkpoint timing was captured at steps 5 and 10.
- [10-step asynchronous Qwen3-0.6B run](https://modal-labs-melody-dev--training-gym-dashboard-fastapi-app.modal.run/training/trite-grill-d3a348019c3b): completed successfully on two non-colocated 8×H100 nodes with 10 rollout summaries and 10 joined actor/rollout/driver timing records under the same rollout IDs and attempt boundary.
- Rendered both completed runs in the deployed melody-dev dashboard with Playwright. The Summary and expanded Rollouts views show the timing data, role-qualified labels, phase colors, and checkpoint/async phases. Repeated rollout polling does not refetch already-loaded timing keys.

### Static checks

- `uv run ruff check modal_training_gym tests/test_live_substep_timing.py`
- `uv run ruff format --check modal_training_gym tests/test_live_substep_timing.py`
- `uv run python -m compileall -q modal_training_gym`
- `uv run pytest -q tests/test_live_substep_timing.py tests/test_rollout_tag_stats.py tests/test_metadata_persistence.py tests/test_step_times.py tests/test_substep_times.py tests/test_run_summary.py` — 57 passed, 1 skipped
- `npm run build`
- Applied the released rollout-status patch followed by the new timing patch to pinned Slime commit `a4b8c9c8e2f4efa753b22edbdda56d066c3e8070`; patched sync and async sources compile
- `git diff --check`
- Audited added lines and new files for added comments and `typing.Any`; neither is present

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->