### PR TITLE
Delete advantage distribution in cleanup.py

### DIFF
--- a/modal_training_gym/cli/cleanup.py
+++ b/modal_training_gym/cli/cleanup.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import time
 
+from modal_training_gym.common.advantage_distribution import AdvantageDistribution
 from modal_training_gym.common.run import TrainingRun, TrainingRunStatus
 from modal_training_gym.utils.metadata import (
     MetadataStore,
     vol_get_summary_items,
     vol_put_summary_items,
     vol_remove,
+    vol_remove_keys_with_prefix,
 )
+
 
 TERMINAL_STATUSES = frozenset({TrainingRunStatus.FAILED, TrainingRunStatus.CANCELLED})
 
@@ -65,6 +68,10 @@ def cleanup(*, older_than_days: int = 7, dry_run: bool = False) -> None:
         if vol_remove(MetadataStore.TRAINING_RUNS, rid):
             deleted_runs += 1
         vol_remove(MetadataStore.FRAMEWORK_STATUS_TOKENS, rid)
+        vol_remove_keys_with_prefix(
+            MetadataStore.ADVANTAGE_DISTRIBUTIONS,
+            AdvantageDistribution.run_prefix(rid),
+        )
         deleted_tokens += 1
 
     rollout_summary = (

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -294,6 +294,29 @@ def vol_list_prefix(store: MetadataStore | str, prefix: str) -> list[dict[str, A
     return results
 
 
+def vol_remove_keys_with_prefix(store: MetadataStore | str, prefix: str) -> int:
+    """Delete every item whose key (file basename) starts with ``prefix``.
+
+    Reads directory entries only (unlike vol_list_prefix). Returns the number of items removed.
+    """
+    from modal.exception import NotFoundError
+
+    vol = _metadata_volume()
+    _safe_reload(vol)
+    try:
+        entries = list(vol.iterdir(_store_path(store)))
+    except (FileNotFoundError, NotFoundError):
+        return 0
+    removed = 0
+    for entry in entries:
+        name = entry.path.rsplit("/", 1)[-1]
+        if not name.endswith(".json") or not name.startswith(prefix):
+            continue
+        if vol_remove(store, name[: -len(".json")]):
+            removed += 1
+    return removed
+
+
 def vol_count_items(store: MetadataStore | str) -> int:
     """Count canonical ``.json`` files in a store without reading them.
 


### PR DESCRIPTION
cleanup.py should delete both rollouts and advantage distribution storage. Created new function in metadata.py to keep accessing volume abstract while not iterating through everything in the volume while deleting -- using list_prefix then deleting would list all rollout infromation which is slow for long runs. fucntion should also be usable for step itme deletion in the future

Update cleanup.py to delete advantage-distribution storage in addition to training rollouts.

Added a new helper (vol_remove_keys_with_prefix) in metadata.py to keep volume access abstract and avoid iterating through the entire volume during deletion (using vol_list_prefix and then deleting would enumerate all rollout information, which is slow for long runs. This helper also should work for step-time deletion in the future.)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->