### PR TITLE
Make function timeout increased and add retries

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -340,14 +340,19 @@ def _run_compact_sync() -> None:
         compact_summary_store(summary_store)
 
 
-@app.function(schedule=modal.Cron("*/30 * * * *"))
+@app.function(schedule=modal.Cron("*/30 * * * *"), retries=3, timeout=1800)
 def compact_summaries() -> None:
     """Scheduled compaction of summary stores (every 30 min)."""
     _run_compact_sync()
     print("Compaction complete.")
 
 
-@app.function(schedule=modal.Cron("*/30 * * * *"), secrets=_function_secrets())
+@app.function(
+    schedule=modal.Cron("*/30 * * * *"),
+    secrets=_function_secrets(),
+    retries=3,
+    timeout=1800,
+)
 def reconcile() -> None:
     """Reconcile orphaned training runs and deployments every 30 minutes."""
     from modal_training_gym.common.reconcile import reconcile as _reconcile


### PR DESCRIPTION
Prevent the training gym dashboard on the Modal Dashboard looking red and scary due to timeouts. Increase execution timeout from [default of 5 minutes](https://modal.com/docs/guide/timeouts) to 30 minutes.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->