### PR TITLE
Make TrainConfig.detach mean something: stop the app when an attached train() is interrupted

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -332,10 +332,13 @@ class TrainConfig:
         ``False`` to run the recipe exactly as written, with no preset
         defaults. Default ``True``.
     detach : bool
-        Run the training app detached so it keeps running on Modal even if
-        the local client disconnects (terminal closed, laptop asleep). Set
-        ``False`` for an attached run that stops on Ctrl-C. Default
-        ``True``.
+        Whether the training app should outlive the local client. The Modal
+        app is always started detached so a dropped connection can't kill a
+        multi-hour run; ``detach`` controls what ``train()`` does when its
+        wait for the result is interrupted (Ctrl-C, a crashed driver):
+        ``True`` leaves the run going on Modal, ``False`` stops the app on
+        the way out. ``launch()`` always leaves the run going, since it
+        returns before training finishes. Default ``True``.
     group_id : str | None
         Shared sweep id. Set by ``TrainingGroup`` so every run in a sweep
         carries the same id, letting the dashboard group variants together.
@@ -358,11 +361,10 @@ class TrainConfig:
     checkpoint: Checkpoint | None = None
     # Known-model recipes are presets by default; complete recipes can opt out.
     merge_model_recipe: bool = True
-    # Run the training app detached so it keeps running on Modal even if the
-    # local client disconnects (terminal closed, laptop asleep). The CLI's
-    # ``modal run --detach`` only detaches the entrypoint, not the nested
-    # ``app.run()`` the driver opens — so we detach it here. Set False for an
-    # attached run that Ctrl-C stops.
+    # Whether a run outlives the local client. The app itself is always started
+    # detached (the CLI's ``modal run --detach`` only detaches the entrypoint,
+    # not the nested ``app.run()`` the driver opens), so this only decides
+    # whether an interrupted ``train()`` stops the app on its way out.
     detach: bool = True
     # Set by TrainingGroup so every run in a sweep shares one id — written into
     # the TrainingRun record so the dashboard can group variants together.
@@ -560,8 +562,15 @@ class TrainConfig:
 
     def train(self, *, show_output: bool = True) -> TrainResult:
         """Build the app, run training, and return the TrainResult."""
+        from modal_training_gym.common.modal_lifecycle import stop_app
+
         launch = self.launch(show_output=show_output, prepare_inputs=True)
-        return launch.result(stop_app_on_success=self.detach)
+        try:
+            return launch.result(stop_app_on_success=True)
+        except BaseException:
+            if not self.detach and launch.modal_app_id:
+                stop_app(launch.modal_app_id)
+            raise
 
     def launch(
         self,
@@ -618,7 +627,7 @@ class TrainConfig:
         app = self._build_app(training_run_id)
         output_context = modal.enable_output() if show_output else nullcontext()
         with output_context:
-            with app.run(detach=self.detach):
+            with app.run(detach=True):
                 modal_app_id = app.app_id or ""
                 modal_app_url = modal_app_dashboard_url(modal_app_id)
                 if show_output:

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -618,7 +618,7 @@ class TrainConfig:
         app = self._build_app(training_run_id)
         output_context = modal.enable_output() if show_output else nullcontext()
         with output_context:
-            with app.run(detach=True):
+            with app.run(detach=self.detach):
                 modal_app_id = app.app_id or ""
                 modal_app_url = modal_app_dashboard_url(modal_app_id)
                 if show_output:


### PR DESCRIPTION
`TrainConfig.detach` was documented as "set False for an attached run that stops on Ctrl-C" but nothing honored it: `launch()` hard-coded `app.run(detach=True)`, and the field only leaked into `result(stop_app_on_success=self.detach)` — so `detach=False` produced a *detached* app that was never stopped (the exact opposite of the documented behavior).

The first attempt here was `app.run(detach=self.detach)`, which is worse: `launch()` spawns `app.train` and leaves the context immediately, so a non-detached app is torn down seconds after launch and `function_call.get()` waits on a killed call. Reverted.

What this PR does instead: the app is *always* started detached (a dropped connection must not kill a multi-hour run), and `detach` decides what an interrupted `train()` does on the way out:

```python
launch = self.launch(...)
try:
    return launch.result(stop_app_on_success=True)   # was stop_app_on_success=self.detach
except BaseException:
    if not self.detach and launch.modal_app_id:      # attached: die with the client
        stop_app(launch.modal_app_id)
    raise
```

So `detach=False` + Ctrl-C now stops the run, and a successful `train()` stops the app regardless (previously `detach=False` leaked a running app forever). `launch()` and `TrainingGroup` are unchanged and still always detached, matching their docstrings. Field docs/comments updated to describe this.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.


Link to Devin session: https://modal.devinenterprise.com/sessions/f1993fcca8364fda8c7fde50c06d5a6a
Requested by: @joyliu-q
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->