### PR TITLE
Fix HuggingFaceDataset docstring to match prompt-only chat output

### DIFF
--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -144,9 +144,12 @@ class HuggingFaceDataset(DatasetConfig):
     """Dataset backed by a HuggingFace ``datasets`` repo.
 
     Subclass and set ``hf_repo`` plus column mappings. When
-    ``input_column`` and ``output_column`` are set, ``prepare()``
-    auto-wraps rows into chat-message format
-    (``{"messages": [{"role": "user", ...}, {"role": "assistant", ...}]}``).
+    ``input_column`` and ``output_column`` are set, ``prepare()`` wraps
+    each row into a prompt-only chat message list plus a separate label
+    field: ``{"messages": [{"role": "user", ...}], <label_key>: ...}``.
+    A leading ``{"role": "system", ...}`` message is included when
+    ``system_prompt`` is set. No assistant turn is emitted — the target
+    from ``output_column`` is stored under ``label_key``.
     """
 
     _type: DatasetType = DatasetType.HUGGING_FACE


### PR DESCRIPTION
Docs-only follow-up to a review comment on #277.

`_to_chat` no longer appends an assistant turn; it emits prompt-only messages plus the target under `label_key`:

```python
{"messages": [{"role": "system", ...}?, {"role": "user", ...}], label_key: str(row[out_col])}
```

The `HuggingFaceDataset` class docstring still described the old `user`+`assistant` wrapping. Updated it to describe the actual format.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/7f668a8df9e145b4acf61272f50f570e
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->