### PR TITLE
Fix a few edge cases for proxy auth setup

### DIFF
--- a/modal_training_gym/cli/setup.py
+++ b/modal_training_gym/cli/setup.py
@@ -207,7 +207,7 @@ def set_password(password: str | None = None) -> None:
 
     setup(
         interactive=False,
-        require_proxy_auth=get_dashboard_proxy_auth(),
+        require_proxy_auth=get_dashboard_proxy_auth() is True,
     )
 
 

--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -14,6 +14,8 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from modal_training_gym.cli.setup import deployed_dashboard_url
+
 
 CONFIG_PATH = Path.home() / ".training-gym.toml"
 MODAL_CONFIG_PATH = Path(
@@ -79,13 +81,13 @@ def get_dashboard_proxy_auth() -> bool | None:
     """
     dashboard = load_config().get("dashboard")
     if not isinstance(dashboard, dict):
-        return None
+        dashboard = {}
 
     persisted = dashboard.get("proxy_auth")
     if not isinstance(persisted, bool):
         persisted = None
 
-    url = dashboard.get("url")
+    url = dashboard.get("url") or deployed_dashboard_url()
     if isinstance(url, str) and url.strip():
         request = Request(
             url.strip().rstrip("/") + DASHBOARD_PROXY_AUTH_PATH,


### PR DESCRIPTION
Fixes two edge cases around proxy auth from #315:
1. Allows `training-gym setup` to check for an existing deployed dashboard, even if one was not configured prior.
2. Coerces `get_dashboard_proxy_auth` to be a `bool` when running `training-gym set-password` so it typechecks with `require_proxy_auth`, which fixes an issue that [Devin pointed out](https://github.com/modal-projects/training-gym/pull/315#discussion_r3715988080) where the local config could become desynchronized with the deployed dashboard.