### PR TITLE
Fix circular import for deployment url

### DIFF
--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -14,8 +14,6 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from modal_training_gym.cli.setup import deployed_dashboard_url
-
 
 CONFIG_PATH = Path.home() / ".training-gym.toml"
 MODAL_CONFIG_PATH = Path(
@@ -79,6 +77,9 @@ def get_dashboard_proxy_auth() -> bool | None:
     identifies an authenticated deployment. The persisted mode remains a
     fallback for older or temporarily unreachable dashboards.
     """
+    # Imported here: ``cli`` imports this module, so a module-level import cycles.
+    from modal_training_gym.cli.setup import deployed_dashboard_url
+
     dashboard = load_config().get("dashboard")
     if not isinstance(dashboard, dict):
         dashboard = {}


### PR DESCRIPTION
cc @anli5005 previous proxy auth changes have circular import issues.
Follow-up: Add test to catch this in the future.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->