### PR TITLE
serve apple-touch-icon.png as FileResponse

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -1159,6 +1159,12 @@ def fastapi_app():
     async def favicon():
         return FileResponse(f"{STATIC_DIR}/favicon.svg", media_type="image/svg+xml")
 
+    @web.get("/apple-touch-icon.png", include_in_schema=False)
+    async def apple_touch_icon():
+        return FileResponse(
+            f"{STATIC_DIR}/apple-touch-icon.png", media_type="image/png"
+        )
+
     # ── SPA fallback ─────────────────────────────────────────────────────
 
     @web.get("/{full_path:path}")

--- a/tests/test_dashboard_runs_route.py
+++ b/tests/test_dashboard_runs_route.py
@@ -15,6 +15,9 @@ def _client(monkeypatch, tmp_path) -> TestClient:
     (static / "assets").mkdir(parents=True)
     (static / "index.html").write_text("ok")
     (static / "favicon.svg").write_text("<svg/>")
+    (static / "apple-touch-icon.png").write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    )
     monkeypatch.setattr(_dashboard, "STATIC_DIR", str(static))
     monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
     return TestClient(_dashboard.fastapi_app.local())
@@ -82,6 +85,15 @@ def test_runs_route_keeps_runs_when_train_result_store_fails(
     assert response.status_code == 200
     assert len(response.json()) == 1
     assert response.json()[0]["has_train_result"] is False
+
+
+def test_apple_touch_icon_is_served_as_png(monkeypatch, tmp_path):
+    with _client(monkeypatch, tmp_path) as client:
+        response = client.get("/apple-touch-icon.png")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/png")
+    assert response.content.startswith(b"\x89PNG")
 
 
 def test_runs_route_isolates_invalid_run_records(fake_volume, monkeypatch, tmp_path):


### PR DESCRIPTION
Follow up to #291.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->