### PR TITLE
Catch circular imports in CI by importing every module first in a fresh interpreter

### DIFF
--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -1,0 +1,37 @@
+"""Guard against import cycles between ``common`` and ``cli``.
+
+``cli`` imports ``common.config``, so anything ``common.config`` needs from
+``cli`` must be imported lazily inside the function that uses it. A module-level
+import there cycles: ``common.config`` stops halfway, ``cli`` re-enters it, and
+the partially initialized module has no ``get_dashboard_url`` yet.
+
+Each module is imported *first* in a fresh interpreter. That ordering is the
+whole point — inside pytest these modules are already in ``sys.modules``, which
+masks the cycle no matter which side is broken.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+CYCLE_MODULES = [
+    "modal_training_gym.common.config",
+    "modal_training_gym.cli",
+    "modal_training_gym.cli.client",
+    "modal_training_gym.cli.setup",
+]
+
+
+@pytest.mark.parametrize("module", CYCLE_MODULES)
+def test_module_imports_first_in_a_fresh_interpreter(module: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"importing {module} first fails:\n{result.stderr}"

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -1,37 +1,147 @@
-"""Guard against import cycles between ``common`` and ``cli``.
+"""Guard against import cycles anywhere in ``modal_training_gym``.
 
-``cli`` imports ``common.config``, so anything ``common.config`` needs from
-``cli`` must be imported lazily inside the function that uses it. A module-level
-import there cycles: ``common.config`` stops halfway, ``cli`` re-enters it, and
-the partially initialized module has no ``get_dashboard_url`` yet.
+Every module is imported *first*, alone, in a fresh interpreter. That ordering is
+the whole point: a cycle only raises for whoever enters it first, and nothing
+else in CI ever does. ``modal_training_gym/__init__.py`` is a lazy
+``__getattr__`` shim, so ``import modal_training_gym`` pulls in no submodule at
+all; ``compileall`` never executes an import; and by the time a test touches
+``common.config`` the module is already in ``sys.modules``, which masks the cycle
+no matter which side is broken.
 
-Each module is imported *first* in a fresh interpreter. That ordering is the
-whole point — inside pytest these modules are already in ``sys.modules``, which
-masks the cycle no matter which side is broken.
+That is how the ``common.config`` -> ``cli.setup`` -> ``_dashboard`` ->
+``common.config`` cycle shipped green: importing either ``common.config`` or
+``_dashboard`` first raised ``ImportError: cannot import name
+'get_dashboard_url' from partially initialized module``, but no CI check imported
+either one first.
+
+Cycles in this package are avoided by deferring the import into the function body
+that needs it (see ``common.config.get_dashboard_proxy_auth``), so a failure here
+usually means "move this module-level import inside the function".
 """
 
 from __future__ import annotations
 
+import concurrent.futures
+import pathlib
 import subprocess
 import sys
 
 import pytest
 
 
-CYCLE_MODULES = [
-    "modal_training_gym.common.config",
-    "modal_training_gym.cli",
-    "modal_training_gym.cli.client",
-    "modal_training_gym.cli.setup",
-]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PKG_ROOT = REPO_ROOT / "modal_training_gym"
+
+# Modules that import slime / Megatron-LM / miles / torch at module scope, or
+# read a file that only exists in the training image. They cannot be imported
+# outside that image, so their import is only checked for *cycles* and not for
+# success. Entries must still name real modules, or the staleness test below
+# fails on a rename or deletion.
+REMOTE_ONLY = frozenset(
+    {
+        "modal_training_gym.frameworks.miles.modal_helpers.patches.patch_sglang_abort",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_advantages",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_bridge_provider_per_token_loss",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_checkpoint_save",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_dist_ckpt_quantized",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_gdn_packed_seq",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_megatron_bridge",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_stop_token_diagnostic",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_torch_load",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_validation",
+        "modal_training_gym.frameworks.slime.modal_helpers.patches.patch_zero_std_metrics",
+        "modal_training_gym.frameworks.slime.opd_reward",
+    }
+)
+
+# CPython's wording for a cycle, from ``_handle_fromlist`` / ``_find_and_load``.
+_CYCLE_MARKERS = (
+    "partially initialized module",
+    "most likely due to a circular import",
+)
 
 
-@pytest.mark.parametrize("module", CYCLE_MODULES)
-def test_module_imports_first_in_a_fresh_interpreter(module: str) -> None:
+def discover_modules() -> list[str]:
+    """Every module in the package as a dotted name, packages included.
+
+    A filesystem walk rather than ``pkgutil.walk_packages``: walk_packages
+    imports each package to read its ``__path__``, which both defeats the point
+    (the parent is in ``sys.modules`` before the module under test loads) and
+    dies on the remote-only subpackages.
+    """
+    modules = []
+    for path in sorted(PKG_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        parts = list(path.relative_to(REPO_ROOT).with_suffix("").parts)
+        if parts[-1] == "__init__":
+            parts.pop()  # the package itself, not a submodule
+        if any(not part.isidentifier() for part in parts):
+            continue
+        modules.append(".".join(parts))
+    return modules
+
+
+MODULES = discover_modules()
+
+
+def _import_alone(module: str) -> str | None:
+    """Import ``module`` first in a fresh interpreter; return stderr on failure."""
     result = subprocess.run(
         [sys.executable, "-c", f"import {module}"],
+        cwd=REPO_ROOT,
         capture_output=True,
         text=True,
     )
+    return None if result.returncode == 0 else result.stderr
 
-    assert result.returncode == 0, f"importing {module} first fails:\n{result.stderr}"
+
+@pytest.fixture(scope="session")
+def import_results() -> dict[str, str | None]:
+    """Import every module in its own interpreter, in parallel (~3s for all of them)."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        return dict(zip(MODULES, pool.map(_import_alone, MODULES)))
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_module_imports_alone(
+    module: str, import_results: dict[str, str | None]
+) -> None:
+    stderr = import_results[module]
+    if stderr is None:
+        return
+
+    if any(marker in stderr for marker in _CYCLE_MARKERS):
+        pytest.fail(
+            f"circular import: {module} cannot be imported first.\n"
+            f"Move the offending module-level import into the function that uses it.\n\n"
+            f"{stderr}"
+        )
+
+    if module in REMOTE_ONLY:
+        # Expected: needs slime / Megatron-LM / miles / torch from the training image.
+        # Checked for cycles above, which is all this test can assert here.
+        return
+
+    pytest.fail(f"importing {module} first fails:\n{stderr}")
+
+
+def test_no_stale_remote_only_entries() -> None:
+    """``REMOTE_ONLY`` must not accumulate entries for modules that no longer exist."""
+    assert not (REMOTE_ONLY - set(MODULES)), (
+        "REMOTE_ONLY names modules that no longer exist; delete these entries"
+    )
+
+
+def test_discovery_covers_the_package() -> None:
+    """A walk that silently stops short would make every check above vacuous."""
+    assert "modal_training_gym" in MODULES
+    assert "modal_training_gym.common.config" in MODULES  # nested module
+    assert "modal_training_gym.frameworks.slime.launcher" in MODULES  # deeply nested
+
+    subpackages = {
+        f"modal_training_gym.{path.name}"
+        for path in PKG_ROOT.iterdir()
+        if (path / "__init__.py").exists()
+    }
+    assert subpackages <= set(MODULES)


### PR DESCRIPTION
Generalizes the 4-module sketch into a check over all 158 modules in `modal_training_gym`.

Nothing in CI could catch a cycle before this. `modal_training_gym/__init__.py` is a lazy `__getattr__` shim, so `import modal_training_gym` pulls in **no** submodule; `compileall` never executes an import; and inside pytest the module is already in `sys.modules` by the time a test touches it. A cycle only raises for whoever enters it *first*, and no CI check imported these modules first — which is how the `common.config` → `cli.setup` → `_dashboard` → `common.config` cycle fixed in #319 shipped green.

So: every module gets its own fresh interpreter.

```python
MODULES = discover_modules()   # filesystem walk, packages included

@pytest.fixture(scope="session")
def import_results():          # all 158 in parallel, ~3s
    with ThreadPoolExecutor(max_workers=16) as pool:
        return dict(zip(MODULES, pool.map(_import_alone, MODULES)))

@pytest.mark.parametrize("module", MODULES)
def test_module_imports_alone(module, import_results):
    stderr = import_results[module]
    ...
```

A session fixture does the work in parallel, and the parametrized test just reads its own result — so failures name the offending module while the whole file still costs **2.7s**.

Three details that keep it from being decorative:

- **Discovery walks the filesystem, not `pkgutil.walk_packages`.** walk_packages imports each package to read its `__path__`, which both defeats the isolation (the parent lands in `sys.modules` before the module under test loads) and dies on the remote-only patch subpackages.
- **Cycles are a separate, never-skippable failure class.** stderr is matched against CPython's `partially initialized module` / `most likely due to a circular import` wording. A cycle fails even inside a `REMOTE_ONLY` module, so it can't hide behind that module's dependency skip.
- **`REMOTE_ONLY` is explicit, not a glob.** 12 modules import slime / Megatron-LM / miles / torch at module scope and are unimportable outside the training image. Listing them by name (rather than skipping `**/patches/**`) means a new unimportable module fails CI instead of being silently absorbed, and a staleness test rejects entries whose module was renamed or deleted.

Verified both directions: green on `main`, and re-introducing the #319 module-level import fails exactly `test_module_imports_alone[modal_training_gym.common.config]` and `[modal_training_gym._dashboard]` with the partially-initialized traceback.

This is deliberately a runtime check — it catches cycles that *do* break. It does not stop the static graph from getting more tangled (currently 125 cycles / 8 at subpackage level, defused by ~250 in-function imports); `import-linter` with today's violations frozen as a ratchet is the follow-up for that.

## Checklist

Not an example — the example checklist doesn't apply.


Link to Devin session: https://modal.devinenterprise.com/sessions/8c78b11f09d74aa4bc0b32b2cc9b8d7c
Requested by: @anli5005