### PR TITLE
Strip auth headers on cross-origin redirects in status POSTs

### DIFF
--- a/modal_training_gym/_safe_http.py
+++ b/modal_training_gym/_safe_http.py
@@ -1,0 +1,113 @@
+"""Small stdlib-only HTTP helpers that strip auth headers on cross-origin redirects.
+
+Used by fire-and-forget status reporters inside training containers, where adding
+``httpx``/third-party clients is undesirable.  ``urllib.request`` forwards custom
+headers on redirects by default, so a compromised dashboard host (or any redirect
+to an attacker-controlled host) would leak credentials.  The helpers below
+remove sensitive headers before following any redirect whose scheme or host
+differs from the original request, and refuse to follow cross-origin redirects
+entirely.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+
+class _CrossOriginSafeRedirectHandler(HTTPRedirectHandler):
+    """Follow redirects, but never forward sensitive auth headers to another origin."""
+
+    _SENSITIVE_HEADERS = frozenset(
+        {
+            "authorization",
+            "modal-key",
+            "modal-secret",
+            "proxy-authorization",
+        }
+    )
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        m = req.get_method()
+        # Follow the same redirects urllib follows by default, plus preserve-method
+        # 307/308 redirects for POST.  Refuse everything else.
+        if not (
+            (code in (301, 302, 303, 307, 308) and m in ("GET", "HEAD"))
+            or (code in (301, 302, 303, 307, 308) and m == "POST")
+        ):
+            raise HTTPError(req.full_url, code, msg, headers, fp)
+
+        # 301/302/303 historically collapse POST -> GET and drop the body.
+        new_method = m
+        new_data = req.data
+        if code in (301, 302, 303) and m == "POST":
+            new_method = "GET"
+            new_data = None
+
+        # Drop content headers when the body is dropped; preserve Content-Type
+        # when the body is preserved (Content-Length is recomputed by Request).
+        drop_headers = {"content-length"}
+        if new_data is None:
+            drop_headers.add("content-type")
+        newheaders = {
+            k: v for k, v in req.headers.items() if k.lower() not in drop_headers
+        }
+
+        old = urlsplit(req.full_url)
+        new = urlsplit(newurl)
+        same_origin = (
+            old.scheme.lower(),
+            old.netloc.lower(),
+        ) == (
+            new.scheme.lower(),
+            new.netloc.lower(),
+        )
+
+        new_req = Request(
+            newurl,
+            data=new_data,
+            headers=newheaders,
+            origin_req_host=req.origin_req_host,
+            unverifiable=True,
+            method=new_method,
+        )
+
+        if not same_origin:
+            for name in self._SENSITIVE_HEADERS:
+                if new_req.has_header(name):
+                    new_req.remove_header(name)
+            # Refuse to follow cross-origin redirects. The destination is not the
+            # configured dashboard and should not receive the request body.
+            raise URLError(
+                f"refusing cross-origin redirect from {old.netloc} to {new.netloc}"
+            )
+
+        return new_req
+
+
+def origin(url: str) -> str | None:
+    """Return the ``scheme://netloc`` origin of ``url`` in lowercase, or ``None``."""
+    parsed = urlsplit(url)
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+    return None
+
+
+def post(
+    url: str,
+    body: bytes,
+    headers: dict[str, str],
+    timeout: float | None = None,
+) -> Any:
+    """POST ``body`` to ``url`` and return the response object.
+
+    Redirects are followed, but ``Authorization``, ``Modal-Key``,
+    ``Modal-Secret``, and ``Proxy-Authorization`` headers are removed before
+    following any redirect whose scheme or host differs from the original URL,
+    and cross-origin redirects are blocked entirely.
+    """
+    request = Request(url, data=body, headers=headers, method="POST")
+    opener = build_opener(_CrossOriginSafeRedirectHandler)
+    return opener.open(request, timeout=timeout)

--- a/modal_training_gym/common/status_reporter.py
+++ b/modal_training_gym/common/status_reporter.py
@@ -25,7 +25,8 @@ import threading
 from queue import Queue
 from typing import Any
 from urllib.error import URLError
-from urllib.request import Request, urlopen
+
+from modal_training_gym._safe_http import origin, post as _post_request
 
 
 # Shared with slime's phase_reporting, whose rollout payloads can be 100KB+ —
@@ -88,18 +89,16 @@ def _post(item: dict[str, Any]) -> None:
     token = str(item.pop("_token", "") or "").strip()
     if not url:
         return
+    # Only post to URLs that belong to the configured dashboard origin.
+    configured_url = _resolve_url()
+    if configured_url and origin(url) != origin(configured_url):
+        return
     body = json.dumps(item, default=str).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    request = Request(
-        url,
-        data=body,
-        headers=headers,
-        method="POST",
-    )
     try:
-        with urlopen(request, timeout=timeout) as response:
+        with _post_request(url, body, headers, timeout=timeout) as response:
             response.read()
     except (OSError, URLError):
         return
@@ -138,8 +137,12 @@ def enqueue_framework_status(
     Returns immediately. If no dashboard URL is configured the call is a
     silent no-op.
     """
-    resolved = (url or "").strip() or _resolve_url()
+    configured = _resolve_url()
+    resolved = (url or "").strip() or configured
     if not resolved or not training_run_id or not phase:
+        return
+    # Reject an explicit URL that does not match the configured dashboard origin.
+    if configured and origin(resolved) != origin(configured):
         return
     _ensure_worker()
     payload: dict[str, Any] = {

--- a/modal_training_gym/frameworks/slime/reporting.py
+++ b/modal_training_gym/frameworks/slime/reporting.py
@@ -14,7 +14,8 @@ import threading
 from queue import Queue
 from typing import Any
 from urllib.error import URLError
-from urllib.request import Request, urlopen
+
+from modal_training_gym._safe_http import origin, post as _post_request
 
 PHASE_REPORT_URL_ENV = "SLIME_PHASE_REPORT_URL"
 PHASE_REPORT_TOKEN_ENV = "SLIME_PHASE_REPORT_TOKEN"
@@ -208,19 +209,18 @@ def _post(item: dict[str, Any]) -> None:
     if not url:
         return
 
+    # Only post to URLs that belong to the configured dashboard origin.
+    base_url = _phase_url()
+    if base_url and origin(url) != origin(base_url):
+        return
+
     body = json.dumps(item, default=str).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     token = _report_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    request = Request(
-        url,
-        data=body,
-        headers=headers,
-        method="POST",
-    )
     try:
-        with urlopen(request, timeout=timeout) as response:
+        with _post_request(url, body, headers, timeout=timeout) as response:
             response.read()
     except (OSError, URLError):
         return


### PR DESCRIPTION
Fixes a credential-leak vector in the fire-and-forget status reporters.

`common/status_reporter.py` and `frameworks/slime/reporting.py` POSTed to dashboard URLs with `urllib.request.urlopen`, which preserves custom headers (including `Authorization` and any future `Modal-Key`/`Modal-Secret`) when following redirects. A compromised dashboard host returning a cross-origin redirect would therefore forward those credentials to an attacker.

Changes:
- Add `modal_training_gym/_safe_http.py`: a stdlib-only helper that follows redirects but strips `Authorization`, `Modal-Key`, `Modal-Secret`, and `Proxy-Authorization` when the scheme or host changes, and refuses to follow cross-origin redirects.
- Route both `_post` implementations through the helper.
- Validate explicit `url` arguments and queued item `_url` values against the configured dashboard origin in `status_reporter.py`, and against the configured phase URL origin in `reporting.py`.

## Test plan
- Manually verified with a local HTTP server: cross-origin 302 redirects are refused, same-origin 302 redirects keep auth, and same-origin 307 redirects preserve the POST body.
- `uv run ruff check modal_training_gym/` and `uv run python -m compileall modal_training_gym/` pass.

Link to Devin session: https://modal.devinenterprise.com/sessions/bdf63600feee40509f981dda0a50418c
Requested by: @joyliu-q