### PR TITLE
dashboard: authenticate ingestion before run lookup

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -128,6 +128,9 @@ PASSWORD_EXEMPT_PATHS = frozenset(
     }
 )
 
+# Only ever the *expected* side of a comparison, so publishing it is safe.
+_MISSING_TOKEN_DUMMY = "training-gym-missing-token-dummy-never-issued"
+
 
 def _is_local() -> bool:
     """True when we're not running inside a Modal container."""
@@ -684,6 +687,12 @@ def fastapi_app():
     async def _require_framework_status_token(
         training_run_id: str, authorization: str | None
     ) -> None:
+        """403 unless ``authorization`` carries the run's status token.
+
+        Handlers must call this *before* any lookup that can 404, or the
+        status code tells an anonymous caller which run ids exist. For the
+        same reason an unknown run is indistinguishable from a wrong token.
+        """
         try:
             expected_token = str(
                 (
@@ -696,9 +705,13 @@ def fastapi_app():
             )
         except KeyError:
             expected_token = ""
-        if not expected_token or not _secrets.compare_digest(
-            _bearer_token(authorization), expected_token
-        ):
+        supplied = _bearer_token(authorization)
+        if not expected_token:
+            # Spend the same comparison an existing token would, then refuse
+            # regardless of its outcome.
+            _secrets.compare_digest(supplied, _MISSING_TOKEN_DUMMY)
+            raise HTTPException(status_code=403, detail="Invalid status token")
+        if not _secrets.compare_digest(supplied, expected_token):
             raise HTTPException(status_code=403, detail="Invalid status token")
 
     async def _get_run_or_404(training_run_id: str) -> TrainingRun:
@@ -764,8 +777,8 @@ def fastapi_app():
         update: FrameworkStatusUpdate,
         authorization: str | None = Header(default=None),
     ):
-        run = await _get_run_or_404(update.training_run_id)
         await _require_framework_status_token(update.training_run_id, authorization)
+        run = await _get_run_or_404(update.training_run_id)
 
         status = await run_in_threadpool(run.apply_framework_status, update)
         if status is None:
@@ -787,8 +800,8 @@ def fastapi_app():
         result: TrainingRolloutResult,
         authorization: str | None = Header(default=None),
     ):
-        run = await _get_run_or_404(result.training_run_id)
         await _require_framework_status_token(result.training_run_id, authorization)
+        run = await _get_run_or_404(result.training_run_id)
 
         await result.save(is_async=True)
         run.record_latest_rollout(result)
@@ -831,8 +844,8 @@ def fastapi_app():
         shard: AdvantageDistribution,
         authorization: str | None = Header(default=None),
     ):
-        await _get_run_or_404(shard.training_run_id)
         await _require_framework_status_token(shard.training_run_id, authorization)
+        await _get_run_or_404(shard.training_run_id)
 
         await shard.save(is_async=True)
         return JSONResponse(

--- a/tests/test_dashboard_ingestion_auth.py
+++ b/tests/test_dashboard_ingestion_auth.py
@@ -1,0 +1,140 @@
+"""Ingestion-route authorization."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from modal_training_gym import _dashboard
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.run import TrainingRun
+from modal_training_gym.utils import metadata
+from modal_training_gym.utils.metadata import MetadataStore
+
+RUN_ID = "run-auth-1"
+TOKEN = "test-status-token-run-auth-1"
+
+
+# Each ingestion POST reads training_run_id off a *different* pydantic model,
+# so they are parametrized rather than sampled: an auth check wired to the
+# wrong handler's variable is the mistake this catches.
+ROUTES = [
+    ("/api/framework-status", {"phase": "training"}),
+    ("/api/training-rollouts", {"rollout_id": 1}),
+    ("/api/advantage-distributions", {"rollout_id": 1}),
+]
+ROUTE_IDS = [route.rsplit("/", 1)[-1] for route, _ in ROUTES]
+
+
+def _client(monkeypatch, tmp_path) -> TestClient:
+    static = tmp_path / "static"
+    (static / "assets").mkdir(parents=True)
+    (static / "index.html").write_text("ok")
+    (static / "favicon.svg").write_text("<svg/>")
+    monkeypatch.setattr(_dashboard, "STATIC_DIR", str(static))
+    monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
+    return TestClient(_dashboard.fastapi_app.local())
+
+
+def _save_run(token: str | None = TOKEN) -> None:
+    TrainingRun(
+        training_run_id=RUN_ID,
+        modal_app_id="ap-auth",
+        framework=Framework.SLIME,
+        config={"model": {"model_name": "Qwen/Qwen3-4B"}},
+        created_at=100,
+        started_at=100,
+        updated_at=150,
+    ).save()
+    if token is not None:
+        metadata.vol_put(
+            MetadataStore.FRAMEWORK_STATUS_TOKENS, RUN_ID, {"token": token}
+        )
+
+
+@pytest.mark.parametrize(("route", "extra"), ROUTES, ids=ROUTE_IDS)
+def test_every_rejection_is_indistinguishable(
+    fake_volume, monkeypatch, tmp_path, route, extra
+):
+    """Rejections must not reveal whether a run id exists.
+
+    The handlers used to look the run up (404) before checking the token
+    (403), so an anonymous caller could enumerate real training-run ids by
+    the status code alone. Asserting the responses are *equal* — rather than
+    each being 403 — is what pins the property: it fails just as loudly if a
+    future change makes unknown runs 404 again, or gives any one failure
+    mode a distinguishing body.
+    """
+    _save_run()
+    rejections = {
+        "unknown run, no credentials": ("ghost-run", {}),
+        "unknown run, valid-looking token": ("ghost-run", f"Bearer {TOKEN}"),
+        "real run, no credentials": (RUN_ID, {}),
+        "real run, wrong token": (RUN_ID, "Bearer wrong-token"),
+        "real run, Basic instead of Bearer": (RUN_ID, "Basic dHJhaW5pbmctZ3ltOnB3"),
+        "real run, bare Bearer": (RUN_ID, "Bearer"),
+    }
+
+    seen = {}
+    with _client(monkeypatch, tmp_path) as client:
+        for label, (run_id, auth) in rejections.items():
+            response = client.post(
+                route,
+                json={"training_run_id": run_id, **extra},
+                headers={"Authorization": auth} if isinstance(auth, str) else {},
+            )
+            seen[label] = (response.status_code, response.json())
+
+    refused = (403, {"detail": "Invalid status token"})
+    assert seen == dict.fromkeys(rejections, refused)
+
+
+@pytest.mark.parametrize(("route", "extra"), ROUTES, ids=ROUTE_IDS)
+def test_correct_token_still_reaches_the_handler(
+    fake_volume, monkeypatch, tmp_path, route, extra
+):
+    """The ingestion path every training container depends on."""
+    _save_run()
+    with _client(monkeypatch, tmp_path) as client:
+        response = client.post(
+            route,
+            json={"training_run_id": RUN_ID, **extra},
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+@pytest.mark.parametrize("stored", [None, ""], ids=["no-record", "empty-token"])
+def test_run_with_no_token_on_record_refuses_the_dummy(
+    fake_volume, monkeypatch, tmp_path, stored
+):
+    """The dummy the no-token path compares against must never authenticate.
+
+    That path exists so a missing token record costs the same comparison as
+    a wrong token; the constant is public, so a refactor that let it match
+    would hand every tokenless run a skeleton key.
+    """
+    _save_run(token=stored)
+    with _client(monkeypatch, tmp_path) as client:
+        response = client.post(
+            "/api/framework-status",
+            json={"training_run_id": RUN_ID, "phase": "training"},
+            headers={"Authorization": f"Bearer {_dashboard._MISSING_TOKEN_DUMMY}"},
+        )
+
+    assert response.status_code == 403
+
+
+def test_payload_validation_still_runs_after_auth(fake_volume, monkeypatch, tmp_path):
+    """Authenticating first must not swallow the handler's own 400s."""
+    _save_run()
+    with _client(monkeypatch, tmp_path) as client:
+        response = client.post(
+            "/api/framework-status",
+            json={"training_run_id": RUN_ID, "phase": "not-a-phase"},
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+
+    assert response.status_code == 400


### PR DESCRIPTION
The three ingestion POSTs (`/api/framework-status`, `/api/training-rollouts`, `/api/advantage-distributions`) looked up the run before checking the per-run bearer token. An unknown run returned 404 and a bad token returned 403, so anyone could tell valid training-run ids apart without credentials.

The token check now runs first. A run with no token on record still performs a `compare_digest` against a dummy expected value instead of returning early, so all rejections look the same — same 403, same body, same comparison cost. The dummy only ever sits on the expected side of the comparison, so presenting it as a bearer token still fails.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->