### PR TITLE
Restyle docs 404 page to match Training Gym brand

### DIFF
--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -1,8 +1,9 @@
 ---
-const actions = [
-  { href: '/', label: 'Back to overview', variant: 'primary' },
-  { href: '/tutorials/', label: 'Browse tutorials', variant: 'ghost' },
-  { href: '/reference/', label: 'API reference', variant: 'ghost' },
+const navItems = [
+  { href: '/', label: 'Overview' },
+  { href: '/tutorials/', label: 'Tutorials' },
+  { href: '/reference/', label: 'API Reference' },
+  { href: '/support/', label: 'Support' },
 ];
 ---
 
@@ -18,7 +19,7 @@ const actions = [
       content="The requested Training Gym docs page could not be found."
     />
     <style>
-      @import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500&family=Inter:wght@400;500;600;700&display=swap');
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 
       @font-face {
         font-family: 'Goga';
@@ -30,52 +31,37 @@ const actions = [
 
       :root {
         color-scheme: dark;
-        --sl-color-accent: #7fee64;
-        --sl-color-white: #ffffff;
-        --sl-color-gray-2: #d1d1d1;
-        --sl-color-gray-3: #a3a3a3;
-        --sl-color-bg: #181818;
-        --sl-color-black: #181818;
-        --tg-panel: #1c1c1c;
-        --tg-panel-alt: #242424;
-        --tg-border: rgba(255, 255, 255, 0.1);
-        --tg-border-strong: rgba(255, 255, 255, 0.2);
+        --tg-accent: #7fee64;
+        --tg-bg: #181818;
+        --tg-text: #d1d1d1;
+        --tg-border: rgba(255, 255, 255, 0.2);
         --tg-font:
           'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
           'Segoe UI', sans-serif;
-        --tg-font-mono:
-          'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
       }
 
       * {
         box-sizing: border-box;
       }
 
-      html {
-        background: linear-gradient(180deg, var(--sl-color-bg) 0%, var(--sl-color-black) 100%);
-      }
-
       body {
         margin: 0;
         min-height: 100vh;
-        display: flex;
-        flex-direction: column;
-        background: transparent;
-        color: var(--sl-color-gray-2);
+        background: var(--tg-bg);
+        color: var(--tg-text);
         font-family: var(--tg-font);
         -webkit-font-smoothing: antialiased;
       }
 
       header {
         border-bottom: 1px solid #2f2f2f;
-        background: var(--sl-color-bg);
       }
 
       .header-inner {
         display: flex;
         align-items: center;
-        gap: 0.55rem;
-        max-width: 56rem;
+        gap: 3.5rem;
+        max-width: 80rem;
         margin: 0 auto;
         padding: 0.75rem 1.25rem;
       }
@@ -93,10 +79,10 @@ const actions = [
       }
 
       .site-title {
-        color: var(--sl-color-accent);
         display: inline-flex;
         align-items: baseline;
         gap: 0.18rem;
+        color: var(--tg-accent);
         font-family: 'Goga', var(--tg-font);
         font-feature-settings: 'ss01' on;
         font-size: 17.6px;
@@ -106,100 +92,66 @@ const actions = [
         white-space: nowrap;
       }
 
-      .site-title__modal {
+      .site-title span:first-child {
         color: #ddffdc;
       }
 
-      main {
-        flex: 1;
+      nav.top {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
-        width: 100%;
+        gap: 1.75rem;
+      }
+
+      nav.top a {
+        color: var(--tg-text);
+        font-size: 0.875rem;
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      nav.top a:hover {
+        color: var(--tg-accent);
+      }
+
+      main {
         max-width: 56rem;
         margin: 0 auto;
-        padding: clamp(3rem, 12vh, 7rem) 1.25rem;
-      }
-
-      .status {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.3rem 0.65rem;
-        border: 1px solid color-mix(in srgb, var(--sl-color-accent) 40%, transparent);
-        border-radius: 9999px;
-        background: color-mix(in srgb, var(--sl-color-accent) 5%, transparent);
-        color: var(--sl-color-accent);
-        font-family: var(--tg-font-mono);
-        font-size: 0.8125rem;
-        line-height: 1;
-      }
-
-      .status::before {
-        content: '';
-        width: 0.4rem;
-        height: 0.4rem;
-        border-radius: 50%;
-        background: currentColor;
+        padding: clamp(3rem, 10vh, 6rem) 1.25rem;
       }
 
       h1 {
-        margin: 1.5rem 0 0;
-        max-width: 18ch;
-        color: var(--sl-color-white);
-        font-size: clamp(2.35rem, 6vw, 3.75rem);
-        font-weight: 600;
-        line-height: 1.05;
-        letter-spacing: -0.03em;
-        text-wrap: balance;
+        margin: 0;
+        color: var(--tg-accent);
+        font-size: 2rem;
+        font-weight: 500;
+        letter-spacing: -0.01em;
       }
 
       p {
         margin: 1rem 0 0;
         max-width: 60ch;
-        font-size: 1.0625rem;
-        line-height: 1.65;
+        font-size: 1rem;
+        line-height: 1.6;
         text-wrap: pretty;
       }
 
-      .path {
-        margin-top: 1.75rem;
-        padding: 0.85rem 1rem;
-        border: 1px solid var(--tg-border);
-        border-radius: 0.5rem;
-        background: var(--tg-panel-alt);
-        color: var(--sl-color-gray-3);
-        font-family: var(--tg-font-mono);
-        font-size: 0.875rem;
-        overflow-x: auto;
-        white-space: nowrap;
-      }
-
-      .path span {
-        color: var(--sl-color-accent);
-        user-select: none;
-      }
-
-      .path code {
-        color: var(--sl-color-gray-2);
-      }
-
-      nav {
+      nav.actions {
         display: flex;
         flex-wrap: wrap;
         gap: 0.6rem;
-        margin-top: 2rem;
+        margin-top: 1.75rem;
       }
 
-      nav a {
+      nav.actions a {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         min-height: 2.25rem;
         padding: 0.375rem 0.9rem;
-        border: 1px solid var(--tg-border-strong);
+        border: 1px solid var(--tg-border);
         border-radius: 9999px;
-        background: transparent;
-        color: var(--sl-color-gray-2);
+        color: var(--tg-text);
         font-size: 0.875rem;
         line-height: 1;
         text-decoration: none;
@@ -209,56 +161,30 @@ const actions = [
           color 0.15s ease;
       }
 
-      nav a:hover {
-        border-color: color-mix(in srgb, var(--tg-border-strong) 72%, white);
+      nav.actions a:hover {
+        border-color: color-mix(in srgb, var(--tg-border) 72%, white);
         background: rgba(255, 255, 255, 0.05);
-        color: var(--sl-color-white);
+        color: #ffffff;
       }
 
-      nav a.primary {
-        border-color: color-mix(in srgb, var(--sl-color-accent) 40%, transparent);
-        background: color-mix(in srgb, var(--sl-color-accent) 5%, transparent);
-        color: var(--sl-color-accent);
-      }
-
-      nav a.primary:hover {
-        background: color-mix(in srgb, var(--sl-color-accent) 10%, transparent);
-        color: var(--sl-color-accent);
-      }
-
-      nav a:focus-visible,
-      .title-wrapper:focus-visible {
-        outline: 2px solid var(--sl-color-accent);
+      a:focus-visible {
+        outline: 2px solid var(--tg-accent);
         outline-offset: 2px;
       }
 
-      footer {
-        border-top: 1px solid var(--tg-border);
-        color: var(--sl-color-gray-3);
-        font-size: 0.8125rem;
-      }
+      @media (max-width: 40em) {
+        .header-inner {
+          gap: 1rem;
+        }
 
-      .footer-inner {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem 1.25rem;
-        max-width: 56rem;
-        margin: 0 auto;
-        padding: 1.25rem;
-      }
-
-      footer a {
-        color: var(--sl-color-gray-2);
-        text-decoration: none;
-      }
-
-      footer a:hover {
-        color: var(--sl-color-accent);
+        nav.top {
+          gap: 1rem;
+        }
       }
 
       @media (prefers-reduced-motion: reduce) {
-        * {
-          transition: none !important;
+        nav.actions a {
+          transition: none;
         }
       }
     </style>
@@ -268,43 +194,25 @@ const actions = [
       <div class="header-inner">
         <a href="/" class="title-wrapper">
           <img src="/modal-logo.svg" alt="Modal" />
-          <span class="site-title"
-            ><span class="site-title__modal">Modal</span><span>Training Gym</span></span
-          >
+          <span class="site-title"><span>Modal</span><span>Training Gym</span></span>
         </a>
+        <nav class="top" aria-label="Primary">
+          {navItems.map((item) => <a href={item.href}>{item.label}</a>)}
+        </nav>
       </div>
     </header>
 
     <main>
-      <div>
-        <div class="status">404 · page not found</div>
-        <h1>This route never made it to the cluster.</h1>
-        <p>
-          The page you asked for doesn't exist, or it moved. The tutorials and API
-          reference below cover everything in the gym.
-        </p>
-        <div class="path">
-          <span>$</span> <code id="requested-path">GET /</code>
-        </div>
-        <nav>
-          {actions.map((action) => (
-            <a href={action.href} class={action.variant}>{action.label}</a>
-          ))}
-        </nav>
-      </div>
+      <h1>Not Found</h1>
+      <p>
+        Sorry, this page doesn't exist! We weren't able to find the Training Gym
+        documentation you were looking for. Did you type the correct URL?
+      </p>
+      <nav class="actions" aria-label="Suggested pages">
+        <a href="/">Overview</a>
+        <a href="/tutorials/">Tutorials</a>
+        <a href="/reference/">API Reference</a>
+      </nav>
     </main>
-
-    <footer>
-      <div class="footer-inner">
-        <span>Modal Training Gym</span>
-        <a href="https://github.com/modal-projects/training-gym">GitHub</a>
-        <a href="/support/">Support</a>
-      </div>
-    </footer>
-
-    <script is:inline>
-      document.getElementById('requested-path').textContent =
-        'GET ' + window.location.pathname;
-    </script>
   </body>
 </html>

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -1,218 +1,28 @@
 ---
-const navItems = [
-  { href: '/', label: 'Overview' },
-  { href: '/tutorials/', label: 'Tutorials' },
-  { href: '/reference/', label: 'API Reference' },
-  { href: '/support/', label: 'Support' },
-];
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 ---
 
-<!doctype html>
-<html lang="en" data-theme="dark">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="/modal-logo.svg" />
-    <title>Page not found | Training Gym</title>
-    <meta
-      name="description"
-      content="The requested Training Gym docs page could not be found."
-    />
-    <style>
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
-
-      @font-face {
-        font-family: 'Goga';
-        src: url('https://modal-cdn.com/fonts/Goga-VariableVF.woff2') format('woff2');
-        font-weight: 100 900;
-        font-style: normal;
-        font-display: swap;
-      }
-
-      :root {
-        color-scheme: dark;
-        --tg-accent: #7fee64;
-        --tg-bg: #181818;
-        --tg-text: #d1d1d1;
-        --tg-border: rgba(255, 255, 255, 0.2);
-        --tg-font:
-          'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-          'Segoe UI', sans-serif;
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        margin: 0;
-        min-height: 100vh;
-        background: var(--tg-bg);
-        color: var(--tg-text);
-        font-family: var(--tg-font);
-        -webkit-font-smoothing: antialiased;
-      }
-
-      header {
-        border-bottom: 1px solid #2f2f2f;
-      }
-
-      .header-inner {
-        display: flex;
-        align-items: center;
-        gap: 3.5rem;
-        max-width: 80rem;
-        margin: 0 auto;
-        padding: 0.75rem 1.25rem;
-      }
-
-      .title-wrapper {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.55rem;
-        text-decoration: none;
-      }
-
-      .title-wrapper img {
-        height: 17.5px;
-        width: auto;
-      }
-
-      .site-title {
-        display: inline-flex;
-        align-items: baseline;
-        gap: 0.18rem;
-        color: var(--tg-accent);
-        font-family: 'Goga', var(--tg-font);
-        font-feature-settings: 'ss01' on;
-        font-size: 17.6px;
-        font-weight: 600;
-        letter-spacing: -0.02em;
-        line-height: 1;
-        white-space: nowrap;
-      }
-
-      .site-title span:first-child {
-        color: #ddffdc;
-      }
-
-      nav.top {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 1.75rem;
-      }
-
-      nav.top a {
-        color: var(--tg-text);
-        font-size: 0.875rem;
-        text-decoration: none;
-        white-space: nowrap;
-      }
-
-      nav.top a:hover {
-        color: var(--tg-accent);
-      }
-
-      main {
-        max-width: 56rem;
-        margin: 0 auto;
-        padding: clamp(3rem, 10vh, 6rem) 1.25rem;
-      }
-
-      h1 {
-        margin: 0;
-        color: var(--tg-accent);
-        font-size: 2rem;
-        font-weight: 500;
-        letter-spacing: -0.01em;
-      }
-
-      p {
-        margin: 1rem 0 0;
-        max-width: 60ch;
-        font-size: 1rem;
-        line-height: 1.6;
-        text-wrap: pretty;
-      }
-
-      nav.actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.6rem;
-        margin-top: 1.75rem;
-      }
-
-      nav.actions a {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 2.25rem;
-        padding: 0.375rem 0.9rem;
-        border: 1px solid var(--tg-border);
-        border-radius: 9999px;
-        color: var(--tg-text);
-        font-size: 0.875rem;
-        line-height: 1;
-        text-decoration: none;
-        transition:
-          border-color 0.15s ease,
-          background-color 0.15s ease,
-          color 0.15s ease;
-      }
-
-      nav.actions a:hover {
-        border-color: color-mix(in srgb, var(--tg-border) 72%, white);
-        background: rgba(255, 255, 255, 0.05);
-        color: #ffffff;
-      }
-
-      a:focus-visible {
-        outline: 2px solid var(--tg-accent);
-        outline-offset: 2px;
-      }
-
-      @media (max-width: 40em) {
-        .header-inner {
-          gap: 1rem;
-        }
-
-        nav.top {
-          gap: 1rem;
-        }
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        nav.actions a {
-          transition: none;
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <div class="header-inner">
-        <a href="/" class="title-wrapper">
-          <img src="/modal-logo.svg" alt="Modal" />
-          <span class="site-title"><span>Modal</span><span>Training Gym</span></span>
-        </a>
-        <nav class="top" aria-label="Primary">
-          {navItems.map((item) => <a href={item.href}>{item.label}</a>)}
-        </nav>
-      </div>
-    </header>
-
-    <main>
-      <h1>Not Found</h1>
-      <p>
-        Sorry, this page doesn't exist! We weren't able to find the Training Gym
-        documentation you were looking for. Did you type the correct URL?
-      </p>
-      <nav class="actions" aria-label="Suggested pages">
-        <a href="/">Overview</a>
-        <a href="/tutorials/">Tutorials</a>
-        <a href="/reference/">API Reference</a>
-      </nav>
-    </main>
-  </body>
-</html>
+<StarlightPage
+  frontmatter={{
+    title: 'Not Found',
+    template: 'splash',
+    pagefind: false,
+    head: [
+      {
+        tag: 'meta',
+        attrs: {
+          name: 'description',
+          content: 'The requested Training Gym docs page could not be found.',
+        },
+      },
+    ],
+  }}
+>
+  <p>
+    Sorry, this page doesn't exist! We weren't able to find the Training Gym
+    documentation you were looking for. Did you type the correct URL?
+  </p>
+  <a class="sl-link-button primary" href="/">Overview</a>
+  <a class="sl-link-button secondary" href="/tutorials/">Tutorials</a>
+  <a class="sl-link-button secondary" href="/reference/">API Reference</a>
+</StarlightPage>

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -31,6 +31,40 @@ import '../styles/custom.css';
       </nav>
     </main>
 
+    {/* Starlight's base styles ship with its own page layout, which this route bypasses.
+        Only the props and utilities the shared header and search button rely on are needed. */}
+    <style is:global>
+      :root {
+        --sl-z-index-navbar: 20;
+      }
+
+      .sl-flex {
+        display: flex;
+      }
+
+      .sl-block {
+        display: block;
+      }
+
+      .sl-hidden {
+        display: none;
+      }
+
+      @media (min-width: 50rem) {
+        .md\:sl-flex {
+          display: flex;
+        }
+
+        .md\:sl-block {
+          display: block;
+        }
+
+        .md\:sl-hidden {
+          display: none;
+        }
+      }
+    </style>
+
     <style>
       body {
         margin: 0;

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -1,12 +1,3 @@
----
-const navItems = [
-  { href: '/', label: 'Overview' },
-  { href: '/tutorials/', label: 'Tutorials' },
-  { href: '/reference/', label: 'API Reference' },
-  { href: '/support/', label: 'Support' },
-];
----
-
 <!doctype html>
 <html lang="en" data-theme="dark">
   <head>

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -1,149 +1,310 @@
 ---
 const actions = [
-  { href: '/', label: 'Back to overview' },
-  { href: '/tutorials/', label: 'Browse tutorials' },
+  { href: '/', label: 'Back to overview', variant: 'primary' },
+  { href: '/tutorials/', label: 'Browse tutorials', variant: 'ghost' },
+  { href: '/reference/', label: 'API reference', variant: 'ghost' },
 ];
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/modal-logo.svg" />
     <title>Page not found | Training Gym</title>
     <meta
       name="description"
       content="The requested Training Gym docs page could not be found."
     />
     <style>
-      @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+      @import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500&family=Inter:wght@400;500;600;700&display=swap');
+
+      @font-face {
+        font-family: 'Goga';
+        src: url('https://modal-cdn.com/fonts/Goga-VariableVF.woff2') format('woff2');
+        font-weight: 100 900;
+        font-style: normal;
+        font-display: swap;
+      }
 
       :root {
-        color-scheme: light dark;
-        --tg-bg: #050a07;
-        --tg-panel: rgba(12, 20, 15, 0.84);
-        --tg-border: rgba(147, 255, 168, 0.18);
-        --tg-accent: #72f27d;
-        --tg-text: #e7f5e8;
-        --tg-muted: #aac4ae;
+        color-scheme: dark;
+        --sl-color-accent: #7fee64;
+        --sl-color-white: #ffffff;
+        --sl-color-gray-2: #d1d1d1;
+        --sl-color-gray-3: #a3a3a3;
+        --sl-color-bg: #181818;
+        --sl-color-black: #181818;
+        --tg-panel: #1c1c1c;
+        --tg-panel-alt: #242424;
+        --tg-border: rgba(255, 255, 255, 0.1);
+        --tg-border-strong: rgba(255, 255, 255, 0.2);
+        --tg-font:
+          'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
+        --tg-font-mono:
+          'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
       }
 
       * {
         box-sizing: border-box;
       }
 
+      html {
+        background: linear-gradient(180deg, var(--sl-color-bg) 0%, var(--sl-color-black) 100%);
+      }
+
       body {
         margin: 0;
         min-height: 100vh;
-        display: grid;
-        place-items: center;
-        padding: 1.5rem;
-        font-family: 'Space Grotesk', system-ui, sans-serif;
-        color: var(--tg-text);
-        background:
-          radial-gradient(circle at top left, rgba(114, 242, 125, 0.16), transparent 26rem),
-          radial-gradient(circle at top right, rgba(58, 193, 255, 0.12), transparent 24rem),
-          linear-gradient(180deg, #050a07, #0a110c 100%);
+        display: flex;
+        flex-direction: column;
+        background: transparent;
+        color: var(--sl-color-gray-2);
+        font-family: var(--tg-font);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      header {
+        border-bottom: 1px solid #2f2f2f;
+        background: var(--sl-color-bg);
+      }
+
+      .header-inner {
+        display: flex;
+        align-items: center;
+        gap: 0.55rem;
+        max-width: 56rem;
+        margin: 0 auto;
+        padding: 0.75rem 1.25rem;
+      }
+
+      .title-wrapper {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.55rem;
+        text-decoration: none;
+      }
+
+      .title-wrapper img {
+        height: 17.5px;
+        width: auto;
+      }
+
+      .site-title {
+        color: var(--sl-color-accent);
+        display: inline-flex;
+        align-items: baseline;
+        gap: 0.18rem;
+        font-family: 'Goga', var(--tg-font);
+        font-feature-settings: 'ss01' on;
+        font-size: 17.6px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        line-height: 1;
+        white-space: nowrap;
+      }
+
+      .site-title__modal {
+        color: #ddffdc;
       }
 
       main {
-        width: min(42rem, 100%);
-        padding: clamp(1.5rem, 4vw, 3rem);
-        border: 1px solid var(--tg-border);
-        border-radius: 1.75rem;
-        background: var(--tg-panel);
-        backdrop-filter: blur(20px);
-        box-shadow: 0 32px 80px rgba(0, 0, 0, 0.34);
+        flex: 1;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        max-width: 56rem;
+        margin: 0 auto;
+        padding: clamp(3rem, 12vh, 7rem) 1.25rem;
       }
 
-      .eyebrow {
+      .status {
         display: inline-flex;
         align-items: center;
-        gap: 0.6rem;
-        margin-bottom: 1rem;
-        color: var(--tg-accent);
-        font-size: 0.76rem;
-        font-weight: 700;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
+        gap: 0.5rem;
+        padding: 0.3rem 0.65rem;
+        border: 1px solid color-mix(in srgb, var(--sl-color-accent) 40%, transparent);
+        border-radius: 9999px;
+        background: color-mix(in srgb, var(--sl-color-accent) 5%, transparent);
+        color: var(--sl-color-accent);
+        font-family: var(--tg-font-mono);
+        font-size: 0.8125rem;
+        line-height: 1;
       }
 
-      .eyebrow::before {
-        content: '404';
-        display: inline-grid;
-        place-items: center;
-        width: 2.4rem;
-        height: 2.4rem;
-        border-radius: 0.8rem;
-        background: linear-gradient(135deg, var(--tg-accent), #3ac1ff);
-        color: #061009;
-        font-family: 'IBM Plex Mono', monospace;
-        letter-spacing: 0.06em;
+      .status::before {
+        content: '';
+        width: 0.4rem;
+        height: 0.4rem;
+        border-radius: 50%;
+        background: currentColor;
       }
 
       h1 {
-        margin: 0;
-        max-width: 12ch;
-        font-size: clamp(2.75rem, 8vw, 4.9rem);
-        line-height: 0.95;
-        letter-spacing: -0.05em;
+        margin: 1.5rem 0 0;
+        max-width: 18ch;
+        color: var(--sl-color-white);
+        font-size: clamp(2.35rem, 6vw, 3.75rem);
+        font-weight: 600;
+        line-height: 1.05;
+        letter-spacing: -0.03em;
+        text-wrap: balance;
       }
 
       p {
-        margin: 1.2rem 0 0;
-        max-width: 38rem;
-        color: var(--tg-muted);
-        font-size: 1.08rem;
-        line-height: 1.7;
+        margin: 1rem 0 0;
+        max-width: 60ch;
+        font-size: 1.0625rem;
+        line-height: 1.65;
+        text-wrap: pretty;
+      }
+
+      .path {
+        margin-top: 1.75rem;
+        padding: 0.85rem 1rem;
+        border: 1px solid var(--tg-border);
+        border-radius: 0.5rem;
+        background: var(--tg-panel-alt);
+        color: var(--sl-color-gray-3);
+        font-family: var(--tg-font-mono);
+        font-size: 0.875rem;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+
+      .path span {
+        color: var(--sl-color-accent);
+        user-select: none;
+      }
+
+      .path code {
+        color: var(--sl-color-gray-2);
       }
 
       nav {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.9rem;
+        gap: 0.6rem;
         margin-top: 2rem;
       }
 
-      a {
+      nav a {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: 0.9rem 1.25rem;
-        border: 1px solid var(--tg-border);
-        border-radius: 999px;
-        color: var(--tg-text);
-        font-weight: 600;
+        min-height: 2.25rem;
+        padding: 0.375rem 0.9rem;
+        border: 1px solid var(--tg-border-strong);
+        border-radius: 9999px;
+        background: transparent;
+        color: var(--sl-color-gray-2);
+        font-size: 0.875rem;
+        line-height: 1;
         text-decoration: none;
         transition:
-          transform 0.2s ease,
-          background-color 0.2s ease,
-          border-color 0.2s ease;
+          border-color 0.15s ease,
+          background-color 0.15s ease,
+          color 0.15s ease;
       }
 
-      a:first-child {
-        background: var(--tg-accent);
-        border-color: var(--tg-accent);
-        color: #061009;
+      nav a:hover {
+        border-color: color-mix(in srgb, var(--tg-border-strong) 72%, white);
+        background: rgba(255, 255, 255, 0.05);
+        color: var(--sl-color-white);
       }
 
-      a:hover {
-        transform: translateY(-1px);
+      nav a.primary {
+        border-color: color-mix(in srgb, var(--sl-color-accent) 40%, transparent);
+        background: color-mix(in srgb, var(--sl-color-accent) 5%, transparent);
+        color: var(--sl-color-accent);
+      }
+
+      nav a.primary:hover {
+        background: color-mix(in srgb, var(--sl-color-accent) 10%, transparent);
+        color: var(--sl-color-accent);
+      }
+
+      nav a:focus-visible,
+      .title-wrapper:focus-visible {
+        outline: 2px solid var(--sl-color-accent);
+        outline-offset: 2px;
+      }
+
+      footer {
+        border-top: 1px solid var(--tg-border);
+        color: var(--sl-color-gray-3);
+        font-size: 0.8125rem;
+      }
+
+      .footer-inner {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1.25rem;
+        max-width: 56rem;
+        margin: 0 auto;
+        padding: 1.25rem;
+      }
+
+      footer a {
+        color: var(--sl-color-gray-2);
+        text-decoration: none;
+      }
+
+      footer a:hover {
+        color: var(--sl-color-accent);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          transition: none !important;
+        }
       }
     </style>
   </head>
   <body>
+    <header>
+      <div class="header-inner">
+        <a href="/" class="title-wrapper">
+          <img src="/modal-logo.svg" alt="Modal" />
+          <span class="site-title"
+            ><span class="site-title__modal">Modal</span><span>Training Gym</span></span
+          >
+        </a>
+      </div>
+    </header>
+
     <main>
-      <div class="eyebrow">Training Gym</div>
-      <h1>That page drifted off-cluster.</h1>
-      <p>
-        The docs URL you requested does not exist, or the route moved during the
-        Starlight cutover.
-      </p>
-      <nav>
-        {actions.map((action) => (
-          <a href={action.href}>{action.label}</a>
-        ))}
-      </nav>
+      <div>
+        <div class="status">404 · page not found</div>
+        <h1>This route never made it to the cluster.</h1>
+        <p>
+          The page you asked for doesn't exist, or it moved. The tutorials and API
+          reference below cover everything in the gym.
+        </p>
+        <div class="path">
+          <span>$</span> <code id="requested-path">GET /</code>
+        </div>
+        <nav>
+          {actions.map((action) => (
+            <a href={action.href} class={action.variant}>{action.label}</a>
+          ))}
+        </nav>
+      </div>
     </main>
+
+    <footer>
+      <div class="footer-inner">
+        <span>Modal Training Gym</span>
+        <a href="https://github.com/modal-projects/training-gym">GitHub</a>
+        <a href="/support/">Support</a>
+      </div>
+    </footer>
+
+    <script is:inline>
+      document.getElementById('requested-path').textContent =
+        'GET ' + window.location.pathname;
+    </script>
   </body>
 </html>

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -44,19 +44,6 @@
         -webkit-font-smoothing: antialiased;
       }
 
-      header {
-        border-bottom: 1px solid #2f2f2f;
-      }
-
-      .header-inner {
-        display: flex;
-        align-items: center;
-        gap: 3.5rem;
-        max-width: 80rem;
-        margin: 0 auto;
-        padding: 0.75rem 1.25rem;
-      }
-
       .title-wrapper {
         display: inline-flex;
         align-items: center;
@@ -86,24 +73,6 @@
 
       .site-title span:first-child {
         color: #ddffdc;
-      }
-
-      nav.top {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 1.75rem;
-      }
-
-      nav.top a {
-        color: var(--tg-text);
-        font-size: 0.875rem;
-        text-decoration: none;
-        white-space: nowrap;
-      }
-
-      nav.top a:hover {
-        color: var(--tg-accent);
       }
 
       main {
@@ -162,16 +131,6 @@
       a:focus-visible {
         outline: 2px solid var(--tg-accent);
         outline-offset: 2px;
-      }
-
-      @media (max-width: 40em) {
-        .header-inner {
-          gap: 1rem;
-        }
-
-        nav.top {
-          gap: 1rem;
-        }
       }
 
       @media (prefers-reduced-motion: reduce) {

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -34,6 +34,12 @@ import '../styles/custom.css';
     {/* Starlight's base styles ship with its own page layout, which this route bypasses.
         Only the props and utilities the shared header and search button rely on are needed. */}
     <style is:global>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
       :root {
         --sl-z-index-navbar: 20;
       }

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -1,6 +1,10 @@
 ---
-import Header from '../components/Header.astro';
-import '../styles/custom.css';
+const navItems = [
+  { href: '/', label: 'Overview' },
+  { href: '/tutorials/', label: 'Tutorials' },
+  { href: '/reference/', label: 'API Reference' },
+  { href: '/support/', label: 'Support' },
+];
 ---
 
 <!doctype html>
@@ -9,120 +13,199 @@ import '../styles/custom.css';
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/modal-logo.svg" />
-    <title>Not Found | Training Gym</title>
+    <title>Page not found | Training Gym</title>
     <meta
       name="description"
       content="The requested Training Gym docs page could not be found."
     />
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+      @font-face {
+        font-family: 'Goga';
+        src: url('https://modal-cdn.com/fonts/Goga-VariableVF.woff2') format('woff2');
+        font-weight: 100 900;
+        font-style: normal;
+        font-display: swap;
+      }
+
+      :root {
+        color-scheme: dark;
+        --tg-accent: #7fee64;
+        --tg-bg: #181818;
+        --tg-text: #d1d1d1;
+        --tg-border: rgba(255, 255, 255, 0.2);
+        --tg-font:
+          'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--tg-bg);
+        color: var(--tg-text);
+        font-family: var(--tg-font);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      header {
+        border-bottom: 1px solid #2f2f2f;
+      }
+
+      .header-inner {
+        display: flex;
+        align-items: center;
+        gap: 3.5rem;
+        max-width: 80rem;
+        margin: 0 auto;
+        padding: 0.75rem 1.25rem;
+      }
+
+      .title-wrapper {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.55rem;
+        text-decoration: none;
+        padding-bottom: 2.5rem;
+      }
+
+      .title-wrapper img {
+        height: 17.5px;
+        width: auto;
+      }
+
+      .site-title {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 0.18rem;
+        color: var(--tg-accent);
+        font-family: 'Goga', var(--tg-font);
+        font-feature-settings: 'ss01' on;
+        font-size: 17.6px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        line-height: 1;
+        white-space: nowrap;
+      }
+
+      .site-title span:first-child {
+        color: #ddffdc;
+      }
+
+      nav.top {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 1.75rem;
+      }
+
+      nav.top a {
+        color: var(--tg-text);
+        font-size: 0.875rem;
+        text-decoration: none;
+        white-space: nowrap;
+      }
+
+      nav.top a:hover {
+        color: var(--tg-accent);
+      }
+
+      main {
+        max-width: 56rem;
+        margin: 0 auto;
+        padding: clamp(3rem, 10vh, 6rem) 1.25rem;
+      }
+
+      h1 {
+        margin: 0;
+        color: var(--tg-accent);
+        font-size: 2rem;
+        font-weight: 500;
+        letter-spacing: -0.01em;
+      }
+
+      p {
+        margin: 1rem 0 0;
+        max-width: 60ch;
+        font-size: 1rem;
+        line-height: 1.6;
+        text-wrap: pretty;
+      }
+
+      nav.actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        margin-top: 1.75rem;
+      }
+
+      nav.actions a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 2.25rem;
+        padding: 0.375rem 0.9rem;
+        border: 1px solid var(--tg-border);
+        border-radius: 9999px;
+        color: var(--tg-text);
+        font-size: 0.875rem;
+        line-height: 1;
+        text-decoration: none;
+        transition:
+          border-color 0.15s ease,
+          background-color 0.15s ease,
+          color 0.15s ease;
+      }
+
+      nav.actions a:hover {
+        border-color: color-mix(in srgb, var(--tg-border) 72%, white);
+        background: rgba(255, 255, 255, 0.05);
+        color: #ffffff;
+      }
+
+      a:focus-visible {
+        outline: 2px solid var(--tg-accent);
+        outline-offset: 2px;
+      }
+
+      @media (max-width: 40em) {
+        .header-inner {
+          gap: 1rem;
+        }
+
+        nav.top {
+          gap: 1rem;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        nav.actions a {
+          transition: none;
+        }
+      }
+    </style>
   </head>
   <body>
-    <header class="header"><div class="sl-container"><Header /></div></header>
-
-    <main class="tg-404">
+    <main>
+      <a href="/" class="title-wrapper">
+        <img src="/modal-logo.svg" alt="Modal" />
+        <span class="site-title"><span>Modal</span><span>Training Gym</span></span>
+      </a>
       <h1>Not Found</h1>
       <p>
         Sorry, this page doesn't exist! We weren't able to find the Training Gym
         documentation you were looking for. Did you type the correct URL?
       </p>
-      <nav aria-label="Suggested pages">
-        <a class="tg-action-button tg-action-button--primary" href="/">Overview</a>
-        <a class="tg-action-button tg-action-button--ghost" href="/tutorials/">Tutorials</a>
-        <a class="tg-action-button tg-action-button--ghost" href="/reference/">API Reference</a>
+      <nav class="actions" aria-label="Suggested pages">
+        <a href="/">Overview</a>
+        <a href="/tutorials/">Tutorials</a>
+        <a href="/reference/">API Reference</a>
       </nav>
     </main>
-
-    {/* Starlight's base styles ship with its own page layout, which this route bypasses.
-        Only the props and utilities the shared header and search button rely on are needed. */}
-    <style is:global>
-      *,
-      *::before,
-      *::after {
-        box-sizing: border-box;
-      }
-
-      :root {
-        --sl-z-index-navbar: 20;
-      }
-
-      .sl-flex {
-        display: flex;
-      }
-
-      .sl-block {
-        display: block;
-      }
-
-      .sl-hidden {
-        display: none;
-      }
-
-      @media (min-width: 50rem) {
-        .md\:sl-flex {
-          display: flex;
-        }
-
-        .md\:sl-block {
-          display: block;
-        }
-
-        .md\:sl-hidden {
-          display: none;
-        }
-      }
-    </style>
-
-    <style>
-      body {
-        margin: 0;
-        min-height: 100vh;
-        font-family: var(--sl-font);
-        -webkit-font-smoothing: antialiased;
-      }
-
-      .header {
-        border-bottom: 1px solid #2f2f2f;
-      }
-
-      .header > .sl-container {
-        max-width: 87.5rem;
-        margin-inline: auto;
-        padding-block: 0.75rem;
-        padding-inline: var(--sl-nav-pad-x);
-      }
-
-      .tg-404 {
-        max-width: var(--sl-content-width);
-        margin-inline: auto;
-        padding: clamp(3rem, 10vh, 5.5rem) var(--sl-nav-pad-x);
-      }
-
-      .tg-404 h1 {
-        margin: 0;
-        color: var(--sl-color-white);
-        font-size: var(--sl-text-h1);
-        font-weight: 600;
-        letter-spacing: -0.02em;
-      }
-
-      .tg-404 p {
-        margin: 1rem 0 0;
-        max-width: 60ch;
-        color: var(--sl-color-text);
-        line-height: 1.7;
-        text-wrap: pretty;
-      }
-
-      .tg-404 nav {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
-        margin-top: 2.25rem;
-      }
-
-      /* The shared `:is(.tg-action-button, …)` rule outranks `--primary` on its own. */
-      .tg-404 nav .tg-action-button--primary {
-        color: var(--sl-color-accent);
-      }
-    </style>
   </body>
 </html>

--- a/docs-next/src/pages/404.astro
+++ b/docs-next/src/pages/404.astro
@@ -1,28 +1,88 @@
 ---
-import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import Header from '../components/Header.astro';
+import '../styles/custom.css';
 ---
 
-<StarlightPage
-  frontmatter={{
-    title: 'Not Found',
-    template: 'splash',
-    pagefind: false,
-    head: [
-      {
-        tag: 'meta',
-        attrs: {
-          name: 'description',
-          content: 'The requested Training Gym docs page could not be found.',
-        },
-      },
-    ],
-  }}
->
-  <p>
-    Sorry, this page doesn't exist! We weren't able to find the Training Gym
-    documentation you were looking for. Did you type the correct URL?
-  </p>
-  <a class="sl-link-button primary" href="/">Overview</a>
-  <a class="sl-link-button secondary" href="/tutorials/">Tutorials</a>
-  <a class="sl-link-button secondary" href="/reference/">API Reference</a>
-</StarlightPage>
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/modal-logo.svg" />
+    <title>Not Found | Training Gym</title>
+    <meta
+      name="description"
+      content="The requested Training Gym docs page could not be found."
+    />
+  </head>
+  <body>
+    <header class="header"><div class="sl-container"><Header /></div></header>
+
+    <main class="tg-404">
+      <h1>Not Found</h1>
+      <p>
+        Sorry, this page doesn't exist! We weren't able to find the Training Gym
+        documentation you were looking for. Did you type the correct URL?
+      </p>
+      <nav aria-label="Suggested pages">
+        <a class="tg-action-button tg-action-button--primary" href="/">Overview</a>
+        <a class="tg-action-button tg-action-button--ghost" href="/tutorials/">Tutorials</a>
+        <a class="tg-action-button tg-action-button--ghost" href="/reference/">API Reference</a>
+      </nav>
+    </main>
+
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: var(--sl-font);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .header {
+        border-bottom: 1px solid #2f2f2f;
+      }
+
+      .header > .sl-container {
+        max-width: 87.5rem;
+        margin-inline: auto;
+        padding-block: 0.75rem;
+        padding-inline: var(--sl-nav-pad-x);
+      }
+
+      .tg-404 {
+        max-width: var(--sl-content-width);
+        margin-inline: auto;
+        padding: clamp(3rem, 10vh, 5.5rem) var(--sl-nav-pad-x);
+      }
+
+      .tg-404 h1 {
+        margin: 0;
+        color: var(--sl-color-white);
+        font-size: var(--sl-text-h1);
+        font-weight: 600;
+        letter-spacing: -0.02em;
+      }
+
+      .tg-404 p {
+        margin: 1rem 0 0;
+        max-width: 60ch;
+        color: var(--sl-color-text);
+        line-height: 1.7;
+        text-wrap: pretty;
+      }
+
+      .tg-404 nav {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 2.25rem;
+      }
+
+      /* The shared `:is(.tg-action-button, …)` rule outranks `--primary` on its own. */
+      .tg-404 nav .tg-action-button--primary {
+        color: var(--sl-color-accent);
+      }
+    </style>
+  </body>
+</html>

--- a/scripts/previews/nginx/docs.conf
+++ b/scripts/previews/nginx/docs.conf
@@ -5,4 +5,14 @@ server {
 
     root /usr/share/nginx/html;
     index index.html;
+
+    location / {
+        try_files $uri $uri/ $uri/index.html =404;
+    }
+
+    error_page 404 /404.html;
+
+    location = /404.html {
+        internal;
+    }
 }


### PR DESCRIPTION
Thought I'd restyle the 404 page since it looked out of place. Asked Devin to iterate on a few designs but settled on something simple that parallels the [Modal docs' 404 page](https://modal.com/docs/404):

<img width="1248" height="778" alt="Screenshot 2026-08-04 at 18 14 56" src="https://github.com/user-attachments/assets/5ef8baba-cf43-462d-864e-03585f31e40b" />

(Originally I had Devin try to use existing components, but those were causing weird regressions with the CSS so am holding off on that.)

<details>
<summary>Original Devin description</summary>

The standalone 404 page rolled its own everything (Space Grotesk / IBM Plex Mono, `#72f27d` green, radial-gradient background, hand-written header markup) and matched nothing else on gym.modal.dev.

It now imports the real `Header.astro` and `custom.css`, so the nav, search, and button styles are the site's own — the only page-local CSS is layout (content width, padding, button row). Content is a "Not Found" title, one line of copy, and three `tg-action-button` links, matching the modal.com/docs 404. Deliberately not `StarlightPage`: that pulls in the `PageTitle` override and its "View on GitHub" action, which doesn't belong on a 404.

Two things this route has to re-declare, since Starlight's base styles ship with its own page layout:

- the `sl-flex` / `sl-hidden` / `md:sl-*` utilities the header and search button use, plus `--sl-z-index-navbar`;
- the accent color on the primary button — the shared `:is(.tg-action-button, …, .tg-header .tg-header__repo)` rule in `custom.css` is (0,2,0) and outranks `.tg-action-button--primary`.

Also updates `scripts/previews/nginx/docs.conf` so preview deploys serve the generated `404.html` on unknown paths:

```nginx
location / { try_files $uri $uri/ $uri/index.html =404; }
error_page 404 /404.html;
location = /404.html { internal; }
```

## Test plan

Built `docs-next` and viewed the page in a local `astro preview`; separately ran nginx in Docker against `dist/` with the new conf and confirmed an unknown path returns HTTP 404 with the `Not Found | Training Gym` body.

![404](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJjbGVyay1vcmdfMmZDNldVdEx4OWxOV1BWY1ZPdEVrWkVFVnF5IiwidXNlcl9pZCI6bnVsbCwiYnVja2V0X25hbWUiOiJkZXZpbmF0dGFjaG1lbnRzIiwiYnVja2V0X2tleSI6ImF0dGFjaG1lbnRzX3ByaXZhdGUvY2xlcmstb3JnXzJmQzZXVXRMeDlsTldQVmNWT3RFa1pFRVZxeS9mNzdlOGI3Yi02ZmZhLTQ5NGUtOWMxNS1kMGMxOWE5MDBhNjAiLCJpYXQiOjE3ODU4ODAxNDUsImV4cCI6MTc4NjQ4NDk0NSwiZmlsZW5hbWUiOiJzc18zZWVhMzYzZi5wbmcifQ.bzjx5bFaOsm0nlqhkkCzt0i80dML69M_fw3OaEdRQl0)

</details>

Link to Devin session: https://modal.devinenterprise.com/sessions/ff8b0e9c787a45b4bf69da0273d74acf
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->