### PR TITLE
Check live dashboard for proxy auth state on deploy

### DIFF
--- a/docs-next/src/content/docs/reference/cli.md
+++ b/docs-next/src/content/docs/reference/cli.md
@@ -17,14 +17,6 @@ Deploy the observability dashboard to your Modal account.
 training-gym setup
 ```
 
-This is equivalent to calling `setup()` from Python:
-
-```python
-import modal_training_gym
-
-modal_training_gym.setup()
-```
-
 The command builds a Modal image (Node.js + Svelte frontend + FastAPI backend),
 deploys it as a persistent web app, and prints the dashboard URL.
 

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -88,7 +88,6 @@ _EXPORTS = {
     "TrainingGymError": ("modal_training_gym.common.errors", "TrainingGymError"),
     "TrainingGroup": ("modal_training_gym.common.training_group", "TrainingGroup"),
     "TrainResult": ("modal_training_gym.common.train_result", "TrainResult"),
-    "setup": ("modal_training_gym.cli.setup", "setup"),
     "WandbConfig": ("modal_training_gym.common.wandb", "WandbConfig"),
 }
 
@@ -137,7 +136,6 @@ __all__ = [
     "Qwen3_VL_8b_Recipe",
     "score_in_sandbox",
     "SlimeRecipe",
-    "setup",
     "ToolCall",
     "TrainConfig",
     "TrainingGymConfigError",

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -56,8 +56,6 @@ from modal_training_gym.common.training_rollout import (
     TrainingRolloutSummary,
 )
 
-_DASHBOARD_REQUIRES_PROXY_AUTH = dashboard_requires_proxy_auth()
-
 SummaryLoader = Callable[[], Awaitable[list[JsonDict]]]
 
 
@@ -72,6 +70,8 @@ class LogEntry(TypedDict):
 
 REPO_URL = "https://github.com/modal-projects/training-gym.git"
 REPO_BRANCH = "main"
+
+DASHBOARD_REQUIRES_PROXY_AUTH_ENV_KEY = "DASHBOARD_REQUIRES_PROXY_AUTH"
 
 _repo_frontend = Path(__file__).resolve().parents[1] / "dashboards" / "frontend"
 _has_local_frontend = _repo_frontend.is_dir()
@@ -102,9 +102,13 @@ def _build_image() -> modal.Image:
             "rm -rf /tmp/training-gym",
         )
 
-    return base.run_commands(
-        "cd /app/frontend && npm install && npm run build",
-    ).add_local_python_source("modal_training_gym", copy=True)
+    return (
+        base.run_commands("cd /app/frontend && npm install && npm run build")
+        .add_local_python_source("modal_training_gym", copy=True)
+        .env({
+            DASHBOARD_REQUIRES_PROXY_AUTH_ENV_KEY: "true" if dashboard_requires_proxy_auth() else "false"
+        })
+    )
 
 
 image = _build_image()
@@ -365,7 +369,7 @@ def reconcile() -> None:
     min_containers=1,
     secrets=_function_secrets(),
 )
-@modal.asgi_app(requires_proxy_auth=_DASHBOARD_REQUIRES_PROXY_AUTH)
+@modal.asgi_app(requires_proxy_auth=dashboard_requires_proxy_auth())
 def fastapi_app():
     import base64
     import binascii
@@ -423,7 +427,7 @@ def fastapi_app():
 
     @web.get(DASHBOARD_PROXY_AUTH_PATH)
     async def proxy_auth_status() -> bool:
-        return _DASHBOARD_REQUIRES_PROXY_AUTH
+        return os.environ.get(DASHBOARD_REQUIRES_PROXY_AUTH_ENV_KEY, "false") == "true"
 
     cache_ttl_seconds = 30.0
     cache_keys = ("runs", "train_results", "evals", "deployments")

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -35,7 +35,10 @@ from starlette.requests import Request
 # Used as endpoint parameter annotations, so — like ``Request`` above — these
 # must resolve from this module's globals.
 from modal_training_gym.common.advantage_distribution import AdvantageDistribution
-from modal_training_gym.common.config import dashboard_requires_proxy_auth
+from modal_training_gym.common.config import (
+    DASHBOARD_PROXY_AUTH_PATH,
+    dashboard_requires_proxy_auth,
+)
 from modal_training_gym.common.run import FrameworkStatusUpdate, TrainingRun
 from modal_training_gym.common.run_list import (
     filter_run_summaries,
@@ -52,6 +55,8 @@ from modal_training_gym.common.training_rollout import (
     TrainingRolloutResult,
     TrainingRolloutSummary,
 )
+
+_DASHBOARD_REQUIRES_PROXY_AUTH = dashboard_requires_proxy_auth()
 
 SummaryLoader = Callable[[], Awaitable[list[JsonDict]]]
 
@@ -118,11 +123,12 @@ MODAL_CREDS_SECRET_NAME = "_training-gym-modal-creds"
 # Set a real value via ``training-gym set-password``.
 DASHBOARD_PASSWORD_SECRET_NAME = "_training-gym-dashboard-password"
 
-# Write endpoints authenticated by their own per-run bearer token. They're
-# exempt from Basic Auth so launchers (which send ``Authorization: Bearer``)
-# keep working even when a dashboard password is set.
+# Routes that must bypass Basic Auth. Write endpoints authenticate with their
+# own per-run bearer token; the proxy-auth status route must report only the
+# Modal-layer setting, independent of dashboard password protection.
 PASSWORD_EXEMPT_PATHS = frozenset(
     {
+        DASHBOARD_PROXY_AUTH_PATH,
         "/api/framework-status",
         "/api/training-rollouts",
         "/api/advantage-distributions",
@@ -359,7 +365,7 @@ def reconcile() -> None:
     min_containers=1,
     secrets=_function_secrets(),
 )
-@modal.asgi_app(requires_proxy_auth=dashboard_requires_proxy_auth())
+@modal.asgi_app(requires_proxy_auth=_DASHBOARD_REQUIRES_PROXY_AUTH)
 def fastapi_app():
     import base64
     import binascii
@@ -414,6 +420,10 @@ def fastapi_app():
                     headers={"WWW-Authenticate": 'Basic realm="training-gym"'},
                 )
         return await call_next(request)
+
+    @web.get(DASHBOARD_PROXY_AUTH_PATH)
+    async def proxy_auth_status() -> bool:
+        return _DASHBOARD_REQUIRES_PROXY_AUTH
 
     cache_ttl_seconds = 30.0
     cache_keys = ("runs", "train_results", "evals", "deployments")

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -105,9 +105,13 @@ def _build_image() -> modal.Image:
     return (
         base.run_commands("cd /app/frontend && npm install && npm run build")
         .add_local_python_source("modal_training_gym", copy=True)
-        .env({
-            DASHBOARD_REQUIRES_PROXY_AUTH_ENV_KEY: "true" if dashboard_requires_proxy_auth() else "false"
-        })
+        .env(
+            {
+                DASHBOARD_REQUIRES_PROXY_AUTH_ENV_KEY: "true"
+                if dashboard_requires_proxy_auth()
+                else "false"
+            }
+        )
     )
 
 

--- a/modal_training_gym/cli/builtin.py
+++ b/modal_training_gym/cli/builtin.py
@@ -25,13 +25,17 @@ def setup_command(proxy_auth: bool, no_proxy_auth: bool) -> None:
             "--proxy-auth and --no-proxy-auth cannot be used together."
         )
 
-    from .setup import ProxyAuthChoiceRequired, setup
-
-    selected = True if proxy_auth else False if no_proxy_auth else None
-    try:
-        setup(proxy_auth=selected)
-    except ProxyAuthChoiceRequired as exc:
-        raise click.UsageError(str(exc)) from exc
+    from .setup import setup
+    from modal_training_gym.common.config import get_dashboard_proxy_auth
+    
+    if not proxy_auth and not no_proxy_auth:
+        if get_dashboard_proxy_auth() is True:
+            raise click.UsageError(
+                "The deployed dashboard uses proxy auth. "
+                "Pass either --proxy-auth or --no-proxy-auth explicitly."
+            )
+    
+    setup(require_proxy_auth=proxy_auth)
 
 
 @click.command("open", cls=_TrainingGymCommand)

--- a/modal_training_gym/cli/builtin.py
+++ b/modal_training_gym/cli/builtin.py
@@ -27,14 +27,14 @@ def setup_command(proxy_auth: bool, no_proxy_auth: bool) -> None:
 
     from .setup import setup
     from modal_training_gym.common.config import get_dashboard_proxy_auth
-    
+
     if not proxy_auth and not no_proxy_auth:
         if get_dashboard_proxy_auth() is True:
             raise click.UsageError(
                 "The deployed dashboard uses proxy auth. "
                 "Pass either --proxy-auth or --no-proxy-auth explicitly."
             )
-    
+
     setup(require_proxy_auth=proxy_auth)
 
 

--- a/modal_training_gym/cli/setup.py
+++ b/modal_training_gym/cli/setup.py
@@ -1,9 +1,5 @@
 """Deploy the training-gym dashboard to Modal.
 
-Usage (Python):
-    import modal_training_gym
-    modal_training_gym.setup()
-
 Usage (CLI):
     training-gym setup
 

--- a/modal_training_gym/cli/setup.py
+++ b/modal_training_gym/cli/setup.py
@@ -57,7 +57,7 @@ def _resolve_dashboard_proxy_auth(proxy_auth: bool | None) -> bool:
 
     if get_dashboard_proxy_auth() is True:
         raise ProxyAuthChoiceRequired(
-            "The dashboard was last deployed with proxy auth. "
+            "The deployed dashboard uses proxy auth. "
             "Pass either --proxy-auth or --no-proxy-auth explicitly."
         )
     return False

--- a/modal_training_gym/cli/setup.py
+++ b/modal_training_gym/cli/setup.py
@@ -31,10 +31,6 @@ DASHBOARD_APP_NAME = "training-gym-dashboard"
 DASHBOARD_WEB_FUNCTION = "fastapi_app"
 
 
-class ProxyAuthChoiceRequired(ValueError):
-    """Raised when an authenticated redeploy requires an explicit CLI choice."""
-
-
 def _load_dashboard_for_deploy(requires_proxy_auth: bool):
     """Import the declarative dashboard with the selected ASGI proxy-auth mode."""
     import importlib
@@ -49,21 +45,7 @@ def _load_dashboard_for_deploy(requires_proxy_auth: bool):
     return importlib.import_module(module_name)
 
 
-def _resolve_dashboard_proxy_auth(proxy_auth: bool | None) -> bool:
-    if proxy_auth is not None:
-        return proxy_auth
-
-    from modal_training_gym.common.config import get_dashboard_proxy_auth
-
-    if get_dashboard_proxy_auth() is True:
-        raise ProxyAuthChoiceRequired(
-            "The deployed dashboard uses proxy auth. "
-            "Pass either --proxy-auth or --no-proxy-auth explicitly."
-        )
-    return False
-
-
-def setup(interactive: bool = True, proxy_auth: bool | None = None) -> str:
+def setup(require_proxy_auth: bool, interactive: bool = True) -> str:
     """Deploy the training-gym dashboard, persist its URL, and return it.
 
     ``interactive=False`` resolves Modal credentials silently (from env vars
@@ -72,14 +54,19 @@ def setup(interactive: bool = True, proxy_auth: bool | None = None) -> str:
     """
     import modal
 
-    requires_proxy_auth = _resolve_dashboard_proxy_auth(proxy_auth)
-
     from modal_training_gym.common.config import CONFIG_PATH, save_dashboard_url
 
-    dashboard = _load_dashboard_for_deploy(requires_proxy_auth)
+    if require_proxy_auth:
+        print("Deploying dashboard with proxy authentication enabled.")
+    else:
+        print("This dashboard will not have proxy authentication enabled.")
+        print("If you would like to enable it, run `training-gym setup --proxy-auth`.")
+        print()
+
+    dashboard = _load_dashboard_for_deploy(require_proxy_auth)
 
     has_proxy_auth_token = ensure_proxy_auth(interactive=interactive)
-    if requires_proxy_auth and not has_proxy_auth_token:
+    if require_proxy_auth and not has_proxy_auth_token:
         print(
             "WARNING: Dashboard proxy auth requires MODAL_KEY and MODAL_SECRET. "
             "Run `training-gym set-proxy-auth` or export both variables."
@@ -96,7 +83,7 @@ def setup(interactive: bool = True, proxy_auth: bool | None = None) -> str:
         dashboard.app.deploy()
 
     web_url = dashboard.fastapi_app.get_web_url()
-    save_dashboard_url(web_url, proxy_auth=requires_proxy_auth)
+    save_dashboard_url(web_url, proxy_auth=require_proxy_auth)
     print(f"\nDashboard deployed: {web_url}")
     print(f"Saved dashboard URL to {CONFIG_PATH}")
     return web_url
@@ -224,7 +211,7 @@ def set_password(password: str | None = None) -> None:
 
     setup(
         interactive=False,
-        proxy_auth=get_dashboard_proxy_auth(),
+        require_proxy_auth=get_dashboard_proxy_auth(),
     )
 
 
@@ -307,7 +294,7 @@ def ensure_dashboard_deployed() -> str | None:
         )
         return setup(
             interactive=False,
-            proxy_auth=get_dashboard_proxy_auth() is True,
+            require_proxy_auth=get_dashboard_proxy_auth() is True,
         )
     except Exception as exc:
         print(

--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -86,22 +86,34 @@ def get_dashboard_proxy_auth() -> bool | None:
         persisted = None
 
     url = dashboard.get("url")
-    if not isinstance(url, str) or not url.strip():
-        return persisted
+    if isinstance(url, str) and url.strip():
+        request = Request(
+            url.strip().rstrip("/") + DASHBOARD_PROXY_AUTH_PATH,
+            headers=modal_proxy_auth_headers(),
+        )
+        try:
+            with urlopen(request, timeout=5) as response:
+                value = loads(response.read())
+                if isinstance(value, bool):
+                    if value:
+                        print("The deployed dashboard uses proxy authentication.")
+                    else:
+                        print("The deployed dashboard does not use proxy authentication.")
+                    return value
+        except HTTPError as exc:
+            if exc.code in {401, 403}:
+                print("The deployed dashboard appears to use proxy authentication.")
+                return True
+            elif exc.code != 404:
+                raise
 
-    request = Request(
-        url.strip().rstrip("/") + DASHBOARD_PROXY_AUTH_PATH,
-        headers=modal_proxy_auth_headers(),
-    )
-    try:
-        with urlopen(request, timeout=5) as response:
-            value = loads(response.read())
-            return value if isinstance(value, bool) else persisted
-    except HTTPError as exc:
-        if exc.code == 403:
-            return True
-    except (JSONDecodeError, OSError, URLError, UnicodeDecodeError):
-        pass
+    if persisted is not None:
+        print("Unable to reach existing dashboard.")
+        if persisted:
+            print("The last deploy from this computer used proxy authentication.")
+        else:
+            print("The last deploy from this computer did not use proxy authentication.")
+
     return persisted
 
 

--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -98,7 +98,9 @@ def get_dashboard_proxy_auth() -> bool | None:
                     if value:
                         print("The deployed dashboard uses proxy authentication.")
                     else:
-                        print("The deployed dashboard does not use proxy authentication.")
+                        print(
+                            "The deployed dashboard does not use proxy authentication."
+                        )
                     return value
         except HTTPError as exc:
             if exc.code in {401, 403}:
@@ -106,13 +108,17 @@ def get_dashboard_proxy_auth() -> bool | None:
                 return True
             elif exc.code != 404:
                 raise
+        except (JSONDecodeError, OSError, URLError, UnicodeDecodeError):
+            pass
 
     if persisted is not None:
         print("Unable to reach existing dashboard.")
         if persisted:
             print("The last deploy from this computer used proxy authentication.")
         else:
-            print("The last deploy from this computer did not use proxy authentication.")
+            print(
+                "The last deploy from this computer did not use proxy authentication."
+            )
 
     return persisted
 

--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import os
 import tomllib
+from json import JSONDecodeError, loads
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 
 CONFIG_PATH = Path.home() / ".training-gym.toml"
@@ -18,6 +21,7 @@ MODAL_CONFIG_PATH = Path(
 )
 
 _dashboard_requires_proxy_auth = False
+DASHBOARD_PROXY_AUTH_PATH = "/api/proxy-auth"
 
 
 def set_dashboard_requires_proxy_auth(value: bool) -> None:
@@ -66,13 +70,39 @@ def get_dashboard_url() -> str | None:
 
 
 def get_dashboard_proxy_auth() -> bool | None:
-    """Return the last deployed dashboard proxy-auth mode, if recorded."""
+    """Return the deployed dashboard's proxy-auth mode, if known.
+
+    The live endpoint is authoritative. Modal itself returns 403 before a
+    proxy-authenticated dashboard request reaches FastAPI, so that status also
+    identifies an authenticated deployment. The persisted mode remains a
+    fallback for older or temporarily unreachable dashboards.
+    """
     dashboard = load_config().get("dashboard")
-    if isinstance(dashboard, dict):
-        proxy_auth = dashboard.get("proxy_auth")
-        if isinstance(proxy_auth, bool):
-            return proxy_auth
-    return None
+    if not isinstance(dashboard, dict):
+        return None
+
+    persisted = dashboard.get("proxy_auth")
+    if not isinstance(persisted, bool):
+        persisted = None
+
+    url = dashboard.get("url")
+    if not isinstance(url, str) or not url.strip():
+        return persisted
+
+    request = Request(
+        url.strip().rstrip("/") + DASHBOARD_PROXY_AUTH_PATH,
+        headers=modal_proxy_auth_headers(),
+    )
+    try:
+        with urlopen(request, timeout=5) as response:
+            value = loads(response.read())
+            return value if isinstance(value, bool) else persisted
+    except HTTPError as exc:
+        if exc.code == 403:
+            return True
+    except (JSONDecodeError, OSError, URLError, UnicodeDecodeError):
+        pass
+    return persisted
 
 
 PROXY_AUTH_SECTION = "proxy_auth"

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -64,12 +64,15 @@ def test_main_returns_no_command_exit_code(capsys):
 def test_setup_dispatches_to_existing_function(runner, monkeypatch):
     setup = Mock()
     monkeypatch.setattr("modal_training_gym.cli.setup.setup", setup)
+    monkeypatch.setattr(
+        "modal_training_gym.common.config.get_dashboard_proxy_auth", lambda: False
+    )
 
     result = runner.invoke(cli_module.entrypoint_cli, ["setup"])
 
     assert result.exit_code == 0
     assert result.stderr == ""
-    setup.assert_called_once_with(proxy_auth=None)
+    setup.assert_called_once_with(require_proxy_auth=False)
 
 
 @pytest.mark.parametrize(
@@ -86,7 +89,7 @@ def test_setup_preserves_proxy_auth_choice(runner, monkeypatch, flag, expected):
     result = runner.invoke(cli_module.entrypoint_cli, ["setup", flag])
 
     assert result.exit_code == 0
-    setup.assert_called_once_with(proxy_auth=expected)
+    setup.assert_called_once_with(require_proxy_auth=expected)
 
 
 def test_setup_rejects_both_proxy_auth_flags(runner):
@@ -102,19 +105,17 @@ def test_setup_rejects_both_proxy_auth_flags(runner):
 def test_setup_prompts_for_explicit_choice_after_authenticated_deploy(
     runner, monkeypatch
 ):
-    from modal_training_gym.cli.setup import ProxyAuthChoiceRequired
-
-    setup = Mock(
-        side_effect=ProxyAuthChoiceRequired(
-            "Pass either --proxy-auth or --no-proxy-auth explicitly."
-        )
-    )
+    setup = Mock()
     monkeypatch.setattr("modal_training_gym.cli.setup.setup", setup)
+    monkeypatch.setattr(
+        "modal_training_gym.common.config.get_dashboard_proxy_auth", lambda: True
+    )
 
     result = runner.invoke(cli_module.entrypoint_cli, ["setup"])
 
     assert result.exit_code == 2
     assert "--proxy-auth or --no-proxy-auth" in result.stderr
+    setup.assert_not_called()
 
 
 def test_open_dispatches_to_existing_function(runner, monkeypatch):
@@ -193,6 +194,9 @@ def test_expected_errors_use_declared_exit_code(runner, monkeypatch):
         )
 
     monkeypatch.setattr("modal_training_gym.cli.setup.setup", fail)
+    monkeypatch.setattr(
+        "modal_training_gym.common.config.get_dashboard_proxy_auth", lambda: False
+    )
 
     result = runner.invoke(cli_module.entrypoint_cli, ["setup"])
 
@@ -253,6 +257,9 @@ def test_main_maps_click_keyboard_interrupt_to_130(monkeypatch, capsys):
     monkeypatch.setattr(
         "modal_training_gym.cli.setup.setup",
         interrupt,
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.config.get_dashboard_proxy_auth", lambda: False
     )
 
     assert cli_module.main(["setup"]) == 130

--- a/tests/test_dashboard_proxy_auth.py
+++ b/tests/test_dashboard_proxy_auth.py
@@ -69,17 +69,6 @@ def test_dashboard_proxy_auth_treats_403_as_enabled(config_path, monkeypatch):
     assert config.get_dashboard_proxy_auth() is True
 
 
-def test_unspecified_mode_defaults_to_no_proxy_auth(config_path):
-    assert cli_setup_module._resolve_dashboard_proxy_auth(None) is False
-
-
-def test_unspecified_mode_requires_choice_after_proxy_auth(config_path):
-    config.save_dashboard_url("https://dashboard.test", proxy_auth=True)
-
-    with pytest.raises(cli_setup_module.ProxyAuthChoiceRequired):
-        cli_setup_module._resolve_dashboard_proxy_auth(None)
-
-
 def test_proxy_auth_status_does_not_require_basic_auth(monkeypatch, tmp_path):
     static = tmp_path / "static"
     (static / "assets").mkdir(parents=True)
@@ -139,7 +128,7 @@ def test_auto_deploy_reuses_proxy_auth_mode(monkeypatch, last_proxy_auth, expect
     monkeypatch.setattr(cli_setup_module, "setup", setup)
 
     assert cli_setup_module.ensure_dashboard_deployed() == "https://dashboard.test"
-    assert calls == [{"interactive": False, "proxy_auth": expected}]
+    assert calls == [{"interactive": False, "require_proxy_auth": expected}]
 
 
 def _capture_report(reporter, monkeypatch):

--- a/tests/test_dashboard_proxy_auth.py
+++ b/tests/test_dashboard_proxy_auth.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import importlib
 import sys
 from types import SimpleNamespace
+from urllib.error import HTTPError, URLError
 
 import pytest
+from fastapi.testclient import TestClient
 
+from modal_training_gym import _dashboard
 from modal_training_gym.cli import setup as cli_setup_module
 from modal_training_gym.common import config
 from modal_training_gym.common import status_reporter
@@ -13,6 +16,9 @@ from modal_training_gym.frameworks.slime import reporting
 
 
 class _Response:
+    def __init__(self, body: bytes = b""):
+        self.body = body
+
     def __enter__(self):
         return self
 
@@ -20,7 +26,7 @@ class _Response:
         return None
 
     def read(self):
-        return b""
+        return self.body
 
 
 @pytest.fixture
@@ -30,12 +36,37 @@ def config_path(tmp_path, monkeypatch):
     return path
 
 
-def test_dashboard_proxy_auth_mode_is_persisted(config_path):
+def test_dashboard_proxy_auth_mode_is_persisted(config_path, monkeypatch):
+    def unavailable(*_args, **_kwargs):
+        raise URLError("unavailable")
+
+    monkeypatch.setattr(config, "urlopen", unavailable)
     config.save_dashboard_url("https://dashboard.test", proxy_auth=True)
 
     assert config.get_dashboard_url() == "https://dashboard.test"
     assert config.get_dashboard_proxy_auth() is True
     assert "proxy_auth = true" in config_path.read_text()
+
+
+@pytest.mark.parametrize(("body", "expected"), [(b"true", True), (b"false", False)])
+def test_live_dashboard_proxy_auth_mode_is_authoritative(
+    config_path, monkeypatch, body, expected
+):
+    config.save_dashboard_url("https://dashboard.test", proxy_auth=not expected)
+    monkeypatch.setattr(config, "urlopen", lambda *_args, **_kwargs: _Response(body))
+
+    assert config.get_dashboard_proxy_auth() is expected
+
+
+def test_dashboard_proxy_auth_treats_403_as_enabled(config_path, monkeypatch):
+    config.save_dashboard_url("https://dashboard.test", proxy_auth=False)
+
+    def forbidden(*_args, **_kwargs):
+        raise HTTPError("https://dashboard.test", 403, "Forbidden", {}, None)
+
+    monkeypatch.setattr(config, "urlopen", forbidden)
+
+    assert config.get_dashboard_proxy_auth() is True
 
 
 def test_unspecified_mode_defaults_to_no_proxy_auth(config_path):
@@ -47,6 +78,22 @@ def test_unspecified_mode_requires_choice_after_proxy_auth(config_path):
 
     with pytest.raises(cli_setup_module.ProxyAuthChoiceRequired):
         cli_setup_module._resolve_dashboard_proxy_auth(None)
+
+
+def test_proxy_auth_status_does_not_require_basic_auth(monkeypatch, tmp_path):
+    static = tmp_path / "static"
+    (static / "assets").mkdir(parents=True)
+    (static / "index.html").write_text("ok")
+    (static / "favicon.svg").write_text("<svg/>")
+    monkeypatch.setattr(_dashboard, "STATIC_DIR", str(static))
+    monkeypatch.setattr(config, "_dashboard_requires_proxy_auth", False)
+    monkeypatch.setenv("DASHBOARD_PASSWORD", "password")
+
+    with TestClient(_dashboard.fastapi_app.local()) as client:
+        response = client.get(config.DASHBOARD_PROXY_AUTH_PATH)
+
+    assert response.status_code == 200
+    assert response.json() is False
 
 
 def test_dashboard_import_sets_proxy_auth_mode(monkeypatch):


### PR DESCRIPTION
Follow up to #313 that adds an API endpoint to the dashboard to check whether proxy auth is on. That way, the setup flow (or any other flow that auto-deploys the dashboard) can match that proxy auth state instead of relying on a potentially stale or missing local config.

This PR also adds some logging that provides visibility into how proxy auth state is being checked and whether it is being set:

<img width="572" height="72" alt="Logging example" src="https://github.com/user-attachments/assets/602c2151-9185-447a-bd4a-a61c7d19e27c" />

Finally, it also moves some of the logic for checking the flags outside of the `setup` function itself.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->