### PR TITLE
Add endpoint serving and checkpoint helpers

### DIFF
--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -16,6 +16,16 @@ _EXPORTS = {
     "Sample": ("modal_training_gym.common.sample", "Sample"),
     "extract_code": ("modal_training_gym.common.eval", "extract_code"),
     "HarborEval": ("modal_training_gym.common.eval", "HarborEval"),
+    "ensure_endpoint": ("modal_training_gym.common.endpoint", "ensure_endpoint"),
+    "endpoint_chat": ("modal_training_gym.common.endpoint", "endpoint_chat"),
+    "endpoint_chat_message": (
+        "modal_training_gym.common.endpoint",
+        "endpoint_chat_message",
+    ),
+    "wait_for_server_url": (
+        "modal_training_gym.common.endpoint",
+        "wait_for_server_url",
+    ),
     "GLM_4_7": ("modal_training_gym.common.models", "GLM_4_7"),
     "HFModelConfiguration": (
         "modal_training_gym.common.models",
@@ -24,6 +34,10 @@ _EXPORTS = {
     "HuggingFaceDataset": ("modal_training_gym.common.dataset", "HuggingFaceDataset"),
     "MultimodalDataset": ("modal_training_gym.common.dataset", "MultimodalDataset"),
     "list_checkpoints": ("modal_training_gym.common.checkpoint", "list_checkpoints"),
+    "convert_checkpoint_to_hf": (
+        "modal_training_gym.common.checkpoint",
+        "convert_checkpoint_to_hf",
+    ),
     "METADATA_VOLUME_NAME": (
         "modal_training_gym.utils.metadata",
         "METADATA_VOLUME_NAME",
@@ -108,10 +122,15 @@ __all__ = [
     "Sample",
     "extract_code",
     "HarborEval",
+    "ensure_endpoint",
+    "endpoint_chat",
+    "endpoint_chat_message",
+    "wait_for_server_url",
     "HFModelConfiguration",
     "HuggingFaceDataset",
     "MultimodalDataset",
     "list_checkpoints",
+    "convert_checkpoint_to_hf",
     "Kimi_K2_6",
     "Kimi_K2_5",
     "METADATA_VOLUME_NAME",

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -7,7 +7,8 @@ from enum import Enum
 import os
 import time
 
-from modal import Volume
+import modal
+from modal import App, Volume
 from modal.exception import NotFoundError
 
 from modal_training_gym.common.errors import TrainingGymConfigError
@@ -15,7 +16,6 @@ from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.models import ModelConfig
 from modal_training_gym.common.run import TrainingRun
 from modal_training_gym.common.train_result import TrainResult
-from modal_training_gym.deploy_recipes import SglangRecipe, VllmRecipe
 
 
 class CheckpointType(Enum):
@@ -37,6 +37,11 @@ class Checkpoint:
     checkpoints_mount_path: str = ""
 
 
+def _checkpoint_sort_key(name: str) -> tuple[int, bool, str]:
+    stem = name.removeprefix("iter_").removesuffix("_hf")
+    return (int(stem) if stem.isdigit() else -1, name.endswith("_hf"), name)
+
+
 def list_checkpoints(training_run_id: str) -> list[Checkpoint]:
     result = TrainResult.from_training_run_id(training_run_id)
     if result.framework in {
@@ -49,18 +54,31 @@ def list_checkpoints(training_run_id: str) -> list[Checkpoint]:
     raise TrainingGymConfigError(f"Unsupported framework: {result.framework}")
 
 
-def _to_volume_path(checkpoint_dir: str, checkpoints_mount_path: str) -> str:
+def to_volume_path(
+    checkpoint_dir: str, checkpoints_mount_path: str = "/checkpoints"
+) -> str:
+    """Convert an in-container checkpoint path to a Volume-relative one.
+
+    Modal Volume APIs and ``modal endpoint create --custom-volume-path`` address
+    entries relative to the Volume root, not the container mount point, so
+    ``/checkpoints/run-1/iter_10`` has to become ``run-1/iter_10``.
+    """
     checkpoint_dir_norm = os.path.normpath(checkpoint_dir)
     checkpoints_mount_path_norm = os.path.normpath(checkpoints_mount_path)
 
     if os.path.isabs(checkpoint_dir_norm):
-        if (
+        if not (
             checkpoint_dir_norm == checkpoints_mount_path_norm
             or checkpoint_dir_norm.startswith(checkpoints_mount_path_norm + os.sep)
         ):
-            rel = os.path.relpath(checkpoint_dir_norm, checkpoints_mount_path_norm)
-            return "" if rel == "." else rel
-        return checkpoint_dir_norm.lstrip("/")
+            raise TrainingGymConfigError(
+                f"Checkpoint path {checkpoint_dir!r} is not under the checkpoints "
+                f"mount {checkpoints_mount_path!r}, so it has no Volume-relative "
+                "path. Pass a path inside the mount, or pass the matching "
+                "checkpoints_mount_path."
+            )
+        rel = os.path.relpath(checkpoint_dir_norm, checkpoints_mount_path_norm)
+        return "" if rel == "." else rel
 
     return checkpoint_dir_norm.lstrip("/")
 
@@ -80,9 +98,12 @@ def _list_checkpoints(train_result: "TrainResult") -> list[Checkpoint]:
         train_result.checkpoints_volume_name or f"{train_result.app_name}-checkpoints"
     )
     checkpoints_mount_path = train_result.checkpoints_mount_path or "/checkpoints"
-    volume = Volume.from_name(checkpoints_volume_name, create_if_missing=True)
     prefix = "iter_"
-    rel = _to_volume_path(checkpoint_dir, checkpoints_mount_path)
+    try:
+        rel = to_volume_path(checkpoint_dir, checkpoints_mount_path)
+    except TrainingGymConfigError:
+        return []
+    volume = Volume.from_name(checkpoints_volume_name, create_if_missing=True)
 
     try:
         entries = {
@@ -107,7 +128,7 @@ def _list_checkpoints(train_result: "TrainResult") -> list[Checkpoint]:
     checkpoints: list[Checkpoint] = []
     for entry in sorted(
         (entry for entry in entries.values() if _is_dir_entry(entry)),
-        key=lambda entry: _entry_name(entry),
+        key=lambda entry: _checkpoint_sort_key(_entry_name(entry)),
     ):
         name = _entry_name(entry)
         if not name.startswith(prefix):
@@ -128,14 +149,11 @@ def _list_checkpoints(train_result: "TrainResult") -> list[Checkpoint]:
     return checkpoints
 
 
-def _conversion_gpu_spec(
-    checkpoint: Checkpoint, recipe: VllmRecipe | SglangRecipe
-) -> str:
-    run_id = getattr(checkpoint, "training_run_id", "")
-    if run_id:
+def _conversion_gpu_spec(checkpoint: Checkpoint) -> str:
+    if checkpoint.training_run_id:
         try:
-            training_run = TrainingRun.from_id(run_id)
-        except KeyError:
+            training_run = TrainingRun.from_id(checkpoint.training_run_id)
+        except (KeyError, FileNotFoundError, NotFoundError):
             training_run = None
         if training_run is not None:
             recipe_config = training_run.config.get("recipe", {})
@@ -145,22 +163,31 @@ def _conversion_gpu_spec(
                 n_gpu = int(n_gpu)
                 return f"{gpu_type}:{n_gpu}" if n_gpu > 1 else str(gpu_type)
 
-    if isinstance(recipe, SglangRecipe):
-        gpu = recipe.gpu
-        n_gpu = recipe.tp or 1
-    else:
-        gpu = recipe.gpu
-        n_gpu = recipe.n_gpu or 1
-    return f"{gpu}:{n_gpu}" if n_gpu > 1 else str(gpu)
+    raise TrainingGymConfigError(
+        "Could not infer a GPU spec for checkpoint conversion from training run "
+        f"{checkpoint.training_run_id!r}. Pass gpu=... explicitly, e.g. "
+        'convert_checkpoint_to_hf(checkpoint, model, gpu="H100:8").'
+    )
 
 
 def convert_checkpoint_to_hf(
     checkpoint: Checkpoint,
     model: ModelConfig,
-    recipe: VllmRecipe | SglangRecipe,
+    *,
+    gpu: str | None = None,
 ) -> Checkpoint:
-    import modal
-    from modal import App, Volume
+    """Convert a Megatron/torch_dist checkpoint to HuggingFace format on Modal.
+
+    Serving runtimes (and ``modal endpoint create --custom-volume-path``) need an
+    HF-format directory with a ``config.json``; slime writes torch_dist
+    checkpoints unless HF export is enabled. This runs slime's converter on a GPU
+    worker and writes ``<checkpoint>_hf`` next to the input on the same
+    checkpoints Volume.
+
+    ``gpu`` defaults to the training run's actor GPU spec.
+    """
+    if checkpoint.checkpoint_type is CheckpointType.hf:
+        return checkpoint
 
     checkpoints_volume_name = checkpoint.checkpoints_volume_name
     if not checkpoints_volume_name:
@@ -175,23 +202,21 @@ def convert_checkpoint_to_hf(
             "Cannot convert a megatron checkpoint without model_name or model_path."
         )
 
-    hf_cache_volume = Volume.from_name("huggingface-cache", create_if_missing=True)
-    checkpoints_volume = Volume.from_name(
-        checkpoints_volume_name,
-        create_if_missing=True,
-    )
     from modal_training_gym.common import hf_secrets
     from modal_training_gym.frameworks.slime.launcher import _build_slime_base_image
 
+    hf_cache_volume = Volume.from_name("huggingface-cache", create_if_missing=True)
+    checkpoints_volume = Volume.from_name(
+        checkpoints_volume_name, create_if_missing=True
+    )
     image = _build_slime_base_image().add_local_python_source(
         "modal_training_gym", copy=True
     )
     conversion_app = App("training-gym-checkpoint-convert")
-    gpu_spec = _conversion_gpu_spec(checkpoint, recipe)
 
     @conversion_app.function(
         image=image,
-        gpu=gpu_spec,
+        gpu=gpu or _conversion_gpu_spec(checkpoint),
         volumes={
             "/root/.cache/huggingface": hf_cache_volume,
             checkpoints_mount_path: checkpoints_volume,
@@ -201,11 +226,7 @@ def convert_checkpoint_to_hf(
         serialized=True,
         name="convert_megatron_to_hf",
     )
-    def convert_megatron_to_hf(
-        input_dir: str,
-        output_dir: str,
-        model_ref: str,
-    ) -> str:
+    def convert_megatron_to_hf(input_dir: str, output_dir: str, model_ref: str) -> str:
         import importlib.util
         import shlex
         import subprocess
@@ -226,7 +247,8 @@ def convert_checkpoint_to_hf(
         convert_script = spec.origin if spec is not None else None
         if not convert_script:
             raise RuntimeError(
-                "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf not found"
+                "modal_training_gym.frameworks.slime.modal_helpers."
+                "convert_torch_dist_to_hf not found"
             )
         cmd = (
             f"python {convert_script} "
@@ -241,13 +263,12 @@ def convert_checkpoint_to_hf(
         return output_dir
 
     output_path = f"{checkpoint.path}_hf"
-    with modal.enable_output():
-        with conversion_app.run():
-            output_path = convert_megatron_to_hf.remote(
-                input_dir=checkpoint.path,
-                output_dir=output_path,
-                model_ref=model_ref,
-            )
+    with modal.enable_output(), conversion_app.run():
+        output_path = convert_megatron_to_hf.remote(
+            input_dir=checkpoint.path,
+            output_dir=output_path,
+            model_ref=model_ref,
+        )
 
     return Checkpoint(
         checkpoint_type=CheckpointType.hf,

--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -46,6 +46,13 @@ def load_config() -> dict[str, Any]:
         return {}
 
 
+def _save_config(config: dict[str, Any]) -> None:
+    fd = os.open(CONFIG_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        os.fchmod(f.fileno(), 0o600)
+        f.write(_render(config))
+
+
 def save_dashboard_url(url: str, *, proxy_auth: bool | None = None) -> None:
     """Persist the deployed dashboard URL and optional proxy-auth mode."""
     config = load_config()
@@ -56,7 +63,7 @@ def save_dashboard_url(url: str, *, proxy_auth: bool | None = None) -> None:
     if proxy_auth is not None:
         dashboard["proxy_auth"] = proxy_auth
     config["dashboard"] = dashboard
-    CONFIG_PATH.write_text(_render(config))
+    _save_config(config)
 
 
 def get_dashboard_url() -> str | None:
@@ -146,7 +153,7 @@ def save_proxy_auth(key: str, secret: str) -> None:
     """Persist the proxy-auth token pair under ``[proxy_auth]``."""
     config = load_config()
     config[PROXY_AUTH_SECTION] = {"key": key.strip(), "secret": secret.strip()}
-    CONFIG_PATH.write_text(_render(config))
+    _save_config(config)
 
 
 def load_proxy_auth() -> bool:

--- a/modal_training_gym/common/deployment.py
+++ b/modal_training_gym/common/deployment.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 from modal_training_gym.common.checkpoint import (
     Checkpoint,
     CheckpointType,
+    _conversion_gpu_spec,
     convert_checkpoint_to_hf,
 )
 from modal_training_gym.common.errors import TrainingGymConfigError
@@ -212,10 +213,22 @@ class DeploymentConfig:
             self.checkpoint is not None
             and self.checkpoint.checkpoint_type == CheckpointType.megatron
         ):
+            try:
+                conversion_gpu = _conversion_gpu_spec(self.checkpoint)
+            except TrainingGymConfigError as exc:
+                if not recipe.gpu:
+                    raise TrainingGymConfigError(
+                        "Cannot infer a GPU for checkpoint conversion. "
+                        "Set DeploymentConfig.recipe.gpu before serving."
+                    ) from exc
+                n_gpu = recipe.tp if isinstance(recipe, SglangRecipe) else recipe.n_gpu
+                conversion_gpu = (
+                    f"{recipe.gpu}:{n_gpu}" if n_gpu and n_gpu > 1 else recipe.gpu
+                )
             self.checkpoint = convert_checkpoint_to_hf(
                 checkpoint=self.checkpoint,
                 model=model,
-                recipe=recipe,
+                gpu=conversion_gpu,
             )
 
         model_path = self._resolved_model_path()

--- a/modal_training_gym/common/endpoint.py
+++ b/modal_training_gym/common/endpoint.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import time
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+import modal
+
+from modal_training_gym.common.checkpoint import to_volume_path
+from modal_training_gym.common.config import load_proxy_auth, modal_proxy_auth_headers
+from modal_training_gym.common.errors import TrainingGymConfigError
+
+_MODAL_HOST_SUFFIXES = (
+    ".modal.run",
+    ".modal.host",
+    ".modal.direct",
+    ".modal.dev",
+)
+
+_DEAD_ENDPOINT_STATUSES = frozenset({"failed", "cancelled", "cancelling", "stopped"})
+
+
+def is_modal_host(base_url: str) -> bool:
+    parsed = urlsplit(base_url)
+    if parsed.scheme != "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    return any(
+        host == suffix.lstrip(".") or host.endswith(suffix)
+        for suffix in _MODAL_HOST_SUFFIXES
+    )
+
+
+def proxy_auth_headers(base_url: str) -> dict[str, str]:
+    return modal_proxy_auth_headers() if is_modal_host(base_url) else {}
+
+
+def _list_endpoints(*, env: str | None = None) -> list[dict[str, Any]]:
+    command = [sys.executable, "-m", "modal", "endpoint", "list", "--json"]
+    if env:
+        command.extend(["--env", env])
+    return json.loads(subprocess.check_output(command, text=True, timeout=60))
+
+
+def _find_endpoint(name: str, endpoints: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for endpoint in endpoints:
+        if endpoint.get("name") == name:
+            return endpoint
+    return None
+
+
+def ensure_endpoint(
+    *,
+    name: str,
+    model: str,
+    unauthenticated: bool = True,
+    routing_region: str | None = None,
+    custom_hf_repo: str | None = None,
+    custom_hf_revision: str | None = None,
+    custom_volume_name: str | None = None,
+    custom_volume_path: str | None = None,
+    custom_volume_mount_path: str = "/checkpoints",
+    env: str | None = None,
+    wait_timeout_sec: float = 15 * 60,
+) -> str:
+    """Create or reuse a managed Modal Endpoint and return its ready base URL.
+
+    The endpoint name is derived from *name* and the serving configuration.
+    Set ``unauthenticated=False`` for Modal proxy authentication. Custom
+    weights may come from either a Hugging Face repository or a Modal Volume.
+    """
+    if custom_hf_repo and custom_volume_name:
+        raise TrainingGymConfigError(
+            "Pass either custom_hf_repo or custom_volume_name, not both."
+        )
+    if custom_hf_revision and not custom_hf_repo:
+        raise TrainingGymConfigError("custom_hf_revision requires custom_hf_repo.")
+    if custom_volume_path is not None and not custom_volume_name:
+        raise TrainingGymConfigError("custom_volume_path requires custom_volume_name.")
+    if custom_volume_name and not custom_volume_path:
+        raise TrainingGymConfigError("custom_volume_name requires custom_volume_path.")
+    if not unauthenticated and not load_proxy_auth():
+        raise TrainingGymConfigError(
+            "Authenticated Modal Endpoints require MODAL_KEY and MODAL_SECRET. "
+            "Run `training-gym set-proxy-auth` or export both variables."
+        )
+
+    volume_path = (
+        to_volume_path(custom_volume_path, custom_volume_mount_path)
+        if custom_volume_path
+        else None
+    )
+    if custom_volume_name and volume_path == "":
+        volume_path = "/"
+
+    spec = {
+        "model": model,
+        "routing_region": routing_region,
+        "custom_hf_repo": custom_hf_repo,
+        "custom_hf_revision": custom_hf_revision,
+        "custom_volume_name": custom_volume_name,
+        "custom_volume_path": volume_path,
+        "unauthenticated": unauthenticated,
+    }
+    digest = hashlib.sha256(
+        json.dumps(spec, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:12]
+    endpoint_name = f"{name[:48].rstrip('-')}-{digest}"
+
+    existing = _find_endpoint(endpoint_name, _list_endpoints(env=env))
+    if existing:
+        status = str(existing.get("status") or "").strip().lower()
+        if status in _DEAD_ENDPOINT_STATUSES:
+            raise RuntimeError(
+                f"Modal Endpoint {endpoint_name!r} is {status}. "
+                "Choose another name or remove the failed endpoint."
+            )
+    else:
+        command = [
+            sys.executable,
+            "-m",
+            "modal",
+            "endpoint",
+            "create",
+            "--name",
+            endpoint_name,
+            "--model",
+            model,
+        ]
+        if env:
+            command.extend(["--env", env])
+        if unauthenticated:
+            command.append("--unauthenticated")
+        if routing_region:
+            command.extend(["--routing-region", routing_region])
+        if custom_hf_repo:
+            command.extend(["--custom-hf-repo", custom_hf_repo])
+        if custom_hf_revision:
+            command.extend(["--custom-hf-revision", custom_hf_revision])
+        if custom_volume_name:
+            command.extend(["--custom-volume-name", custom_volume_name])
+        if volume_path is not None:
+            command.extend(["--custom-volume-path", volume_path])
+        subprocess.run(command, check=True, timeout=120)
+
+    return _wait_for_endpoint_url(
+        endpoint_name,
+        env=env,
+        proxy_auth=not unauthenticated,
+        timeout_sec=wait_timeout_sec,
+    )
+
+
+def wait_for_server_url(
+    server: Any,
+    *,
+    timeout_sec: float = 15 * 60,
+    label: str = "Server",
+    proxy_auth: bool = False,
+) -> str:
+    """Wait for a Modal server URL and its OpenAI-compatible model route."""
+    deadline = time.monotonic() + timeout_sec
+    url: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            raw = server.get_url()
+        except modal.exception.NotFoundError:
+            raw = None
+        if raw:
+            url = raw.rstrip("/")
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"Timed out waiting for a URL from {label}")
+
+    headers: dict[str, str] = {}
+    if proxy_auth:
+        headers = proxy_auth_headers(url)
+        if not headers:
+            raise TrainingGymConfigError(
+                "Proxy authentication requires an HTTPS Modal URL and "
+                "MODAL_KEY and MODAL_SECRET."
+            )
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(
+                f"{url}/v1/models",
+                headers=headers,
+                timeout=30,
+                follow_redirects=False,
+            )
+            if response.status_code == 200:
+                return url
+            if 300 <= response.status_code < 400:
+                raise RuntimeError(
+                    f"{label} readiness redirected to "
+                    f"{response.headers.get('location', '<unknown>')!r}"
+                )
+            if response.status_code in {401, 403}:
+                if not proxy_auth:
+                    raise RuntimeError(
+                        f"{label} returned HTTP {response.status_code} without "
+                        "proxy credentials. Retry with proxy_auth=True if it uses "
+                        "Modal proxy authentication."
+                    )
+                raise RuntimeError(
+                    f"{label} rejected proxy authentication. "
+                    "Run `training-gym set-proxy-auth` and retry."
+                )
+            if response.status_code not in {404, 429, 500, 502, 503, 504}:
+                response.raise_for_status()
+            last_error = RuntimeError(
+                f"{label} readiness returned HTTP {response.status_code}"
+            )
+        except httpx.RequestError as exc:
+            last_error = exc
+        time.sleep(2)
+    raise TimeoutError(
+        f"Timed out waiting for {label} at {url} to become ready"
+    ) from last_error
+
+
+def _wait_for_endpoint_url(
+    name: str,
+    *,
+    env: str | None = None,
+    timeout_sec: float = 15 * 60,
+    proxy_auth: bool = False,
+) -> str:
+    return wait_for_server_url(
+        modal.Server.from_name(f"ep-{name}", "Server", environment_name=env),
+        timeout_sec=timeout_sec,
+        label=f"Modal Endpoint {name!r}",
+        proxy_auth=proxy_auth,
+    )
+
+
+def endpoint_chat(
+    base_url: str,
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    timeout: int = 120,
+    max_attempts: int = 4,
+    extra_body: dict[str, Any] | None = None,
+    proxy_auth: bool = False,
+    **kwargs: Any,
+) -> str:
+    """Send a chat-completions request and return the assistant text."""
+    message = endpoint_chat_message(
+        base_url,
+        model=model,
+        messages=messages,
+        timeout=timeout,
+        max_attempts=max_attempts,
+        extra_body=extra_body,
+        proxy_auth=proxy_auth,
+        **kwargs,
+    )
+    return str(message.get("content") or message.get("reasoning_content") or "")
+
+
+def endpoint_chat_message(
+    base_url: str,
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    timeout: int = 120,
+    max_attempts: int = 4,
+    extra_body: dict[str, Any] | None = None,
+    proxy_auth: bool = False,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Send a chat-completions request and return the assistant message.
+
+    Set ``proxy_auth=True`` for endpoints protected by Modal proxy
+    authentication. Transient server and rate-limit responses are retried up
+    to *max_attempts*.
+    """
+    url = f"{base_url.rstrip('/')}/v1/chat/completions"
+    body: dict[str, Any] = {"model": model, "messages": messages, **kwargs}
+    if extra_body:
+        body.update(extra_body)
+    headers = {"Content-Type": "application/json"}
+    if proxy_auth:
+        proxy_headers = proxy_auth_headers(base_url)
+        if not proxy_headers:
+            raise TrainingGymConfigError(
+                "Proxy authentication requires an HTTPS Modal URL and "
+                "MODAL_KEY and MODAL_SECRET."
+            )
+        headers.update(proxy_headers)
+    transient = {429, 500, 502, 503, 504}
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            resp = httpx.post(
+                url,
+                json=body,
+                timeout=timeout,
+                headers=headers,
+                follow_redirects=False,
+            )
+            if 300 <= resp.status_code < 400:
+                raise RuntimeError(
+                    f"Modal Endpoint redirected to "
+                    f"{resp.headers.get('location', '<unknown>')!r}"
+                )
+            if resp.status_code in transient and attempt < max_attempts:
+                time.sleep(min(2 * attempt, 5))
+                continue
+            if resp.status_code in {401, 403}:
+                if not proxy_auth:
+                    raise RuntimeError(
+                        f"HTTP {resp.status_code} from {url}. Retry with "
+                        "proxy_auth=True if the endpoint uses Modal proxy "
+                        "authentication."
+                    )
+                raise RuntimeError(
+                    f"HTTP {resp.status_code} from {url}. Proxy credentials were "
+                    "rejected. Refresh them with `modal workspace proxy-tokens "
+                    "create` and export MODAL_KEY and MODAL_SECRET."
+                )
+            resp.raise_for_status()
+            return resp.json()["choices"][0]["message"]
+        except httpx.RequestError:
+            if attempt >= max_attempts:
+                raise
+            time.sleep(min(2 * attempt, 5))
+
+    raise RuntimeError(f"Chat completions exhausted {max_attempts} attempts at {url}")

--- a/modal_training_gym/common/train_result.py
+++ b/modal_training_gym/common/train_result.py
@@ -51,6 +51,7 @@ from dataclasses import asdict, dataclass, field, fields
 import copy
 from typing import TYPE_CHECKING, Any
 
+from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.utils.metadata import (
     MetadataStore,
@@ -61,6 +62,7 @@ from modal_training_gym.utils.metadata import (
 if TYPE_CHECKING:
     from modal import Volume
 
+    from modal_training_gym.common.checkpoint import Checkpoint
     from modal_training_gym.common.models import ModelConfig
 
 
@@ -185,29 +187,71 @@ class TrainResult:
 
     # ── Volume lookup ────────────────────────────────────────────────────
 
-    def volume(self) -> "Volume":
-        volume_name = self.checkpoints_volume_name or f"{self.app_name}-checkpoints"
-        return Volume.from_name(volume_name, create_if_missing=True)
-
     @property
-    def model(self) -> "ModelConfig":
+    def checkpoints_volume(self) -> str:
+        return self.checkpoints_volume_name or f"{self.app_name}-checkpoints"
+
+    def volume(self) -> "Volume":
+        from modal import Volume
+
+        return Volume.from_name(self.checkpoints_volume, create_if_missing=True)
+
+    def _require_model_config(self) -> "ModelConfig":
         if self.model_config is None:
             raise ValueError(
                 "No model_config on this TrainResult. "
                 "Was it saved by an older launcher?"
             )
+        return self.model_config
 
-        from modal_training_gym.common.checkpoint import list_checkpoints
-
-        model = copy.copy(self.model_config)
-        checkpoints = list_checkpoints(self.training_run_id)
-        if checkpoints:
-            model.model_path = checkpoints[-1].path
-        elif self.checkpoint_dir:
-            model.model_path = self.checkpoint_dir
-
+    def _model_at(self, model_path: str) -> "ModelConfig":
+        model = copy.copy(self._require_model_config())
+        if model_path:
+            model.model_path = model_path
         if self.checkpoints_volume_name:
             setattr(model, "checkpoints_volume_name", self.checkpoints_volume_name)
         if self.checkpoints_mount_path:
             setattr(model, "checkpoints_mount_path", self.checkpoints_mount_path)
         return model
+
+    def checkpoints(self) -> "list[Checkpoint]":
+        from modal_training_gym.common.checkpoint import list_checkpoints
+
+        return list_checkpoints(self.training_run_id)
+
+    @property
+    def model(self) -> "ModelConfig":
+        checkpoints = self.checkpoints()
+        model_path = checkpoints[-1].path if checkpoints else self.checkpoint_dir
+        return self._model_at(model_path)
+
+    def hf_model(self, *, gpu: str | None = None) -> "ModelConfig":
+        """Return a model pointed at the newest checkpoint in HuggingFace format.
+
+        slime writes torch_dist checkpoints unless HF export is enabled, and
+        neither ``modal endpoint create --custom-volume-path`` nor any serving
+        runtime can load those. This converts the newest checkpoint to
+        ``<name>_hf`` on the same Volume (a GPU job, minutes) and returns a
+        :class:`~modal_training_gym.common.models.ModelConfig` pointing at it.
+
+        ``gpu`` overrides the conversion worker's GPU spec, which otherwise
+        comes from the training run's actor GPUs.
+        """
+        from modal_training_gym.common.checkpoint import (
+            _checkpoint_sort_key,
+            convert_checkpoint_to_hf,
+        )
+
+        model_config = self._require_model_config()
+        checkpoints = self.checkpoints()
+        if not checkpoints:
+            raise TrainingGymConfigError(
+                f"No checkpoints found for training run {self.training_run_id!r}."
+            )
+        latest = max(
+            checkpoints, key=lambda checkpoint: _checkpoint_sort_key(checkpoint.name)
+        )
+        if latest.checkpoint_type.value == "hf":
+            return self._model_at(latest.path)
+        converted = convert_checkpoint_to_hf(latest, model_config, gpu=gpu)
+        return self._model_at(converted.path)

--- a/tests/test_deployment_chat.py
+++ b/tests/test_deployment_chat.py
@@ -1,7 +1,12 @@
 from types import SimpleNamespace
 
+import pytest
+
+from modal_training_gym.common.checkpoint import CheckpointType
 from modal_training_gym.common import deployment as deployment_module
-from modal_training_gym.common.deployment import ModelDeployment
+from modal_training_gym.common.deployment import DeploymentConfig, ModelDeployment
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.deploy_recipes.vllm_recipe import VllmRecipe
 
 
 def test_chat_serializes_tool_arguments_without_mutating_messages(monkeypatch) -> None:
@@ -96,3 +101,18 @@ def test_generate_accepts_caller_supplied_messages(monkeypatch) -> None:
         "ensure_ready": False,
         "kwargs": {"temperature": 0},
     }
+
+
+def test_serve_requires_gpu_when_conversion_inference_fails(monkeypatch) -> None:
+    def _missing_gpu(_checkpoint) -> str:
+        raise TrainingGymConfigError("missing training metadata")
+
+    monkeypatch.setattr(deployment_module, "_conversion_gpu_spec", _missing_gpu)
+    config = DeploymentConfig(
+        model=SimpleNamespace(),
+        checkpoint=SimpleNamespace(checkpoint_type=CheckpointType.megatron),
+        recipe=VllmRecipe(),
+    )
+
+    with pytest.raises(TrainingGymConfigError, match="recipe.gpu"):
+        config.serve()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import stat
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from modal_training_gym.common import config as local_config
+from modal_training_gym.common.checkpoint import to_volume_path
+from modal_training_gym.common.endpoint import (
+    endpoint_chat_message,
+    ensure_endpoint,
+    is_modal_host,
+    proxy_auth_headers,
+    wait_for_server_url,
+)
+from modal_training_gym.common.errors import TrainingGymConfigError
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_dir", "mount_path", "expected"),
+    [
+        ("/checkpoints/run-1/iter_10_hf", "/checkpoints", "run-1/iter_10_hf"),
+        ("/checkpoints/run-1/iter_10_hf/", "/checkpoints", "run-1/iter_10_hf"),
+        ("/checkpoints", "/checkpoints", ""),
+        ("run-1/iter_10_hf", "/checkpoints", "run-1/iter_10_hf"),
+        ("/data/ckpt/iter_5_hf", "/data/ckpt", "iter_5_hf"),
+        ("/checkpoints/run-1/iter_2_hf", None, "run-1/iter_2_hf"),
+    ],
+)
+def test_to_volume_path_strips_mount_prefix(
+    checkpoint_dir: str, mount_path: str | None, expected: str
+) -> None:
+    if mount_path is None:
+        assert to_volume_path(checkpoint_dir) == expected
+    else:
+        assert to_volume_path(checkpoint_dir, mount_path) == expected
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_dir", "mount_path"),
+    [
+        ("/elsewhere/iter_5_hf", "/checkpoints"),
+        ("/checkpointsX/iter_5_hf", "/checkpoints"),
+        ("/data/ckpt/iter_5_hf", "/checkpoints"),
+    ],
+)
+def test_to_volume_path_rejects_paths_outside_the_mount(
+    checkpoint_dir: str, mount_path: str
+) -> None:
+    with pytest.raises(TrainingGymConfigError):
+        to_volume_path(checkpoint_dir, mount_path)
+
+
+@pytest.mark.parametrize(
+    ("base_url", "modal_host"),
+    [
+        ("https://ws--ep-abc.modal.run", True),
+        ("https://ws--ep-abc.modal.run/v1/chat/completions", True),
+        ("https://something.modal.host", True),
+        ("https://gym.modal.dev", True),
+        ("https://evil.example.com", False),
+        ("https://modal.run.evil.com", False),
+        ("https://my-modal.dev.attacker.net", False),
+        ("http://localhost:8000", False),
+        ("http://gym.modal.dev", False),
+    ],
+)
+def test_proxy_auth_headers_only_for_modal_https_hosts(
+    base_url: str, modal_host: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MODAL_KEY", "wk-test")
+    monkeypatch.setenv("MODAL_SECRET", "ws-test")
+
+    assert is_modal_host(base_url) is modal_host
+    if modal_host:
+        assert proxy_auth_headers(base_url) == {
+            "Modal-Key": "wk-test",
+            "Modal-Secret": "ws-test",
+        }
+    else:
+        assert proxy_auth_headers(base_url) == {}
+
+
+def test_proxy_auth_headers_empty_without_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.modal_proxy_auth_headers", lambda: {}
+    )
+
+    assert proxy_auth_headers("https://ws--ep-abc.modal.run") == {}
+
+
+def test_wait_for_server_url_only_attaches_proxy_headers_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.httpx.get",
+        lambda *_, **kwargs: requests.append(kwargs) or _FakeResponse(),
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.proxy_auth_headers",
+        lambda _: {"Modal-Key": "wk", "Modal-Secret": "ws"},
+    )
+    server = SimpleNamespace(get_url=lambda: "https://ws--ep.modal.run")
+
+    wait_for_server_url(server, timeout_sec=1)
+    wait_for_server_url(server, timeout_sec=1, proxy_auth=True)
+
+    assert requests[0]["headers"] == {}
+    assert requests[1]["headers"]["Modal-Key"] == "wk"
+
+
+@pytest.mark.parametrize(
+    ("proxy_auth", "expected"),
+    [
+        (False, "proxy_auth=True"),
+        (True, "rejected proxy authentication"),
+    ],
+)
+def test_wait_for_server_url_distinguishes_unauthenticated_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    proxy_auth: bool,
+    expected: str,
+) -> None:
+    response = _FakeResponse()
+    response.status_code = 401
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.httpx.get",
+        lambda *_, **__: response,
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.proxy_auth_headers",
+        lambda _: {"Modal-Key": "wk", "Modal-Secret": "ws"},
+    )
+    server = SimpleNamespace(get_url=lambda: "https://ws--ep.modal.run")
+
+    with pytest.raises(RuntimeError, match=expected):
+        wait_for_server_url(server, timeout_sec=1, proxy_auth=proxy_auth)
+
+
+def test_save_proxy_auth_creates_private_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    config_path = tmp_path / ".training-gym.toml"
+    monkeypatch.setattr(local_config, "CONFIG_PATH", config_path)
+    real_fchmod = local_config.os.fchmod
+    mode_before_fchmod: int | None = None
+
+    def capture_mode(fd: int, mode: int) -> None:
+        nonlocal mode_before_fchmod
+        mode_before_fchmod = stat.S_IMODE(local_config.os.fstat(fd).st_mode)
+        real_fchmod(fd, mode)
+
+    monkeypatch.setattr(local_config.os, "fchmod", capture_mode)
+    previous_umask = local_config.os.umask(0o022)
+    try:
+        local_config.save_proxy_auth("wk-test", "ws-test")
+    finally:
+        local_config.os.umask(previous_umask)
+
+    assert mode_before_fchmod == 0o600
+
+
+def test_save_proxy_auth_restricts_existing_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    config_path = tmp_path / ".training-gym.toml"
+    config_path.write_text('[dashboard]\nurl = "https://dashboard"\n')
+    config_path.chmod(0o644)
+    monkeypatch.setattr(local_config, "CONFIG_PATH", config_path)
+
+    local_config.save_proxy_auth("wk-test", "ws-test")
+
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+    assert local_config.get_proxy_auth() == ("wk-test", "ws-test")
+
+
+class _FakeEndpointCli:
+    def __init__(self, listed: list[dict[str, Any]]) -> None:
+        self.listed = listed
+        self.commands: list[list[str]] = []
+        self.waits: list[tuple[str, str | None, bool]] = []
+
+    def run(self, command: list[str], **_: Any) -> None:
+        self.commands.append(command)
+
+
+class _FakeResponse:
+    status_code = 200
+    headers: dict[str, str] = {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+
+@pytest.fixture
+def fake_endpoint_cli(monkeypatch: pytest.MonkeyPatch):
+    def _install(listed: list[dict[str, Any]]) -> _FakeEndpointCli:
+        cli = _FakeEndpointCli(listed)
+        monkeypatch.setattr(
+            "modal_training_gym.common.endpoint._list_endpoints",
+            lambda **_: cli.listed,
+        )
+        monkeypatch.setattr(
+            "modal_training_gym.common.endpoint.subprocess.run", cli.run
+        )
+        monkeypatch.setattr(
+            "modal_training_gym.common.endpoint.load_proxy_auth", lambda: True
+        )
+        monkeypatch.setattr(
+            "modal_training_gym.common.endpoint.proxy_auth_headers", lambda _: {}
+        )
+
+        def _wait(name: str, *, env=None, proxy_auth=False, **_: Any) -> str:
+            cli.waits.append((name, env, proxy_auth))
+            return f"https://ws--ep-{name}.modal.run"
+
+        monkeypatch.setattr(
+            "modal_training_gym.common.endpoint._wait_for_endpoint_url",
+            _wait,
+        )
+        monkeypatch.setattr(
+            "modal_training_gym.common.endpoint.httpx.get",
+            lambda *_, **__: _FakeResponse(),
+        )
+        return cli
+
+    return _install
+
+
+@pytest.mark.parametrize(
+    ("custom_volume_path", "mount_path", "expected_rel"),
+    [
+        ("/checkpoints/run-1/iter_10_hf", None, "run-1/iter_10_hf"),
+        ("/data/ckpt/run-1/iter_10_hf", "/data/ckpt", "run-1/iter_10_hf"),
+        ("/checkpoints", None, "/"),
+    ],
+)
+def test_ensure_endpoint_converts_volume_path_and_defaults_unauthenticated(
+    fake_endpoint_cli,
+    custom_volume_path: str,
+    mount_path: str | None,
+    expected_rel: str,
+) -> None:
+    cli = fake_endpoint_cli([])
+    kwargs: dict[str, Any] = {
+        "name": "my-ft",
+        "model": "Qwen/Qwen3-4B",
+        "custom_volume_name": "gym-checkpoints",
+        "custom_volume_path": custom_volume_path,
+    }
+    if mount_path is not None:
+        kwargs["custom_volume_mount_path"] = mount_path
+
+    url = ensure_endpoint(**kwargs)
+
+    assert url.startswith("https://ws--ep-my-ft-")
+    (command,) = cli.commands
+    assert command[command.index("--custom-volume-path") + 1] == expected_rel
+    assert "--unauthenticated" in command
+    assert cli.waits[-1][2] is False
+
+
+def test_ensure_endpoint_rejects_empty_volume_path(fake_endpoint_cli) -> None:
+    fake_endpoint_cli([])
+
+    with pytest.raises(TrainingGymConfigError, match="requires custom_volume_path"):
+        ensure_endpoint(
+            name="my-ft",
+            model="Qwen/Qwen3-4B",
+            custom_volume_name="gym-checkpoints",
+            custom_volume_path="",
+        )
+
+
+def test_ensure_endpoint_reuses_live_endpoint_without_creating(
+    fake_endpoint_cli,
+) -> None:
+    cli = fake_endpoint_cli([])
+    ensure_endpoint(name="my-ft", model="Qwen/Qwen3-4B")
+    endpoint_name = cli.waits[-1][0]
+    cli.commands.clear()
+    cli.listed = [{"name": endpoint_name, "status": "running"}]
+
+    url = ensure_endpoint(name="my-ft", model="Qwen/Qwen3-4B")
+
+    assert url == f"https://ws--ep-{endpoint_name}.modal.run"
+    assert cli.commands == []
+
+
+def test_ensure_endpoint_names_include_auth_mode(fake_endpoint_cli) -> None:
+    cli = fake_endpoint_cli([])
+    ensure_endpoint(name="my-ft", model="Qwen/Qwen3-4B")
+    public_name = cli.waits[-1][0]
+    assert cli.waits[-1][2] is False
+    assert "--unauthenticated" in cli.commands[-1]
+
+    ensure_endpoint(name="my-ft", model="Qwen/Qwen3-4B", unauthenticated=False)
+    authenticated_name = cli.waits[-1][0]
+    assert cli.waits[-1][2] is True
+
+    assert public_name != authenticated_name
+    assert "--unauthenticated" not in cli.commands[-1]
+
+
+def test_ensure_endpoint_requires_proxy_credentials_when_authenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.load_proxy_auth", lambda: False
+    )
+
+    with pytest.raises(TrainingGymConfigError, match="MODAL_KEY"):
+        ensure_endpoint(name="my-ft", model="Qwen/Qwen3-4B", unauthenticated=False)
+
+
+def test_endpoint_chat_attaches_proxy_headers_only_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, Any]] = []
+
+    def _post(*_: Any, **kwargs: Any) -> _FakeResponse:
+        requests.append(kwargs)
+        return _FakeResponse()
+
+    monkeypatch.setattr("modal_training_gym.common.endpoint.httpx.post", _post)
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.proxy_auth_headers",
+        lambda _: {"Modal-Key": "wk", "Modal-Secret": "ws"},
+    )
+
+    endpoint_chat_message(
+        "https://ws--ep.modal.run",
+        model="model",
+        messages=[],
+    )
+    assert requests[0]["headers"] == {"Content-Type": "application/json"}
+
+    endpoint_chat_message(
+        "https://ws--ep.modal.run",
+        model="model",
+        messages=[],
+        proxy_auth=True,
+    )
+    assert requests[1]["headers"]["Modal-Key"] == "wk"
+
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.proxy_auth_headers", lambda _: {}
+    )
+    with pytest.raises(TrainingGymConfigError, match="Proxy authentication requires"):
+        endpoint_chat_message(
+            "https://ws--ep.modal.run",
+            model="model",
+            messages=[],
+            proxy_auth=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("proxy_auth", "expected"),
+    [
+        (False, "proxy_auth=True"),
+        (True, "Proxy credentials were rejected"),
+    ],
+)
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_endpoint_chat_auth_error_distinguishes_unauthenticated_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    proxy_auth: bool,
+    expected: str,
+    status_code: int,
+) -> None:
+    response = _FakeResponse()
+    response.status_code = status_code
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.httpx.post",
+        lambda *_, **__: response,
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.endpoint.proxy_auth_headers",
+        lambda _: {"Modal-Key": "wk", "Modal-Secret": "ws"},
+    )
+
+    with pytest.raises(RuntimeError, match=expected):
+        endpoint_chat_message(
+            "https://ws--ep.modal.run",
+            model="model",
+            messages=[],
+            proxy_auth=proxy_auth,
+        )

--- a/tests/test_train_result_model.py
+++ b/tests/test_train_result_model.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from modal_training_gym.common.checkpoint import (
+    Checkpoint,
+    CheckpointType,
+    _list_checkpoints,
+    convert_checkpoint_to_hf,
+)
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.models import ModelConfig
+from modal_training_gym.common.train_result import TrainResult
+
+MOUNT = "/checkpoints"
+
+
+def _train_result(**overrides) -> TrainResult:
+    kwargs = {
+        "app_name": "gym-app",
+        "framework": Framework.SLIME,
+        "training_run_id": "run-1",
+        "checkpoint_dir": f"{MOUNT}/run-1",
+        "model_config": ModelConfig(model_name="Qwen/Qwen3-4B"),
+    }
+    kwargs.update(overrides)
+    return TrainResult(**kwargs)
+
+
+def _checkpoint(name: str, *, training_run_id: str = "run-1") -> Checkpoint:
+    return Checkpoint(
+        checkpoint_type=(
+            CheckpointType.hf if name.endswith("_hf") else CheckpointType.megatron
+        ),
+        name=name,
+        path=f"{MOUNT}/run-1/{name}",
+        timestamp=0.0,
+        training_run_id=training_run_id,
+        app_name="gym-app",
+        checkpoints_volume_name="gym-app-checkpoints",
+        checkpoints_mount_path=MOUNT,
+    )
+
+
+@pytest.fixture
+def listed_checkpoints(monkeypatch: pytest.MonkeyPatch):
+    def _install(names: list[str]) -> None:
+        monkeypatch.setattr(
+            "modal_training_gym.common.checkpoint.list_checkpoints",
+            lambda _run_id: [_checkpoint(name) for name in names],
+        )
+
+    return _install
+
+
+@pytest.fixture
+def recorded_conversions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, str | None]]:
+    calls: list[tuple[str, str | None]] = []
+
+    def _convert(checkpoint: Checkpoint, _model, *, gpu: str | None = None):
+        calls.append((checkpoint.name, gpu))
+        return _checkpoint(f"{checkpoint.name}_hf")
+
+    monkeypatch.setattr(
+        "modal_training_gym.common.checkpoint.convert_checkpoint_to_hf", _convert
+    )
+    return calls
+
+
+def test_hf_model_converts_latest_megatron_checkpoint(
+    listed_checkpoints, recorded_conversions
+) -> None:
+    listed_checkpoints(["iter_10", "iter_9"])
+
+    model = _train_result(
+        checkpoints_volume_name="shared-checkpoints",
+        checkpoints_mount_path=MOUNT,
+    ).hf_model()
+
+    assert recorded_conversions == [("iter_10", None)]
+    assert model.model_path == f"{MOUNT}/run-1/iter_10_hf"
+    assert getattr(model, "checkpoints_volume_name") == "shared-checkpoints"
+    assert getattr(model, "checkpoints_mount_path") == MOUNT
+
+
+def test_hf_model_reuses_existing_hf_checkpoint(
+    listed_checkpoints, recorded_conversions
+) -> None:
+    listed_checkpoints(["iter_10_hf", "iter_10"])
+
+    model = _train_result().hf_model()
+
+    assert recorded_conversions == []
+    assert model.model_path == f"{MOUNT}/run-1/iter_10_hf"
+
+
+def test_hf_model_rejects_missing_checkpoints(
+    listed_checkpoints, recorded_conversions
+) -> None:
+    listed_checkpoints([])
+
+    with pytest.raises(TrainingGymConfigError, match="No checkpoints found"):
+        _train_result().hf_model()
+    assert recorded_conversions == []
+
+
+def test_hf_model_forwards_explicit_gpu(
+    listed_checkpoints, recorded_conversions
+) -> None:
+    listed_checkpoints(["iter_10"])
+
+    _train_result().hf_model(gpu="H100:8")
+
+    assert recorded_conversions == [("iter_10", "H100:8")]
+
+
+def test_list_checkpoints_handles_legacy_mount_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "modal_training_gym.common.checkpoint.Volume.from_name",
+        lambda *_, **__: pytest.fail("should not open a mismatched Volume path"),
+    )
+
+    result = _train_result(
+        checkpoint_dir="/legacy-checkpoints/run-1",
+        checkpoints_mount_path=None,
+    )
+
+    assert _list_checkpoints(result) == []
+
+
+def _stub_convert_modal(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    class _FakeVolume:
+        @staticmethod
+        def from_name(*_args: Any, **_kwargs: Any) -> object:
+            return object()
+
+    class _FakeApp:
+        def __init__(self, _name: str) -> None:
+            return None
+
+        def function(self, **kwargs: Any):
+            captured["gpu"] = kwargs.get("gpu")
+
+            def _decorate(fn):
+                class _Bound:
+                    @staticmethod
+                    def remote(**remote_kwargs: Any) -> str:
+                        return remote_kwargs["output_dir"]
+
+                return _Bound()
+
+            return _decorate
+
+        def run(self):
+            return nullcontext()
+
+    class _FakeImage:
+        def add_local_python_source(self, *_args: Any, **_kwargs: Any) -> _FakeImage:
+            return self
+
+    monkeypatch.setattr("modal_training_gym.common.checkpoint.Volume", _FakeVolume)
+    monkeypatch.setattr("modal_training_gym.common.checkpoint.App", _FakeApp)
+    monkeypatch.setattr(
+        "modal_training_gym.common.checkpoint.modal.enable_output",
+        lambda: nullcontext(),
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.hf_secrets",
+        lambda: [],
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.frameworks.slime.launcher._build_slime_base_image",
+        lambda: _FakeImage(),
+    )
+    return captured
+
+
+def test_convert_checkpoint_to_hf_infers_gpu_from_training_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _stub_convert_modal(monkeypatch)
+    monkeypatch.setattr(
+        "modal_training_gym.common.run.TrainingRun.from_id",
+        lambda _run_id: SimpleNamespace(
+            config={"recipe": {"gpu_type": "H100", "actor_num_gpus_per_node": 8}}
+        ),
+    )
+
+    converted = convert_checkpoint_to_hf(
+        _checkpoint("iter_10"),
+        ModelConfig(model_name="Qwen/Qwen3-4B"),
+    )
+
+    assert captured["gpu"] == "H100:8"
+    assert converted.checkpoint_type is CheckpointType.hf
+    assert converted.path == f"{MOUNT}/run-1/iter_10_hf"
+
+
+def test_convert_checkpoint_to_hf_errors_actionably_without_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_convert_modal(monkeypatch)
+    monkeypatch.setattr(
+        "modal_training_gym.common.run.TrainingRun.from_id",
+        lambda _run_id: SimpleNamespace(config={"recipe": {}}),
+    )
+
+    with pytest.raises(TrainingGymConfigError) as excinfo:
+        convert_checkpoint_to_hf(
+            _checkpoint("iter_10"),
+            ModelConfig(model_name="Qwen/Qwen3-4B"),
+        )
+
+    assert 'gpu="H100:8"' in str(excinfo.value)


### PR DESCRIPTION
Part 1/6 of the tutorials-first endpoint migration.

Adds Modal endpoint creation, request authentication helpers, and checkpoint conversion. Existing evaluation and deployment APIs remain available.

Stack: [1/6 #327](https://github.com/modal-projects/training-gym/pull/327), [2/6 #330](https://github.com/modal-projects/training-gym/pull/330), [3/6 #331](https://github.com/modal-projects/training-gym/pull/331), [4/6 #328](https://github.com/modal-projects/training-gym/pull/328), [5/6 #332](https://github.com/modal-projects/training-gym/pull/332), [6/6 #333](https://github.com/modal-projects/training-gym/pull/333).