### PR TITLE
dashboard: opt-in Modal proxy auth; authenticate ingestion before run lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ Modal prints a URL where you can watch jobs in progress.
 
 ![Gym Observability Dashboard](./assets/observability_dashboard_1.png)
 
+### Locking the dashboard down (optional)
+
+The dashboard deploys open. Two opt-in layers, usable together:
+
+- **`training-gym set-password`** puts HTTP Basic in front of the UI and read
+  APIs. Browser-friendly; ingestion POSTs keep using their per-run tokens.
+- **`TRAINING_GYM_DASHBOARD_REQUIRES_PROXY_AUTH=1`** in the shell running
+  `training-gym setup` (or `modal deploy dashboards/app.py`) turns on
+  [Modal proxy auth](https://modal.com/docs/guide/webhook-proxy-auth), so
+  Modal's edge drops anonymous requests before they reach the app — what
+  `DeploymentConfig(unauthenticated=False)` already does for serving
+  endpoints. Callers need a workspace `wk-`/`ws-` pair: the CLI and the status
+  reporters send it whenever `MODAL_KEY`/`MODAL_SECRET` are set (persist them
+  with `training-gym setup`; launchers forward them into training containers),
+  and browsers cannot send it at all, which is what the password is for. Read
+  at deploy time, so changing it means redeploying. The choice is sticky —
+  saved to `~/.training-gym.toml`, so a redeploy without the variable keeps
+  it; deploying open again takes an explicit `=0`. Because the pair is a
+  workspace-wide credential, clients only send it to `https` Modal-served
+  hostnames (`*.modal.run`, `*.modal.direct`); name a custom `https` domain in
+  `TRAINING_GYM_PROXY_AUTH_HOSTS` (comma-separated) to allow it.
+
 
 ## Tutorials
 

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -128,6 +128,53 @@ PASSWORD_EXEMPT_PATHS = frozenset(
     }
 )
 
+# Opt-in Modal edge auth: with this set, Modal rejects any request without a
+# workspace proxy-auth pair before app code runs. The reporters and the CLI
+# send it from MODAL_KEY/MODAL_SECRET (see common/proxy_auth.py); launchers
+# forward it into train containers via proxy_auth_secrets().
+REQUIRES_PROXY_AUTH_ENV = "TRAINING_GYM_DASHBOARD_REQUIRES_PROXY_AUTH"
+
+# Only ever the *expected* side of a comparison, so publishing it is safe.
+_MISSING_TOKEN_DUMMY = "training-gym-missing-token-dummy-never-issued"
+
+
+def _requires_proxy_auth() -> bool:
+    """Resolve the opt-in edge-auth flag, stickily.
+
+    Read in the *deploying* process at decorator time. Anything but
+    1/true/0/false/unset raises, because a typo that read as "off" would
+    deploy an open dashboard. An explicit value is persisted to
+    ``~/.training-gym.toml`` and unset falls back to the persisted choice,
+    so a redeploy from a shell that doesn't export the variable cannot
+    silently reopen the dashboard — downgrading takes an explicit ``0``.
+    Containers only parse the env var and never touch the config file.
+    """
+    raw = os.environ.get(REQUIRES_PROXY_AUTH_ENV, "").strip().lower()
+    if raw in ("1", "true"):
+        explicit = True
+    elif raw in ("0", "false"):
+        explicit = False
+    elif raw == "":
+        explicit = None
+    else:
+        raise ValueError(
+            f"{REQUIRES_PROXY_AUTH_ENV} must be 1/true or 0/false/unset, got {raw!r}"
+        )
+
+    if not _is_local():
+        return bool(explicit)
+
+    from modal_training_gym.common.config import (
+        get_dashboard_requires_proxy_auth,
+        save_dashboard_requires_proxy_auth,
+    )
+
+    if explicit is None:
+        return get_dashboard_requires_proxy_auth()
+    if explicit != get_dashboard_requires_proxy_auth():
+        save_dashboard_requires_proxy_auth(explicit)
+    return explicit
+
 
 def _is_local() -> bool:
     """True when we're not running inside a Modal container."""
@@ -355,7 +402,7 @@ def reconcile() -> None:
     min_containers=1,
     secrets=_function_secrets(),
 )
-@modal.asgi_app()
+@modal.asgi_app(requires_proxy_auth=_requires_proxy_auth())
 def fastapi_app():
     import base64
     import binascii
@@ -684,6 +731,12 @@ def fastapi_app():
     async def _require_framework_status_token(
         training_run_id: str, authorization: str | None
     ) -> None:
+        """403 unless ``authorization`` carries the run's status token.
+
+        Handlers must call this *before* any lookup that can 404, or the
+        status code tells an anonymous caller which run ids exist. For the
+        same reason an unknown run is indistinguishable from a wrong token.
+        """
         try:
             expected_token = str(
                 (
@@ -696,9 +749,13 @@ def fastapi_app():
             )
         except KeyError:
             expected_token = ""
-        if not expected_token or not _secrets.compare_digest(
-            _bearer_token(authorization), expected_token
-        ):
+        supplied = _bearer_token(authorization)
+        if not expected_token:
+            # Spend the same comparison an existing token would, then refuse
+            # regardless of its outcome.
+            _secrets.compare_digest(supplied, _MISSING_TOKEN_DUMMY)
+            raise HTTPException(status_code=403, detail="Invalid status token")
+        if not _secrets.compare_digest(supplied, expected_token):
             raise HTTPException(status_code=403, detail="Invalid status token")
 
     async def _get_run_or_404(training_run_id: str) -> TrainingRun:
@@ -764,8 +821,8 @@ def fastapi_app():
         update: FrameworkStatusUpdate,
         authorization: str | None = Header(default=None),
     ):
-        run = await _get_run_or_404(update.training_run_id)
         await _require_framework_status_token(update.training_run_id, authorization)
+        run = await _get_run_or_404(update.training_run_id)
 
         status = await run_in_threadpool(run.apply_framework_status, update)
         if status is None:
@@ -787,8 +844,8 @@ def fastapi_app():
         result: TrainingRolloutResult,
         authorization: str | None = Header(default=None),
     ):
-        run = await _get_run_or_404(result.training_run_id)
         await _require_framework_status_token(result.training_run_id, authorization)
+        run = await _get_run_or_404(result.training_run_id)
 
         await result.save(is_async=True)
         run.record_latest_rollout(result)
@@ -831,8 +888,8 @@ def fastapi_app():
         shard: AdvantageDistribution,
         authorization: str | None = Header(default=None),
     ):
-        await _get_run_or_404(shard.training_run_id)
         await _require_framework_status_token(shard.training_run_id, authorization)
+        await _get_run_or_404(shard.training_run_id)
 
         await shard.save(is_async=True)
         return JSONResponse(

--- a/modal_training_gym/cli/client.py
+++ b/modal_training_gym/cli/client.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import base64
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import TracebackType
 from typing import Any, Self
-from urllib.parse import urlsplit
+from urllib.parse import SplitResult, urlsplit
 
 import httpx
 
 from modal_training_gym.common.config import get_dashboard_url
+from modal_training_gym.common.proxy_auth import modal_proxy_auth_headers
 
 from .errors import CLIError, ExitCode
 
@@ -18,6 +20,46 @@ from .errors import CLIError, ExitCode
 DASHBOARD_PASSWORD_ENV = "TRAINING_GYM_DASHBOARD_PASSWORD"
 DEFAULT_TIMEOUT_SECONDS = 10.0
 QueryParams = Mapping[str, str | int | float | bool | None]
+
+_CREDENTIAL_HEADERS = ("Authorization", "Modal-Key", "Modal-Secret")
+
+
+def _origin(parsed: SplitResult) -> tuple[str, str, int | None]:
+    """(scheme, host, port) with default ports normalized to ``None``,
+    matching how ``httpx.URL`` reports them."""
+    port = parsed.port
+    if (parsed.scheme, port) in {("http", 80), ("https", 443)}:
+        port = None
+    return (parsed.scheme, parsed.hostname or "", port)
+
+
+def _credential_hook(
+    origin: tuple[str, str, int | None],
+    password: str,
+    proxy_headers: Mapping[str, str],
+) -> Callable[[httpx.Request], None]:
+    """Attach the dashboard password and proxy-auth pair, on-origin only.
+
+    A request hook rather than an ``httpx.Auth`` flow because it has to run on
+    *every* redirect hop: httpx drops ``Authorization`` when the origin
+    changes but copies custom headers along, so the pair needs its own
+    boundary.
+    """
+    encoded = base64.b64encode(f"training-gym:{password}".encode()).decode("ascii")
+    basic_header = f"Basic {encoded}" if password else ""
+
+    def _apply(request: httpx.Request) -> None:
+        if (request.url.scheme, request.url.host, request.url.port) == origin:
+            if basic_header:
+                request.headers["Authorization"] = basic_header
+            for name, value in proxy_headers.items():
+                request.headers[name] = value
+        else:
+            for name in _CREDENTIAL_HEADERS:
+                if name in request.headers:
+                    del request.headers[name]
+
+    return _apply
 
 
 class DashboardClient:
@@ -49,16 +91,16 @@ class DashboardClient:
         dashboard_password = (
             os.environ.get(DASHBOARD_PASSWORD_ENV, "") if password is None else password
         )
-        auth = (
-            httpx.BasicAuth("training-gym", dashboard_password)
-            if dashboard_password
-            else None
+        credential_hook = _credential_hook(
+            _origin(parsed),
+            dashboard_password,
+            modal_proxy_auth_headers(configured_url),
         )
         self._client = httpx.Client(
             base_url=configured_url.rstrip("/") + "/",
-            auth=auth,
             timeout=DEFAULT_TIMEOUT_SECONDS,
             follow_redirects=True,
+            event_hooks={"request": [credential_hook]},
         )
 
     def get_json(
@@ -117,7 +159,12 @@ class DashboardClient:
                 "Dashboard authentication was rejected.",
                 error="authentication_failed",
                 exit_code=ExitCode.AUTH,
-                hint="training-gym set-password",
+                hint=(
+                    "training-gym set-password; for a dashboard deployed with "
+                    "TRAINING_GYM_DASHBOARD_REQUIRES_PROXY_AUTH=1, configure the "
+                    "Modal proxy-auth pair via training-gym setup or "
+                    "MODAL_KEY/MODAL_SECRET"
+                ),
             )
         if status_code == 404:
             raise CLIError(

--- a/modal_training_gym/cli/setup.py
+++ b/modal_training_gym/cli/setup.py
@@ -45,9 +45,29 @@ def setup(interactive: bool = True) -> str:
     import modal
 
     from modal_training_gym._dashboard import app, fastapi_app
-    from modal_training_gym.common.config import CONFIG_PATH, save_dashboard_url
+    from modal_training_gym.common.config import (
+        CONFIG_PATH,
+        get_dashboard_requires_proxy_auth,
+        save_dashboard_url,
+    )
 
     ensure_proxy_auth(interactive=interactive)
+
+    # The decorator resolved the sticky flag at import; say which way it went,
+    # so neither a redeploy that stays closed despite an unset env var nor a
+    # machine without the persisted choice deploying open is ever a surprise.
+    if get_dashboard_requires_proxy_auth():
+        print(
+            "Dashboard edge auth: on — Modal rejects anonymous requests at its "
+            "edge. Sticky across redeploys; export "
+            "TRAINING_GYM_DASHBOARD_REQUIRES_PROXY_AUTH=0 to deploy open."
+        )
+    else:
+        print(
+            "Dashboard edge auth: off — Modal's edge forwards anonymous "
+            "requests to the dashboard. Export "
+            "TRAINING_GYM_DASHBOARD_REQUIRES_PROXY_AUTH=1 to reject them there."
+        )
 
     if not ensure_creds_secret(interactive=interactive):
         print(

--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -7,6 +7,7 @@ caller) to look up where to POST phase reports and other client-side defaults.
 from __future__ import annotations
 
 import os
+import tempfile
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,30 @@ def load_config() -> dict[str, Any]:
         return {}
 
 
+def _write_config(config: dict[str, Any]) -> None:
+    """Write atomically, owner-only: the file can hold the proxy-auth pair.
+
+    The temporary name is unique per call. A fixed one is not safe here:
+    ``save_dashboard_url`` and ``save_proxy_auth`` can run concurrently (two
+    parallel deploys, or ``setup`` beside one), and a shared temp path lets one
+    writer rename the other's half-written file into place — or delete it out
+    from under the other's ``os.replace``.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=CONFIG_PATH.parent, prefix=CONFIG_PATH.name + ".", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        # mkstemp already creates 0600; the mode matters because this file can
+        # hold a workspace credential.
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(_render(config))
+        os.replace(tmp_path, CONFIG_PATH)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def save_dashboard_url(url: str) -> None:
     """Persist the deployed dashboard URL under ``[dashboard].url``."""
     config = load_config()
@@ -37,7 +62,27 @@ def save_dashboard_url(url: str) -> None:
         dashboard = {}
     dashboard["url"] = url
     config["dashboard"] = dashboard
-    CONFIG_PATH.write_text(_render(config))
+    _write_config(config)
+
+
+def get_dashboard_requires_proxy_auth() -> bool:
+    """Return the persisted dashboard edge-auth choice (default ``False``)."""
+    dashboard = load_config().get("dashboard")
+    if isinstance(dashboard, dict):
+        return dashboard.get("requires_proxy_auth") is True
+    return False
+
+
+def save_dashboard_requires_proxy_auth(value: bool) -> None:
+    """Persist the dashboard edge-auth choice under
+    ``[dashboard].requires_proxy_auth``."""
+    config = load_config()
+    dashboard = config.get("dashboard")
+    if not isinstance(dashboard, dict):
+        dashboard = {}
+    dashboard["requires_proxy_auth"] = bool(value)
+    config["dashboard"] = dashboard
+    _write_config(config)
 
 
 def get_dashboard_url() -> str | None:
@@ -70,7 +115,7 @@ def save_proxy_auth(key: str, secret: str) -> None:
     """Persist the proxy-auth token pair under ``[proxy_auth]``."""
     config = load_config()
     config[PROXY_AUTH_SECTION] = {"key": key.strip(), "secret": secret.strip()}
-    CONFIG_PATH.write_text(_render(config))
+    _write_config(config)
 
 
 def load_proxy_auth() -> bool:

--- a/modal_training_gym/common/deployment.py
+++ b/modal_training_gym/common/deployment.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import os
 import threading
 import warnings
 from dataclasses import dataclass
@@ -32,6 +31,12 @@ from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.ids import create_hash
 from modal_training_gym.common.modal_urls import modal_app_dashboard_url
 from modal_training_gym.common.models import ModelConfig
+from modal_training_gym.common.proxy_auth import (
+    PROXY_AUTH_HOSTS_ENV,
+    _configured_pair,
+    modal_proxy_auth_headers,
+    proxy_auth_url_allowed,
+)
 from modal_training_gym.deploy_recipes.base import DeployRecipeType
 from modal_training_gym.deploy_recipes.sglang_recipe import SglangRecipe
 from modal_training_gym.deploy_recipes.vllm_recipe import VllmRecipe
@@ -76,24 +81,9 @@ def _run_coro(coro):
     return result["value"]
 
 
-def _modal_proxy_auth_headers() -> dict[str, str]:
-    """Headers to authenticate against Modal endpoints behind proxy auth.
-
-    Reads the Modal proxy-auth token pair (``wk-``/``ws-``) from ``MODAL_KEY`` /
-    ``MODAL_SECRET`` and returns them as ``Modal-Key`` / ``Modal-Secret`` headers.
-    Falls back to the pair persisted in ``~/.training-gym.toml`` (written by
-    ``training-gym setup``) when the env vars are unset. Returns an empty dict
-    when neither source provides them, so endpoints without proxy auth are
-    unaffected.
-    """
-    from modal_training_gym.common.config import load_proxy_auth
-
-    load_proxy_auth()
-    key = os.environ.get("MODAL_KEY", "").strip()
-    secret = os.environ.get("MODAL_SECRET", "").strip()
-    if key and secret:
-        return {"Modal-Key": key, "Modal-Secret": secret}
-    return {}
+# Shared with the dashboard clients (status reporters, CLI); see that module
+# for resolution rules.
+_modal_proxy_auth_headers = modal_proxy_auth_headers
 
 
 def _raise_for_proxy_auth(status_code: int, url: str) -> None:
@@ -102,29 +92,37 @@ def _raise_for_proxy_auth(status_code: int, url: str) -> None:
     SGLang endpoints are public by default (``unauthenticated=True``). When
     an endpoint was served with ``unauthenticated=False``, a 401 almost
     always means the ``MODAL_KEY`` / ``MODAL_SECRET`` proxy-auth token pair
-    is missing from the environment (so :func:`_modal_proxy_auth_headers`
-    returned no headers) rather than a real authorization problem — surface
-    that instead of a bare ``HTTPError``/``TimeoutError``. No-op for any
-    other status.
+    never reached it — unset, or withheld from a non-Modal URL by the egress
+    guard — rather than a real authorization problem; surface which, instead
+    of a bare ``HTTPError``/``TimeoutError``. No-op for any other status.
     """
     if status_code != 401:
         return
-    sent_auth = bool(_modal_proxy_auth_headers())
-    detail = (
-        "the MODAL_KEY / MODAL_SECRET proxy-auth tokens are not set in this environment"
-        if not sent_auth
-        else "the MODAL_KEY / MODAL_SECRET tokens were sent but rejected (expired "
-        "or wrong workspace)"
-    )
+    key, secret = _configured_pair()
+    if key and secret and not proxy_auth_url_allowed(url):
+        detail = (
+            "the configured MODAL_KEY / MODAL_SECRET pair was withheld from "
+            f"this non-Modal URL; set {PROXY_AUTH_HOSTS_ENV}=<host> to send it"
+        )
+    elif not (key and secret):
+        detail = (
+            "the MODAL_KEY / MODAL_SECRET proxy-auth tokens are not set in "
+            "this environment. Create a proxy-auth token pair at "
+            "https://modal.com/settings/proxy-auth-tokens and export MODAL_KEY "
+            "(wk-…) and MODAL_SECRET (ws-…) in the shell that runs the "
+            "eval/serve. For calls issued from remote workers (e.g. a custom "
+            "rm/reward function), also forward the pair into the worker via a "
+            "modal.Secret"
+        )
+    else:
+        detail = (
+            "the MODAL_KEY / MODAL_SECRET tokens were sent but rejected "
+            "(expired or wrong workspace)"
+        )
     raise RuntimeError(
         f"401 Unauthorized from {url} — this endpoint is behind Modal proxy auth "
-        f"and {detail}. Create a proxy-auth token pair at "
-        "https://modal.com/settings/proxy-auth-tokens and export MODAL_KEY (wk-…) "
-        "and MODAL_SECRET (ws-…) in the shell that runs the eval/serve. For calls "
-        "issued from remote workers (e.g. a custom rm/reward function), also "
-        "forward the pair into the worker via a modal.Secret. SGLang endpoints "
-        "are public by default; pass DeploymentConfig(unauthenticated=False) to "
-        "require proxy auth."
+        f"and {detail}. SGLang endpoints are public by default; pass "
+        "DeploymentConfig(unauthenticated=False) to require proxy auth."
     )
 
 
@@ -494,7 +492,7 @@ class ModelDeployment(BaseModel):
                     f"{self.url}/v1/chat/completions",
                     json=body,
                     timeout=timeout,
-                    headers=_modal_proxy_auth_headers(),
+                    headers=_modal_proxy_auth_headers(self.url),
                 )
                 if (
                     resp.status_code in transient_status_codes
@@ -642,7 +640,7 @@ class ModelDeployment(BaseModel):
                     resp = requests.get(
                         f"{self.url}/v1/models",
                         timeout=10,
-                        headers=_modal_proxy_auth_headers(),
+                        headers=_modal_proxy_auth_headers(self.url),
                     )
                     if resp.ok and resp.json().get("data"):
                         return

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -171,6 +171,21 @@ def build_app_tags(
     return tags
 
 
+_SENSITIVE_ENV_SUFFIXES = ("_TOKEN", "_SECRET", "_KEY", "_PASSWORD")
+
+
+def redact_env_values(env: dict[str, Any]) -> dict[str, Any]:
+    """Copy ``env`` with credential-shaped values masked, for safe printing.
+
+    Launchers echo the Ray ``runtime_env`` into logs, and it carries the run's
+    status token.
+    """
+    return {
+        key: "***" if str(key).upper().endswith(_SENSITIVE_ENV_SUFFIXES) else value
+        for key, value in env.items()
+    }
+
+
 def run_download_phase(
     *,
     training_run_id: str,

--- a/modal_training_gym/common/proxy_auth.py
+++ b/modal_training_gym/common/proxy_auth.py
@@ -1,0 +1,175 @@
+"""Modal proxy-auth plumbing shared by the dashboard HTTP clients.
+
+An endpoint deployed with ``requires_proxy_auth=True`` is enforced at Modal's
+edge: without a workspace ``wk-``/``ws-`` pair in ``Modal-Key``/``Modal-Secret``
+the request never reaches the app. The serving path already speaks this via
+``DeploymentConfig(unauthenticated=False)``; this gives the status reporters
+and the CLI the same ability, and is inert when no pair is configured.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, build_opener
+
+PROXY_AUTH_KEY_ENV = "MODAL_KEY"
+PROXY_AUTH_SECRET_ENV = "MODAL_SECRET"
+
+# Comma-separated extra hostnames the pair may be sent to (e.g. a custom
+# domain in front of Modal); non-Modal hosts not named here never see it.
+PROXY_AUTH_HOSTS_ENV = "TRAINING_GYM_PROXY_AUTH_HOSTS"
+
+# Modal edge auth only exists on Modal-served hostnames.
+_MODAL_HOST_SUFFIXES = (".modal.run", ".modal.direct")
+
+# Where plaintext is not an exposure: a loopback request never reaches a
+# network. Also what the tests' local dashboard server speaks.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _extra_hosts() -> frozenset[str]:
+    raw = os.environ.get(PROXY_AUTH_HOSTS_ENV, "")
+    return frozenset(host.strip().lower() for host in raw.split(",") if host.strip())
+
+
+def proxy_auth_url_allowed(url: str) -> bool:
+    """Whether the workspace pair may be sent to ``url``.
+
+    The pair is a workspace-wide credential and the dashboard URL is
+    operator-supplied configuration, so it goes only where Modal edge auth
+    can exist: an ``https`` origin on a Modal-served hostname, or on a host
+    named in ``TRAINING_GYM_PROXY_AUTH_HOSTS``. Naming a host opts it into
+    receiving the pair, not into sending it in the clear.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    host = (parts.hostname or "").lower()
+    if not host:
+        return False
+    if parts.scheme != "https" and host not in _LOOPBACK_HOSTS:
+        return False
+    if host in _extra_hosts():
+        return True
+    return host.endswith(_MODAL_HOST_SUFFIXES)
+
+
+def _configured_pair() -> tuple[str, str]:
+    from modal_training_gym.common.config import load_proxy_auth
+
+    load_proxy_auth()
+    return (
+        os.environ.get(PROXY_AUTH_KEY_ENV, "").strip(),
+        os.environ.get(PROXY_AUTH_SECRET_ENV, "").strip(),
+    )
+
+
+def modal_proxy_auth_headers(url: str) -> dict[str, str]:
+    """Proxy-auth headers for ``url``, from the environment or
+    ``~/.training-gym.toml``.
+
+    Containers only ever see the env vars, forwarded by
+    :func:`modal_training_gym.common.proxy_auth_secrets`; the file is how a
+    laptop persists the pair via ``training-gym setup``. A partial pair — or
+    a URL that fails :func:`proxy_auth_url_allowed` — returns nothing.
+    """
+    key, secret = _configured_pair()
+    if key and secret and proxy_auth_url_allowed(url):
+        return {"Modal-Key": key, "Modal-Secret": secret}
+    return {}
+
+
+class _RefuseRedirects(HTTPRedirectHandler):
+    """urllib replays the original headers — run token and proxy pair — at
+    whatever origin a redirect names. The ingestion endpoints never redirect,
+    so treat a 3xx as the misconfiguration it is."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+NO_REDIRECT_OPENER = build_opener(_RefuseRedirects)
+
+
+_AUTH_WARN_INTERVAL_SECONDS = 60.0
+_auth_warn_lock = threading.Lock()
+# Per warning kind, so an auth warning cannot silence a redirect warning.
+_next_warn: dict[str, float] = {}
+
+
+def _warn_rate_limited(kind: str) -> bool:
+    now = time.monotonic()
+    with _auth_warn_lock:
+        if now < _next_warn.get(kind, 0.0):
+            return True
+        _next_warn[kind] = now + _AUTH_WARN_INTERVAL_SECONDS
+    return False
+
+
+def _loggable(url: str) -> str:
+    """``scheme://host/path`` — enough to identify the endpoint, without the
+    userinfo or query string a hand-configured status URL might sign.
+
+    ``urlsplit`` accepts a non-numeric port and ``SplitResult.port`` raises for
+    it lazily, so the port has to be read inside the guard: this runs from the
+    reporter's ``except HTTPError`` path, where an exception would unwind the
+    worker thread and silently end reporting for the rest of the run.
+    """
+    try:
+        parts = urlsplit(url)
+        port = f":{parts.port}" if parts.port else ""
+    except ValueError:
+        return "<unparseable url>"
+    if not parts.scheme and not parts.hostname:
+        return "<unparseable url>"
+    return f"{parts.scheme}://{parts.hostname or ''}{port}{parts.path}"
+
+
+def warn_auth_rejected(status: int, url: str) -> None:
+    """Rate-limited stderr warning for a 401/403 from the dashboard.
+
+    Reports are fire-and-forget, so a bad run token — or a proxy-authed
+    dashboard reached without the pair — would otherwise erase dashboard
+    updates in silence. Never logs a credential.
+    """
+    if _warn_rate_limited("auth"):
+        return
+    key, secret = _configured_pair()
+    if key and secret and not proxy_auth_url_allowed(url):
+        hint = (
+            "The configured Modal proxy-auth pair was withheld from this "
+            f"non-Modal URL; set {PROXY_AUTH_HOSTS_ENV}=<host> to send it."
+        )
+    else:
+        hint = (
+            "Check the run's status token and, if the dashboard requires "
+            "Modal proxy auth, MODAL_KEY/MODAL_SECRET."
+        )
+    print(
+        f"training-gym reporter: dashboard rejected a report (HTTP {status} "
+        f"from {_loggable(url)}). {hint} Reports are "
+        "best-effort; training is unaffected.",
+        file=sys.stderr,
+    )
+
+
+def warn_redirect_refused(status: int, url: str) -> None:
+    """Rate-limited stderr warning for a 3xx from the dashboard.
+
+    Redirects are refused (see :class:`_RefuseRedirects`), so a redirecting
+    dashboard URL — e.g. one saved as ``http://`` — silently drops every
+    report; that configuration error is worth one loud line.
+    """
+    if _warn_rate_limited("redirect"):
+        return
+    print(
+        f"training-gym reporter: refusing a redirect (HTTP {status} from "
+        f"{_loggable(url)}); reports are being dropped. Configure the final "
+        "https dashboard URL. Training is unaffected.",
+        file=sys.stderr,
+    )

--- a/modal_training_gym/common/status_reporter.py
+++ b/modal_training_gym/common/status_reporter.py
@@ -24,8 +24,15 @@ import os
 import threading
 from queue import Queue
 from typing import Any
-from urllib.error import URLError
-from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+
+from modal_training_gym.common.proxy_auth import (
+    NO_REDIRECT_OPENER,
+    modal_proxy_auth_headers,
+    warn_auth_rejected,
+    warn_redirect_refused,
+)
 
 
 # Shared with slime's phase_reporting, whose rollout payloads can be 100KB+ —
@@ -92,6 +99,7 @@ def _post(item: dict[str, Any]) -> None:
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    headers.update(modal_proxy_auth_headers(url))
     request = Request(
         url,
         data=body,
@@ -99,8 +107,14 @@ def _post(item: dict[str, Any]) -> None:
         method="POST",
     )
     try:
-        with urlopen(request, timeout=timeout) as response:
+        with NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:
             response.read()
+    except HTTPError as exc:
+        if exc.code in (401, 403):
+            warn_auth_rejected(exc.code, url)
+        elif 300 <= exc.code < 400:
+            warn_redirect_refused(exc.code, url)
+        return
     except (OSError, URLError):
         return
 

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -42,6 +42,7 @@ from modal_training_gym.common.launcher_helpers import (
     init_training_run_record,
     mark_run_failed,
     mark_run_stopped,
+    redact_env_values,
     resolve_caller_context,
     resolve_checkpoint_volumes,
     run_download_phase,
@@ -214,7 +215,9 @@ def build_miles_app(
             checkpoints_mount_path: checkpoints_volume,
         },
         timeout=4 * 60 * 60,
-        secrets=hf_secrets(),
+        # proxy_auth_secrets: this phase reports status to the dashboard,
+        # which may require proxy auth.
+        secrets=[*hf_secrets(), *proxy_auth_secrets()],
         serialized=True,
         name="download",
     )
@@ -256,6 +259,8 @@ def build_miles_app(
         gpu=gpu_spec,
         volumes=all_volumes,
         timeout=4 * 60 * 60,
+        # See download: status reports must pass the dashboard's proxy auth.
+        secrets=proxy_auth_secrets(),
         experimental_options={"efa_enabled": True} if convert_multi_node else {},
         serialized=True,
         name="convert_checkpoint",
@@ -648,7 +653,11 @@ def build_miles_app(
                 f"Training {app_name} - {miles.total_nodes} node(s) x {gpu_spec} ({mode})"
             )
             print(miles.gpu_allocation.summary())
-            print(f"Command: {cmd}, runtime_env: {runtime_env}")
+            printable_env = {
+                **runtime_env,
+                "env_vars": redact_env_values(runtime_env["env_vars"]),
+            }
+            print(f"Command: {cmd}, runtime_env: {printable_env}")
 
             await _set_framework_status(MilesStatus.TRAINING)
             async with cluster.forward_dashboard() as tunnel:

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -56,6 +56,7 @@ from modal_training_gym.common.launcher_helpers import (
     init_training_run_record,
     mark_run_failed,
     mark_run_stopped,
+    redact_env_values,
     resolve_caller_context,
     resolve_checkpoint_volumes,
     run_download_phase,
@@ -675,7 +676,9 @@ def build_slime_app(
             checkpoints_mount_path: checkpoints_volume,
         },
         timeout=6 * 60 * 60,
-        secrets=hf_secrets(),
+        # proxy_auth_secrets: this phase reports status to the dashboard,
+        # which may require proxy auth.
+        secrets=[*hf_secrets(), *proxy_auth_secrets()],
         serialized=True,
         name="download",
     )
@@ -714,6 +717,8 @@ def build_slime_app(
         region=slime.region,
         volumes=all_volumes,
         timeout=4 * 60 * 60,
+        # See download: status reports must pass the dashboard's proxy auth.
+        secrets=proxy_auth_secrets(),
         experimental_options={"efa_enabled": True},
         serialized=True,
         name="convert_checkpoint",
@@ -1257,7 +1262,11 @@ def build_slime_app(
                 f"Training {app_name} — {slime.total_nodes} node(s) × {gpu_spec}  ({mode})"
             )
             print(slime.gpu_allocation.summary())
-            print(f"Command: {cmd}, runtime_env: {runtime_env}")
+            printable_env = {
+                **runtime_env,
+                "env_vars": redact_env_values(runtime_env["env_vars"]),
+            }
+            print(f"Command: {cmd}, runtime_env: {printable_env}")
 
             await _set_framework_status_async(SlimeStatus.ROLLOUT_INITIALIZING)
             async with cluster.forward_dashboard() as tunnel:

--- a/modal_training_gym/frameworks/slime/reporting.py
+++ b/modal_training_gym/frameworks/slime/reporting.py
@@ -13,8 +13,15 @@ import os
 import threading
 from queue import Queue
 from typing import Any
-from urllib.error import URLError
-from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+
+from modal_training_gym.common.proxy_auth import (
+    NO_REDIRECT_OPENER,
+    modal_proxy_auth_headers,
+    warn_auth_rejected,
+    warn_redirect_refused,
+)
 
 PHASE_REPORT_URL_ENV = "SLIME_PHASE_REPORT_URL"
 PHASE_REPORT_TOKEN_ENV = "SLIME_PHASE_REPORT_TOKEN"
@@ -213,6 +220,7 @@ def _post(item: dict[str, Any]) -> None:
     token = _report_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    headers.update(modal_proxy_auth_headers(url))
     request = Request(
         url,
         data=body,
@@ -220,7 +228,13 @@ def _post(item: dict[str, Any]) -> None:
         method="POST",
     )
     try:
-        with urlopen(request, timeout=timeout) as response:
+        with NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:
             response.read()
+    except HTTPError as exc:
+        if exc.code in (401, 403):
+            warn_auth_rejected(exc.code, url)
+        elif 300 <= exc.code < 400:
+            warn_redirect_refused(exc.code, url)
+        return
     except (OSError, URLError):
         return

--- a/tests/test_cli_client.py
+++ b/tests/test_cli_client.py
@@ -11,15 +11,22 @@ from modal_training_gym.cli.client import (
     DashboardClient,
 )
 from modal_training_gym.cli.errors import CLIError, ExitCode
+from modal_training_gym.common import config as config_module
 
 
 @pytest.fixture(autouse=True)
-def configured_dashboard_url(monkeypatch):
+def configured_dashboard_url(monkeypatch, tmp_path):
     monkeypatch.setattr(
         client_module,
         "get_dashboard_url",
         lambda: "https://example.test",
     )
+    # Keep the client hermetic: never read the developer's real
+    # ~/.training-gym.toml (it may hold a proxy-auth pair) or env pair.
+    monkeypatch.setattr(config_module, "CONFIG_PATH", tmp_path / "training-gym.toml")
+    monkeypatch.delenv("MODAL_KEY", raising=False)
+    monkeypatch.delenv("MODAL_SECRET", raising=False)
+    monkeypatch.delenv("TRAINING_GYM_PROXY_AUTH_HOSTS", raising=False)
 
 
 @pytest.fixture
@@ -96,6 +103,45 @@ def test_does_not_forward_basic_auth_to_redirected_host(monkeypatch, mock_transp
 
     assert requests[0].headers["authorization"].startswith("Basic ")
     assert "authorization" not in requests[1].headers
+
+
+@pytest.mark.parametrize(
+    ("location", "still_credentialed"),
+    [
+        ("https://other.test/api/items", False),
+        ("https://example.test/api/items/", True),
+    ],
+    ids=["cross-origin", "same-origin"],
+)
+def test_proxy_pair_follows_only_same_origin_redirects(
+    monkeypatch, mock_transport, location, still_credentialed
+):
+    """httpx drops ``Authorization`` when a redirect changes origin but copies
+    custom headers along unchanged, so the pair needs its own boundary — and
+    that boundary must not be so eager it strips the dashboard's own trailing
+    slash redirects."""
+    monkeypatch.setenv("MODAL_KEY", "wk-key")
+    monkeypatch.setenv("MODAL_SECRET", "ws-secret")
+    # Allowlisted so the egress guard releases the pair to the mock host.
+    monkeypatch.setenv("TRAINING_GYM_PROXY_AUTH_HOSTS", "example.test")
+    monkeypatch.setenv("TRAINING_GYM_DASHBOARD_PASSWORD", "secret")
+    requests = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if str(request.url) == "https://example.test/api/items":
+            return httpx.Response(302, headers={"location": location})
+        return httpx.Response(200, json={})
+
+    mock_transport(respond)
+    with DashboardClient() as client:
+        client.get_json("/api/items")
+
+    assert requests[0].headers["modal-key"] == "wk-key"
+    redirected = requests[1].headers
+    assert ("modal-key" in redirected) is still_credentialed
+    assert ("modal-secret" in redirected) is still_credentialed
+    assert ("authorization" in redirected) is still_credentialed
 
 
 def test_omits_auth_when_password_is_absent(monkeypatch, mock_transport):

--- a/tests/test_dashboard_ingestion_auth.py
+++ b/tests/test_dashboard_ingestion_auth.py
@@ -1,0 +1,256 @@
+"""Ingestion-route authorization and the opt-in edge-auth flag."""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import modal
+import pytest
+from fastapi.testclient import TestClient
+
+from modal_training_gym import _dashboard
+from modal_training_gym.common import config
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.run import TrainingRun
+from modal_training_gym.utils import metadata
+from modal_training_gym.utils.metadata import MetadataStore
+
+RUN_ID = "run-auth-1"
+TOKEN = "test-status-token-run-auth-1"
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_file(monkeypatch, tmp_path):
+    """The sticky flag reads/writes the developer's real config otherwise."""
+    monkeypatch.setattr(config, "CONFIG_PATH", tmp_path / "training-gym.toml")
+
+
+# Each ingestion POST reads training_run_id off a *different* pydantic model,
+# so they are parametrized rather than sampled: an auth check wired to the
+# wrong handler's variable is the mistake this catches.
+ROUTES = [
+    ("/api/framework-status", {"phase": "training"}),
+    ("/api/training-rollouts", {"rollout_id": 1}),
+    ("/api/advantage-distributions", {"rollout_id": 1}),
+]
+ROUTE_IDS = [route.rsplit("/", 1)[-1] for route, _ in ROUTES]
+
+
+def _client(monkeypatch, tmp_path) -> TestClient:
+    static = tmp_path / "static"
+    (static / "assets").mkdir(parents=True)
+    (static / "index.html").write_text("ok")
+    (static / "favicon.svg").write_text("<svg/>")
+    monkeypatch.setattr(_dashboard, "STATIC_DIR", str(static))
+    monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
+    return TestClient(_dashboard.fastapi_app.local())
+
+
+def _save_run(token: str | None = TOKEN) -> None:
+    TrainingRun(
+        training_run_id=RUN_ID,
+        modal_app_id="ap-auth",
+        framework=Framework.SLIME,
+        config={"model": {"model_name": "Qwen/Qwen3-4B"}},
+        created_at=100,
+        started_at=100,
+        updated_at=150,
+    ).save()
+    if token is not None:
+        metadata.vol_put(
+            MetadataStore.FRAMEWORK_STATUS_TOKENS, RUN_ID, {"token": token}
+        )
+
+
+@pytest.mark.parametrize(("route", "extra"), ROUTES, ids=ROUTE_IDS)
+def test_every_rejection_is_indistinguishable(
+    fake_volume, monkeypatch, tmp_path, route, extra
+):
+    """Rejections must not reveal whether a run id exists.
+
+    The handlers used to look the run up (404) before checking the token
+    (403), so an anonymous caller could enumerate real training-run ids by
+    the status code alone. Asserting the responses are *equal* — rather than
+    each being 403 — is what pins the property: it fails just as loudly if a
+    future change makes unknown runs 404 again, or gives any one failure
+    mode a distinguishing body.
+    """
+    _save_run()
+    rejections = {
+        "unknown run, no credentials": ("ghost-run", {}),
+        "unknown run, valid-looking token": ("ghost-run", f"Bearer {TOKEN}"),
+        "real run, no credentials": (RUN_ID, {}),
+        "real run, wrong token": (RUN_ID, "Bearer wrong-token"),
+        "real run, Basic instead of Bearer": (RUN_ID, "Basic dHJhaW5pbmctZ3ltOnB3"),
+        "real run, bare Bearer": (RUN_ID, "Bearer"),
+    }
+
+    seen = {}
+    with _client(monkeypatch, tmp_path) as client:
+        for label, (run_id, auth) in rejections.items():
+            response = client.post(
+                route,
+                json={"training_run_id": run_id, **extra},
+                headers={"Authorization": auth} if isinstance(auth, str) else {},
+            )
+            seen[label] = (response.status_code, response.json())
+
+    refused = (403, {"detail": "Invalid status token"})
+    assert seen == dict.fromkeys(rejections, refused)
+
+
+@pytest.mark.parametrize(("route", "extra"), ROUTES, ids=ROUTE_IDS)
+def test_correct_token_still_reaches_the_handler(
+    fake_volume, monkeypatch, tmp_path, route, extra
+):
+    """The ingestion path every training container depends on."""
+    _save_run()
+    with _client(monkeypatch, tmp_path) as client:
+        response = client.post(
+            route,
+            json={"training_run_id": RUN_ID, **extra},
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+@pytest.mark.parametrize("stored", [None, ""], ids=["no-record", "empty-token"])
+def test_run_with_no_token_on_record_refuses_the_dummy(
+    fake_volume, monkeypatch, tmp_path, stored
+):
+    """The dummy the no-token path compares against must never authenticate.
+
+    That path exists so a missing token record costs the same comparison as
+    a wrong token; the constant is public, so a refactor that let it match
+    would hand every tokenless run a skeleton key.
+    """
+    _save_run(token=stored)
+    with _client(monkeypatch, tmp_path) as client:
+        response = client.post(
+            "/api/framework-status",
+            json={"training_run_id": RUN_ID, "phase": "training"},
+            headers={"Authorization": f"Bearer {_dashboard._MISSING_TOKEN_DUMMY}"},
+        )
+
+    assert response.status_code == 403
+
+
+def test_payload_validation_still_runs_after_auth(fake_volume, monkeypatch, tmp_path):
+    """Authenticating first must not swallow the handler's own 400s."""
+    _save_run()
+    with _client(monkeypatch, tmp_path) as client:
+        response = client.post(
+            "/api/framework-status",
+            json={"training_run_id": RUN_ID, "phase": "not-a-phase"},
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+    assert response.status_code == 400
+
+
+# ── TRAINING_GYM_DASHBOARD_REQUIRES_PROXY_AUTH ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("1", True),
+        (" TRUE ", True),
+        # A truthy-looking value that parsed as "off" would deploy an open
+        # dashboard while the operator believed otherwise — so it must raise.
+        ("yes", ValueError),
+        ("on", ValueError),
+        ("2", ValueError),
+    ],
+)
+def test_flag_parses_strictly(monkeypatch, raw, expected):
+    if raw is None:
+        monkeypatch.delenv(_dashboard.REQUIRES_PROXY_AUTH_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_dashboard.REQUIRES_PROXY_AUTH_ENV, raw)
+
+    if expected is ValueError:
+        with pytest.raises(ValueError):
+            _dashboard._requires_proxy_auth()
+    else:
+        assert _dashboard._requires_proxy_auth() is expected
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("1", True), (None, False)])
+def test_flag_reaches_the_asgi_decorator(monkeypatch, tmp_path, raw, expected):
+    """The flag is only worth anything if it lands on the decorator.
+
+    Parsing it correctly and then not passing it through would leave a
+    deployment silently unprotected — the one failure this whole knob exists
+    to prevent — and no assertion on ``_requires_proxy_auth`` alone can see
+    it. Re-imports the module (which is where the decorator runs) with
+    ``modal.asgi_app`` recording its keyword arguments.
+    """
+    # Module import provisions a Modal Secret from ~/.modal.toml when it can
+    # find credentials; point that lookup at nothing so the reload stays local.
+    monkeypatch.setattr(config, "MODAL_CONFIG_PATH", tmp_path / "absent.toml")
+    monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+    monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+    if raw is None:
+        monkeypatch.delenv(_dashboard.REQUIRES_PROXY_AUTH_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_dashboard.REQUIRES_PROXY_AUTH_ENV, raw)
+
+    recorded: dict[str, object] = {}
+    real_asgi_app = modal.asgi_app
+
+    def recording_asgi_app(**kwargs):
+        recorded.update(kwargs)
+        return real_asgi_app(**kwargs)
+
+    monkeypatch.setattr(modal, "asgi_app", recording_asgi_app)
+    try:
+        importlib.reload(_dashboard)
+    finally:
+        monkeypatch.setattr(modal, "asgi_app", real_asgi_app)
+        # Other modules hold a reference to this module object; reload once
+        # more, unpatched, so they see it in its default state (the sticky
+        # persisted choice must go too).
+        os.environ.pop(_dashboard.REQUIRES_PROXY_AUTH_ENV, None)
+        config.CONFIG_PATH.unlink(missing_ok=True)
+        importlib.reload(_dashboard)
+
+    assert recorded == {"requires_proxy_auth": expected}
+
+
+def test_unset_flag_keeps_the_persisted_choice(monkeypatch):
+    """A redeploy from a shell that doesn't export the flag must keep the
+    persisted choice instead of silently reopening the dashboard; downgrading
+    takes an explicit 0, which is just as sticky."""
+    monkeypatch.setenv(_dashboard.REQUIRES_PROXY_AUTH_ENV, "1")
+    assert _dashboard._requires_proxy_auth() is True
+
+    monkeypatch.delenv(_dashboard.REQUIRES_PROXY_AUTH_ENV)
+    assert _dashboard._requires_proxy_auth() is True
+
+    monkeypatch.setenv(_dashboard.REQUIRES_PROXY_AUTH_ENV, "0")
+    assert _dashboard._requires_proxy_auth() is False
+
+    monkeypatch.delenv(_dashboard.REQUIRES_PROXY_AUTH_ENV)
+    assert _dashboard._requires_proxy_auth() is False
+
+
+def test_containers_never_touch_the_config_file(monkeypatch):
+    """In-container re-imports must neither create a config file nor
+    resurrect a persisted choice; the edge already has its config."""
+    monkeypatch.setenv("MODAL_IS_REMOTE", "1")
+
+    monkeypatch.setenv(_dashboard.REQUIRES_PROXY_AUTH_ENV, "1")
+    assert _dashboard._requires_proxy_auth() is True
+    assert not config.CONFIG_PATH.exists()
+
+    config.save_dashboard_requires_proxy_auth(True)
+    monkeypatch.delenv(_dashboard.REQUIRES_PROXY_AUTH_ENV)
+    assert _dashboard._requires_proxy_auth() is False

--- a/tests/test_deployment_chat.py
+++ b/tests/test_deployment_chat.py
@@ -30,7 +30,7 @@ def test_chat_serializes_tool_arguments_without_mutating_messages(monkeypatch) -
     import requests
 
     monkeypatch.setattr(requests, "post", post)
-    monkeypatch.setattr(deployment_module, "_modal_proxy_auth_headers", lambda: {})
+    monkeypatch.setattr(deployment_module, "_modal_proxy_auth_headers", lambda url: {})
     deployment = ModelDeployment.model_construct(
         deployment_id="test",
         deployment_config=SimpleNamespace(served_model_name="test-model"),

--- a/tests/test_proxy_auth_clients.py
+++ b/tests/test_proxy_auth_clients.py
@@ -1,0 +1,345 @@
+"""What the dashboard clients put on the wire when proxy auth is configured.
+
+The reporters are exercised against a real local HTTP server rather than a
+mocked ``urlopen``: the properties worth protecting here — which headers
+leave the process, and where they are allowed to go — are only observable
+from the receiving end.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from modal_training_gym.common import config, deployment, proxy_auth, status_reporter
+from modal_training_gym.common.launcher_helpers import redact_env_values
+from modal_training_gym.common.proxy_auth import modal_proxy_auth_headers
+from modal_training_gym.frameworks.slime import reporting
+
+# Both reporters post to the dashboard and both had to be taught the pair;
+# patching only the common one would silently drop slime's rollouts and
+# advantage distributions, which is invisible until a run reports nothing.
+POSTERS = {
+    "status_reporter": lambda url: status_reporter._post(
+        {"_url": url, "_timeout": 5.0, "_token": "run-token", "phase": "training"}
+    ),
+    "slime_reporting": lambda url: reporting._post(
+        {"_url": url, "_timeout": 5.0, "phase": "training"}
+    ),
+}
+
+
+@pytest.fixture(autouse=True)
+def isolated_credentials(monkeypatch, tmp_path):
+    """No pair in the environment, and never the developer's real config file."""
+    monkeypatch.setattr(config, "CONFIG_PATH", tmp_path / "training-gym.toml")
+    monkeypatch.setenv("TRAINING_GYM_FRAMEWORK_STATUS_TOKEN", "run-token")
+    # load_proxy_auth() populates os.environ by design, so monkeypatch cannot
+    # undo it; restore both variables by hand.
+    original = {name: os.environ.get(name) for name in ("MODAL_KEY", "MODAL_SECRET")}
+    for name in original:
+        monkeypatch.delenv(name, raising=False)
+    yield
+    for name, value in original.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+
+@pytest.fixture
+def pair(monkeypatch):
+    monkeypatch.setenv("MODAL_KEY", "wk-key")
+    monkeypatch.setenv("MODAL_SECRET", "ws-secret")
+    # Named because the egress guard withholds the pair from non-Modal hosts.
+    monkeypatch.setenv(proxy_auth.PROXY_AUTH_HOSTS_ENV, "127.0.0.1")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def _record(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        # urllib normalizes header casing on the wire (``Modal-Key`` arrives as
+        # ``Modal-key``), so compare lower-cased.
+        self.server.seen.append(
+            {name.lower(): value for name, value in self.headers.items()}
+        )
+        status, headers = self.server.reply
+        self.send_response(status)
+        for name, value in headers.items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    # GET as well as POST: urllib turns a redirected POST into a GET, so a
+    # handler that only recorded POSTs would see a credential leak as silence.
+    do_POST = _record
+    do_GET = _record
+
+    def log_message(self, *_args):
+        pass
+
+
+def _serve():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    server.seen = []
+    server.reply = (200, {})
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, f"http://127.0.0.1:{server.server_address[1]}/api/framework-status"
+
+
+@pytest.fixture
+def dashboard():
+    server, url = _serve()
+    try:
+        yield server, url
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.parametrize("post", POSTERS.values(), ids=POSTERS)
+def test_proxy_pair_is_sent_alongside_the_run_token(dashboard, pair, post):
+    """Edge auth is additional to per-run authorization, not a replacement:
+    dropping the bearer would make every run's reports interchangeable."""
+    server, url = dashboard
+
+    post(url)
+
+    assert server.seen[0]["authorization"] == "Bearer run-token"
+    assert server.seen[0]["modal-key"] == "wk-key"
+    assert server.seen[0]["modal-secret"] == "ws-secret"
+
+
+@pytest.mark.parametrize("post", POSTERS.values(), ids=POSTERS)
+def test_credentials_never_follow_a_redirect(dashboard, pair, post):
+    """urllib's redirect handler replays the original headers at the new
+    location, whatever origin it names — so a dashboard URL that redirects
+    (or is made to) would hand the run token and the workspace pair to
+    somewhere else entirely."""
+    server, url = dashboard
+    elsewhere, _ = _serve()
+    try:
+        elsewhere_url = f"http://127.0.0.1:{elsewhere.server_address[1]}/"
+        server.reply = (302, {"Location": elsewhere_url})
+
+        post(url)
+
+        assert len(server.seen) == 1
+        assert elsewhere.seen == []
+    finally:
+        elsewhere.shutdown()
+        elsewhere.server_close()
+
+
+@pytest.mark.parametrize("post", POSTERS.values(), ids=POSTERS)
+@pytest.mark.parametrize("status", [401, 403])
+def test_rejected_reports_warn_once_and_leak_nothing(
+    dashboard, pair, capsys, monkeypatch, post, status
+):
+    """Reports are fire-and-forget, so a dashboard that started refusing them
+    would otherwise erase observability in silence. Both codes matter and mean
+    different things: 401 is Modal's edge turning away a missing pair, 403 is
+    the app refusing the run token. The warning also depends on ``HTTPError``
+    being caught before ``OSError`` — it is a subclass, so reordering those
+    excepts turns this back into silence."""
+    server, url = dashboard
+    server.reply = (status, {})
+    monkeypatch.setattr(proxy_auth, "_next_warn", {})
+
+    post(url)
+    post(url)
+
+    err = capsys.readouterr().err
+    assert err.count("dashboard rejected a report") == 1
+    assert str(status) in err
+    assert "wk-key" not in err and "ws-secret" not in err and "run-token" not in err
+
+
+def test_warning_does_not_echo_a_signed_status_url(capsys, monkeypatch):
+    """The URL is operator-supplied (TRAINING_GYM_FRAMEWORK_STATUS_URL), so it
+    can carry userinfo or a signed query — and this warning goes to logs the
+    whole team reads."""
+    monkeypatch.setattr(proxy_auth, "_next_warn", {})
+
+    proxy_auth.warn_auth_rejected(
+        401, "https://user:pw@dash.test:8443/api/framework-status?sig=deadbeef"
+    )
+
+    err = capsys.readouterr().err
+    assert "https://dash.test:8443/api/framework-status" in err
+    assert "deadbeef" not in err and "pw" not in err
+
+
+@pytest.mark.parametrize("half", ["MODAL_KEY", "MODAL_SECRET"])
+def test_half_a_pair_is_no_pair(monkeypatch, half):
+    """Sending one header without the other authenticates nothing and reads
+    like a configuration success at the call site."""
+    monkeypatch.setenv(half, "set")
+    assert modal_proxy_auth_headers("https://dash--x.modal.run/api") == {}
+
+
+def test_pair_falls_back_to_the_config_file():
+    """How a laptop CLI run gets the pair; containers only ever see the env."""
+    config.save_proxy_auth("wk-from-toml", "ws-from-toml")
+
+    assert modal_proxy_auth_headers("https://dash--x.modal.run/api") == {
+        "Modal-Key": "wk-from-toml",
+        "Modal-Secret": "ws-from-toml",
+    }
+
+
+@pytest.mark.parametrize(
+    "url,allowed",
+    [
+        ("https://dash--x.modal.run/api", True),
+        ("https://dash.us-east.modal.direct/api", True),
+        ("http://dash--x.modal.run/api", False),  # never over plaintext
+        ("https://evilmodal.run/api", False),  # lookalike, not a subdomain
+        ("https://dashboard.internal.test/api", False),
+        ("not a url", False),
+    ],
+)
+def test_pair_egress_guard(url, allowed):
+    """The URL is operator-supplied config, so a typo or poisoned value must
+    fail toward withholding the workspace credential."""
+    assert proxy_auth.proxy_auth_url_allowed(url) is allowed
+
+
+def test_allowlisted_host_releases_the_pair(monkeypatch):
+    monkeypatch.setenv(proxy_auth.PROXY_AUTH_HOSTS_ENV, "Dash.Corp.test , other.test")
+
+    assert proxy_auth.proxy_auth_url_allowed("https://dash.corp.test/api")
+    assert not proxy_auth.proxy_auth_url_allowed("https://third.test/api")
+    # Allowlisting a host says where the pair may go, not that it may go in
+    # the clear -- the same rule the Modal hostnames get above.
+    assert not proxy_auth.proxy_auth_url_allowed("http://dash.corp.test/api")
+
+
+def test_configured_pair_is_withheld_from_non_modal_urls(pair, monkeypatch):
+    monkeypatch.delenv(proxy_auth.PROXY_AUTH_HOSTS_ENV, raising=False)
+
+    assert modal_proxy_auth_headers("https://dashboard.internal.test/api") == {}
+
+
+def test_rejection_warning_explains_a_withheld_pair(pair, capsys, monkeypatch):
+    """ "Set MODAL_KEY" would gaslight an operator whose configured pair was
+    withheld by the egress guard; the warning must name the actual cause."""
+    monkeypatch.delenv(proxy_auth.PROXY_AUTH_HOSTS_ENV, raising=False)
+    monkeypatch.setattr(proxy_auth, "_next_warn", {})
+
+    proxy_auth.warn_auth_rejected(401, "https://dashboard.internal.test/api")
+
+    assert proxy_auth.PROXY_AUTH_HOSTS_ENV in capsys.readouterr().err
+
+
+def test_warning_survives_a_malformed_dashboard_url(pair, capsys, monkeypatch):
+    """The warning runs inside the reporter's ``except HTTPError``, and the
+    worker loop has no ``except``: an exception here would unwind the thread and
+    end reporting for the rest of the run. ``SplitResult.port`` raises lazily
+    for a non-numeric port, which ``urlsplit`` itself accepts."""
+    monkeypatch.setattr(proxy_auth, "_next_warn", {})
+
+    proxy_auth.warn_auth_rejected(401, "https://dash.test:abc/api/framework-status")
+
+    assert "<unparseable url>" in capsys.readouterr().err
+
+
+def test_serve_401_hint_explains_a_withheld_pair(pair, monkeypatch):
+    """Same property on the serving client's 401 hint: an endpoint on a
+    custom domain must not be told its configured pair is "not set"."""
+    monkeypatch.delenv(proxy_auth.PROXY_AUTH_HOSTS_ENV, raising=False)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        deployment._raise_for_proxy_auth(401, "https://serve.internal.test/v1")
+
+    message = str(exc_info.value)
+    assert proxy_auth.PROXY_AUTH_HOSTS_ENV in message
+    assert "not set" not in message
+
+
+@pytest.mark.parametrize("post", POSTERS.values(), ids=POSTERS)
+def test_refused_redirects_warn_instead_of_silent_loss(
+    dashboard, pair, capsys, monkeypatch, post
+):
+    """Refusing a 3xx protects the credentials but drops every report for the
+    run — that misconfiguration must be loud, not silent."""
+    server, url = dashboard
+    server.reply = (302, {"Location": "https://elsewhere.test/"})
+    monkeypatch.setattr(proxy_auth, "_next_warn", {})
+
+    post(url)
+    post(url)
+
+    assert capsys.readouterr().err.count("302") == 1
+
+
+def test_config_file_holding_the_pair_is_owner_only():
+    """It stores a workspace credential; 0644 would expose it to every local
+    account, and the file predates this so existing ones must be tightened."""
+    config.CONFIG_PATH.write_text('[dashboard]\nurl = "https://old.test"\n')
+    os.chmod(config.CONFIG_PATH, 0o644)
+
+    config.save_proxy_auth("wk-abc", "ws-def")
+
+    assert stat.S_IMODE(os.stat(config.CONFIG_PATH).st_mode) == 0o600
+    assert config.get_dashboard_url() == "https://old.test"
+    assert list(config.CONFIG_PATH.parent.glob("*.tmp")) == []
+
+
+def test_concurrent_writers_cannot_clobber_each_other(monkeypatch):
+    """Two writers overlap for real: ``training-gym setup`` beside a deploy, or
+    two parallel deploys both calling save_dashboard_url.
+
+    Interleaving is forced rather than raced — a second write is driven to
+    completion from inside the first one's ``os.replace``. With a shared
+    temp-file name the second writer renames the first one's file away, so the
+    first ``os.replace`` raises FileNotFoundError and its config is lost.
+    """
+    real_replace = os.replace
+    nested_done = []
+
+    def replace_once(src, dst):
+        if not nested_done:
+            nested_done.append(True)
+            config.save_dashboard_url("https://second-writer.test")
+        return real_replace(src, dst)
+
+    # No monkeypatch.undo() here: pytest hands the whole test one MonkeyPatch
+    # instance, so undoing would also revert the autouse fixture's CONFIG_PATH
+    # and point these assertions at the developer's real config file.
+    monkeypatch.setattr(config.os, "replace", replace_once)
+    config.save_proxy_auth("wk-abc", "ws-def")
+
+    assert nested_done, "the nested writer never ran; the test proves nothing"
+    # Last writer wins, but neither may corrupt the file or lose the section it
+    # wrote, and no temp file may survive.
+    assert config.get_proxy_auth() == ("wk-abc", "ws-def")
+    assert stat.S_IMODE(os.stat(config.CONFIG_PATH).st_mode) == 0o600
+    assert list(config.CONFIG_PATH.parent.glob("*.tmp")) == []
+
+
+def test_runtime_env_echo_masks_credentials():
+    """Launchers print the Ray runtime_env, which carries the run's status
+    token, into logs the whole team can read."""
+    redacted = redact_env_values(
+        {
+            "TRAINING_GYM_FRAMEWORK_STATUS_TOKEN": "tok",
+            "MODAL_SECRET": "ws-1",
+            "WANDB_API_KEY": "k",
+            "MASTER_ADDR": "10.0.0.1",
+            "WANDB_RUN_ID": "run-7",
+        }
+    )
+
+    assert redacted == {
+        "TRAINING_GYM_FRAMEWORK_STATUS_TOKEN": "***",
+        "MODAL_SECRET": "***",
+        "WANDB_API_KEY": "***",
+        "MASTER_ADDR": "10.0.0.1",
+        "WANDB_RUN_ID": "run-7",
+    }

--- a/tutorials/rl/009_cross_tokenizer_distillation/009_cross_tokenizer_distillation.ipynb
+++ b/tutorials/rl/009_cross_tokenizer_distillation/009_cross_tokenizer_distillation.ipynb
@@ -806,7 +806,7 @@
     "                async with aiohttp.ClientSession() as session:\n",
     "                    async with session.post(\n",
     "                        args.rm_url, json=payload,\n",
-    "                        headers=_modal_proxy_auth_headers(),\n",
+    "                        headers=_modal_proxy_auth_headers(args.rm_url),\n",
     "                        timeout=aiohttp.ClientTimeout(total=request_timeout),\n",
     "                    ) as resp:\n",
     "                        resp.raise_for_status()\n",

--- a/tutorials/rl/009_cross_tokenizer_distillation/009_cross_tokenizer_distillation.py
+++ b/tutorials/rl/009_cross_tokenizer_distillation/009_cross_tokenizer_distillation.py
@@ -529,7 +529,7 @@ async def cross_tokenizer_reward(args, sample, **kwargs):
                 async with aiohttp.ClientSession() as session:
                     async with session.post(
                         args.rm_url, json=payload,
-                        headers=_modal_proxy_auth_headers(),
+                        headers=_modal_proxy_auth_headers(args.rm_url),
                         timeout=aiohttp.ClientTimeout(total=request_timeout),
                     ) as resp:
                         resp.raise_for_status()

--- a/tutorials/tutorial_generator/rl/009_cross_tokenizer_distillation.py
+++ b/tutorials/tutorial_generator/rl/009_cross_tokenizer_distillation.py
@@ -724,7 +724,7 @@ def _teacher_reward():
                     async with aiohttp.ClientSession() as session:
                         async with session.post(
                             args.rm_url, json=payload,
-                            headers=_modal_proxy_auth_headers(),
+                            headers=_modal_proxy_auth_headers(args.rm_url),
                             timeout=aiohttp.ClientTimeout(total=request_timeout),
                         ) as resp:
                             resp.raise_for_status()


### PR DESCRIPTION
### 1. Ingestion routes authenticate before the run lookup

The three ingestion POSTs (`/api/framework-status`, `/api/training-rollouts`, `/api/advantage-distributions`) looked up the run before checking the per-run bearer token. An unknown run returned 404 and a bad token returned 403, so anyone could tell valid training-run ids apart without credentials.

The token check now runs first. A run with no token on record still performs a `compare_digest` against a dummy value instead of returning early, so all rejections look the same.

### 2. `TRAINING_GYM_DASHBOARD_REQUIRES_PROXY_AUTH`

Set this to `1` in the shell that runs `training-gym setup` (or `modal deploy dashboards/app.py`) to deploy the dashboard with `requires_proxy_auth=True`. That is the same edge protection the serving path already offers through `DeploymentConfig(unauthenticated=False)`. It defaults to off.

The value is read at decorator time in the deploying process, so a Secret attached to the remote function has no effect on it. Only `1`, `true`, `0`, `false`, and unset are accepted; anything else raises, since a typo that quietly meant "off" would deploy an open dashboard. The choice is sticky: an explicit value persists to `~/.training-gym.toml`, and unset falls back to the persisted choice, so redeploying from a shell that doesn't export the variable can't silently reopen a locked dashboard — downgrading takes an explicit `0`. `training-gym setup` prints the edge-auth state both ways, so a machine without the persisted choice deploying open is never silent.

Browsers can't send proxy-auth headers, so this works alongside `training-gym set-password` rather than replacing it.

### 3. Dashboard clients can pass Modal edge auth

A new `common/proxy_auth.py`, extracted from `deployment.py`, adds the workspace `wk-`/`ws-` pair from `MODAL_KEY`/`MODAL_SECRET` (environment, or `~/.training-gym.toml` locally). It sends both headers or neither, never one — and only to `https` URLs, on Modal-served hostnames (`*.modal.run`, `*.modal.direct`) or hosts named in `TRAINING_GYM_PROXY_AUTH_HOSTS`: the pair is a workspace credential and the dashboard URL is operator-supplied configuration, so anywhere else gets the request without it. Naming a host says where the pair may go, not that it may go in the clear — `https` is required there too, loopback excepted since there is no network to observe. Three callers use it:

- Both status reporters, `common/status_reporter.py` and `frameworks/slime/reporting.py`. Only patching the first would have quietly dropped slime's rollouts and advantage distributions. Both now refuse redirects rather than replaying the run token and the pair at whatever origin a `Location` header names, and both warn on stderr (rate-limited) for a 401, a 403, or a refused redirect, so a misconfigured dashboard doesn't silently stop receiving updates. A 401 whose pair was withheld by the origin check says so, instead of telling the operator to set what is already set.
- The CLI `DashboardClient`, through a request event hook tied to the configured origin. This needs to be a hook rather than an `httpx.Auth` flow because it has to run on every redirect hop — httpx drops `Authorization` when the origin changes but carries custom headers over, so the pair needs its own check.
- The slime and miles `download` and `convert_checkpoint` functions, which report phase status but never mounted `proxy_auth_secrets()`, so those phases stopped reporting whenever the flag was on.

`deployment.py`, where the helper came from, keeps using it for serve/eval calls; its 401 hint now distinguishes a configured pair withheld from a non-Modal serve URL from no pair at all, naming `TRAINING_GYM_PROXY_AUTH_HOSTS` for the former instead of advising the operator to set what is already set.

One deliberate break to note in the release notes: `_modal_proxy_auth_headers` survives as an alias, but it now takes a URL, so a zero-argument call raises `TypeError` — which matters because the tutorials import it by name inside reward/generate functions that cloudpickle ships to rollout workers, so user code copied from an earlier tutorial fails there rather than at import. The in-repo tutorial call sites are updated; a compatible zero-arg signature was rejected because it would have to either send the pair unconditionally (the leak this guard exists to close) or return nothing and turn the break into a silent 401.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


