### PR TITLE
Fix tutorial launches to use `.launch()` and `.result()` instead of `.spawn()`

### DIFF
--- a/docs-next/public/llms.txt
+++ b/docs-next/public/llms.txt
@@ -82,6 +82,7 @@ Repo: https://github.com/modal-projects/training-gym
 ### Training
 
 - [TrainConfig](https://gym.modal.dev/reference/training/trainconfig/): `TrainConfig`
+- [TrainingRun](https://gym.modal.dev/reference/training/trainingrun/): `TrainingRun`
 - [TrainingGroup](https://gym.modal.dev/reference/training/traininggroup/): `TrainingGroup`
 - [SlimeRecipe](https://gym.modal.dev/reference/training/slimerecipe/): `SlimeRecipe`
 - [MilesRecipe](https://gym.modal.dev/reference/training/milesrecipe/): `MilesRecipe`

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -87,6 +87,7 @@ _EXPORTS = {
     ),
     "TrainingGymError": ("modal_training_gym.common.errors", "TrainingGymError"),
     "TrainingGroup": ("modal_training_gym.common.training_group", "TrainingGroup"),
+    "TrainingRun": ("modal_training_gym.common.run", "TrainingRun"),
     "TrainResult": ("modal_training_gym.common.train_result", "TrainResult"),
     "WandbConfig": ("modal_training_gym.common.wandb", "WandbConfig"),
 }
@@ -141,6 +142,7 @@ __all__ = [
     "TrainingGymConfigError",
     "TrainingGymError",
     "TrainingGroup",
+    "TrainingRun",
     "TrainResult",
     "WandbConfig",
 ]

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -75,6 +75,29 @@ class TrainingRunStatus(Enum):
 
 
 class TrainingRun(BaseModel):
+    """Handle to one launched training run — the record *and* the way to wait on it.
+
+    ``TrainConfig.launch()`` returns a ``TrainingRun`` as soon as training is
+    spawned, and persists it to the metadata volume (which is what the
+    dashboard reads). Because the Modal app is started detached and the
+    ``train`` function-call id is persisted on the record, a run outlives the
+    process that launched it and can be picked back up by id from anywhere:
+
+    ```python
+    run = TrainConfig(...).launch()
+    print(run.training_run_id, run.modal_app_url)
+
+    # ...later, from any other process:
+    run = TrainingRun.from_id("<training_run_id>")
+    train_result = run.result()   # block for the TrainResult
+    run.function_call.cancel(terminate_containers=True)   # or stop it early
+    ```
+
+    Never hand-roll ``_build_app()`` + ``app.train.spawn()`` to get this: that
+    nested ``app.run()`` is ephemeral, so leaving the block (or Ctrl-C) stops
+    the app and kills the run.
+    """
+
     training_run_id: str
     modal_app_id: str = ""
     modal_app_url: str = ""

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -1,7 +1,9 @@
 import dataclasses as _dc
 import secrets as _secrets
+import sys
 import threading
 import time
+import warnings
 from contextlib import nullcontext
 from typing import Any
 from typing import TypeVar
@@ -111,6 +113,32 @@ def _convert_checkpoint_on_cache_miss(
         return False
     app.convert_checkpoint.remote(hf_path=hf_path, **call_kwargs)
     return True
+
+
+def _warn_if_external_build_app() -> None:
+    """Warn when ``_build_app()`` is called from outside the package.
+
+    Hand-rolling ``_build_app()`` + ``app.run()`` + ``app.train.spawn()`` is a
+    trap: the nested ``app.run()`` is ephemeral, so exiting the block (or
+    Ctrl-C) stops the app and kills the spawned run — and ``modal run
+    --detach`` does not help, since it only detaches the CLI's own entrypoint
+    app. ``launch()`` / ``train()`` open the app with ``detach=True`` and
+    persist the function-call id so the run can be waited on from anywhere.
+    """
+    try:
+        caller = sys._getframe(2).f_globals.get("__name__", "")
+    except ValueError:  # no such frame — never block a launch over a warning
+        return
+    if caller.startswith("modal_training_gym"):
+        return
+    warnings.warn(
+        "TrainConfig._build_app() is private and does not start a detached "
+        "app: spawning train() on it yourself means the run dies when the "
+        "enclosing app.run() block exits or is interrupted. Use "
+        "TrainConfig.launch() (returns a TrainingRun handle immediately) or "
+        "TrainConfig.train() (blocks for the TrainResult) instead.",
+        stacklevel=3,
+    )
 
 
 _STAGE_LABELS: dict[str, str] = {
@@ -393,6 +421,7 @@ class TrainConfig:
         )
 
     def _build_app(self, training_run_id: str | None = None):
+        _warn_if_external_build_app()
         if training_run_id is None:
             training_run_id = self._generate_training_run_id()
         recipe_type = self.recipe.recipe_type

--- a/modal_training_gym/common/train_result.py
+++ b/modal_training_gym/common/train_result.py
@@ -1,28 +1,24 @@
 """Post-training handle: look up checkpoints, serve them, write evals.
 
-A :class:`TrainResult` is produced by ``train`` itself — one per call —
-and is also persisted to a shared :class:`modal.Dict` keyed by
-``training_run_id`` so that a *separate* evaluation script can look it up after
-the fact without re-running training.
+A :class:`TrainResult` is produced by ``train`` itself — one per call — and is
+also persisted to the metadata volume keyed by ``training_run_id`` so that a
+*separate* evaluation script can look it up after the fact without re-running
+training.
 
 Typical flow:
 
 .. code-block:: python
 
     # training.py
-    app = TrainConfig(...).build_app()
-
-    # Kick off training:
-    #   modal run --detach training.py::app.train
-    # The train function constructs a TrainResult, writes it to the
-    # shared modal.Dict, and returns it.
+    result = TrainConfig(...).train()          # blocks, returns the TrainResult
+    # or, to launch and walk away:
+    run = TrainConfig(...).launch()            # detached; returns a TrainingRun
+    result = run.result()                      # optional wait
 
     # eval.py (anywhere, any time after `train` finishes):
     from modal_training_gym.common.train_result import TrainResult
 
-    result = TrainResult.load("my-app")                 # latest run
-    # or
-    result = TrainResult.load("my-app", training_run_id="...")   # pinned
+    result = TrainResult.load(training_run_id)
 
     print(result.checkpoint_dir)            # /checkpoints/my-app_train_...
     print(result.latest_checkpoint_path())  # .../iter_0000050
@@ -33,15 +29,15 @@ Typical flow:
 
 Two design invariants:
 
-1. ``TrainResult`` is **not** attached to the ``modal.App`` returned by
-   ``build_app()`` — a training run has no "result" before ``train`` has
-   executed. The ``modal.App`` object is a deployment handle, not a run
-   handle.
+1. ``TrainResult`` is **not** attached to the ``modal.App`` that
+   ``TrainConfig`` builds internally — a training run has no "result" before
+   ``train`` has executed. The ``modal.App`` object is a deployment handle,
+   not a run handle; :class:`TrainingRun` is the run handle.
 2. Every call to ``train`` can produce a *different* result (different
-   ``training_run_id``, different ``checkpoint_dir``). We use a :class:`modal.Dict`
-   named ``{app_name}-train-results`` as the shared store so that eval
-   scripts — which don't import the training closure and don't call
-   ``train()`` — can still retrieve results by ``training_run_id``.
+   ``training_run_id``, different ``checkpoint_dir``). Results live in the
+   shared metadata volume so that eval scripts — which don't import the
+   training closure and don't call ``train()`` — can still retrieve them by
+   ``training_run_id``.
 """
 
 from __future__ import annotations

--- a/scripts/api_reference_manifest.py
+++ b/scripts/api_reference_manifest.py
@@ -179,6 +179,13 @@ API_REFERENCE_MANIFEST = [
         "sidebar_label": "TrainConfig",
     },
     {
+        "class_name": "TrainingRun",
+        "module": "modal_training_gym.common.run",
+        "group": "training",
+        "class_type": "behavior",
+        "sidebar_label": "TrainingRun",
+    },
+    {
         "class_name": "TrainingGroup",
         "module": "modal_training_gym.common.training_group",
         "group": "training",

--- a/tutorials/multinode/000_kimi_k25/000_kimi_k25.ipynb
+++ b/tutorials/multinode/000_kimi_k25/000_kimi_k25.ipynb
@@ -90,9 +90,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import modal\n",
-    "\n",
-    "from modal_training_gym.common.modal_urls import modal_app_dashboard_url\n",
     "from modal_training_gym import (\n",
     "    HuggingFaceDataset,\n",
     "    Kimi_K2_5,\n",
@@ -137,10 +134,15 @@
    "id": "cell-009",
    "metadata": {},
    "source": [
-    "## Build and launch training\n",
+    "## Launch training\n",
     "\n",
-    "Build the training config, construct the Modal app, and spawn\n",
-    "the training function as a detached call."
+    "`TrainConfig.launch()` starts the Modal app **detached** and returns a\n",
+    "`TrainingRun` handle as soon as training is spawned. Detached means the run\n",
+    "survives this process: closing the notebook, dropping your connection, or\n",
+    "hitting Ctrl-C leaves the 16 nodes training on Modal.\n",
+    "\n",
+    "The handle records the Modal app id and the `train` function-call id, so the\n",
+    "run can be waited on \u2014 or cancelled \u2014 from anywhere later."
    ]
   },
   {
@@ -158,16 +160,59 @@
     "    )\n",
     "\n",
     "training_run = build_training_config()\n",
-    "app = training_run._build_app()\n",
+    "run = training_run.launch()\n",
     "\n",
-    "with modal.enable_output():\n",
-    "    with app.run():\n",
-    "        modal_app_id = app.app_id or \"\"\n",
-    "        function_call = app.train.spawn(\n",
-    "            modal_app_id=modal_app_id,\n",
-    "            modal_app_url=modal_app_dashboard_url(modal_app_id),\n",
-    "        )\n",
-    "        print(f\"Spawned train function call: {function_call.object_id}\")"
+    "print(f\"Training run:  {run.training_run_id}\")\n",
+    "print(f\"Modal app:     {run.modal_app_url}\")\n",
+    "print(f\"Function call: {run.function_call_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-011",
+   "metadata": {},
+   "source": [
+    "## Reattach later\n",
+    "\n",
+    "A launched run is addressable by id from any process \u2014 the handle is\n",
+    "reconstructed from the persisted `function_call_id`, so you don't need to\n",
+    "keep this session open:\n",
+    "\n",
+    "```python\n",
+    "from modal_training_gym import TrainingRun\n",
+    "\n",
+    "run = TrainingRun.from_id(\"<training_run_id>\")\n",
+    "train_result = run.result()  # block for the TrainResult\n",
+    "\n",
+    "# Or stop it early:\n",
+    "run.function_call.cancel(terminate_containers=True)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-012",
+   "metadata": {},
+   "source": [
+    "## Wait for the result (optional)\n",
+    "\n",
+    "`run.result()` blocks until training finishes and returns the\n",
+    "`TrainResult`. Interrupting the wait does **not** stop the run \u2014 with\n",
+    "`TrainConfig.detach=True` (the default) an interrupted wait leaves training\n",
+    "going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.\n",
+    "\n",
+    "Skip this cell entirely if you just want to launch and walk away."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_result = run.result()\n",
+    "print(f\"Training complete: {train_result.training_run_id}\")"
    ]
   }
  ],

--- a/tutorials/multinode/000_kimi_k25/000_kimi_k25.ipynb
+++ b/tutorials/multinode/000_kimi_k25/000_kimi_k25.ipynb
@@ -197,9 +197,10 @@
     "## Wait for the result (optional)\n",
     "\n",
     "`run.result()` blocks until training finishes and returns the\n",
-    "`TrainResult`. Interrupting the wait does **not** stop the run \u2014 with\n",
-    "`TrainConfig.detach=True` (the default) an interrupted wait leaves training\n",
-    "going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.\n",
+    "`TrainResult`. Interrupting the wait does **not** stop the run: a launched\n",
+    "run always lives in a detached Modal app, so Ctrl-C here only stops\n",
+    "waiting. To actually stop training, cancel the call:\n",
+    "`run.function_call.cancel(terminate_containers=True)`.\n",
     "\n",
     "Skip this cell entirely if you just want to launch and walk away."
    ]

--- a/tutorials/multinode/000_kimi_k25/000_kimi_k25.py
+++ b/tutorials/multinode/000_kimi_k25/000_kimi_k25.py
@@ -27,9 +27,6 @@
 
 import modal
 
-import modal
-
-from modal_training_gym.common.modal_urls import modal_app_dashboard_url
 from modal_training_gym import (
     HuggingFaceDataset,
     Kimi_K2_5,
@@ -54,10 +51,15 @@ class MathDataset(HuggingFaceDataset):
     apply_chat_template = True
     always_prepare = True
 
-# ## Build and launch training
+# ## Launch training
 #
-# Build the training config, construct the Modal app, and spawn
-# the training function as a detached call.
+# `TrainConfig.launch()` starts the Modal app **detached** and returns a
+# `TrainingRun` handle as soon as training is spawned. Detached means the run
+# survives this process: closing the notebook, dropping your connection, or
+# hitting Ctrl-C leaves the 16 nodes training on Modal.
+#
+# The handle records the Modal app id and the `train` function-call id, so the
+# run can be waited on — or cancelled — from anywhere later.
 
 def build_training_config() -> TrainConfig:
     return TrainConfig(
@@ -80,16 +82,38 @@ def _main_impl() -> None:
         ) from e
 
     training_run = build_training_config()
-    app = training_run._build_app()
+    run = training_run.launch()
 
-    with modal.enable_output():
-        with app.run():
-            modal_app_id = app.app_id or ""
-            function_call = app.train.spawn(
-                modal_app_id=modal_app_id,
-                modal_app_url=modal_app_dashboard_url(modal_app_id),
-            )
-            print(f"Spawned train function call: {function_call.object_id}")
+    print(f"Training run:  {run.training_run_id}")
+    print(f"Modal app:     {run.modal_app_url}")
+    print(f"Function call: {run.function_call_id}")
+
+    # ## Reattach later
+    #
+    # A launched run is addressable by id from any process — the handle is
+    # reconstructed from the persisted `function_call_id`, so you don't need to
+    # keep this session open:
+    #
+    # ```python
+    # from modal_training_gym import TrainingRun
+    #
+    # run = TrainingRun.from_id("<training_run_id>")
+    # train_result = run.result()  # block for the TrainResult
+    #
+    # # Or stop it early:
+    # run.function_call.cancel(terminate_containers=True)
+    # ```
+    # ## Wait for the result (optional)
+    #
+    # `run.result()` blocks until training finishes and returns the
+    # `TrainResult`. Interrupting the wait does **not** stop the run — with
+    # `TrainConfig.detach=True` (the default) an interrupted wait leaves training
+    # going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    #
+    # Skip this cell entirely if you just want to launch and walk away.
+
+    train_result = run.result()
+    print(f"Training complete: {train_result.training_run_id}")
 
 @tutorial_cli_app.local_entrypoint()
 def main() -> None:

--- a/tutorials/multinode/000_kimi_k25/000_kimi_k25.py
+++ b/tutorials/multinode/000_kimi_k25/000_kimi_k25.py
@@ -106,9 +106,10 @@ def _main_impl() -> None:
     # ## Wait for the result (optional)
     #
     # `run.result()` blocks until training finishes and returns the
-    # `TrainResult`. Interrupting the wait does **not** stop the run — with
-    # `TrainConfig.detach=True` (the default) an interrupted wait leaves training
-    # going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    # `TrainResult`. Interrupting the wait does **not** stop the run: a launched
+    # run always lives in a detached Modal app, so Ctrl-C here only stops
+    # waiting. To actually stop training, cancel the call:
+    # `run.function_call.cancel(terminate_containers=True)`.
     #
     # Skip this cell entirely if you just want to launch and walk away.
 

--- a/tutorials/multinode/001_kimi_k26/001_kimi_k26.ipynb
+++ b/tutorials/multinode/001_kimi_k26/001_kimi_k26.ipynb
@@ -90,9 +90,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import modal\n",
-    "\n",
-    "from modal_training_gym.common.modal_urls import modal_app_dashboard_url\n",
     "from modal_training_gym import (\n",
     "    HuggingFaceDataset,\n",
     "    Kimi_K2_6,\n",
@@ -137,10 +134,15 @@
    "id": "cell-009",
    "metadata": {},
    "source": [
-    "## Build and launch training\n",
+    "## Launch training\n",
     "\n",
-    "Build the training config, construct the Modal app, and spawn\n",
-    "the training function as a detached call."
+    "`TrainConfig.launch()` starts the Modal app **detached** and returns a\n",
+    "`TrainingRun` handle as soon as training is spawned. Detached means the run\n",
+    "survives this process: closing the notebook, dropping your connection, or\n",
+    "hitting Ctrl-C leaves the 16 nodes training on Modal.\n",
+    "\n",
+    "The handle records the Modal app id and the `train` function-call id, so the\n",
+    "run can be waited on \u2014 or cancelled \u2014 from anywhere later."
    ]
   },
   {
@@ -158,16 +160,59 @@
     "    )\n",
     "\n",
     "training_run = build_training_config()\n",
-    "app = training_run._build_app()\n",
+    "run = training_run.launch()\n",
     "\n",
-    "with modal.enable_output():\n",
-    "    with app.run():\n",
-    "        modal_app_id = app.app_id or \"\"\n",
-    "        function_call = app.train.spawn(\n",
-    "            modal_app_id=modal_app_id,\n",
-    "            modal_app_url=modal_app_dashboard_url(modal_app_id),\n",
-    "        )\n",
-    "        print(f\"Spawned train function call: {function_call.object_id}\")"
+    "print(f\"Training run:  {run.training_run_id}\")\n",
+    "print(f\"Modal app:     {run.modal_app_url}\")\n",
+    "print(f\"Function call: {run.function_call_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-011",
+   "metadata": {},
+   "source": [
+    "## Reattach later\n",
+    "\n",
+    "A launched run is addressable by id from any process \u2014 the handle is\n",
+    "reconstructed from the persisted `function_call_id`, so you don't need to\n",
+    "keep this session open:\n",
+    "\n",
+    "```python\n",
+    "from modal_training_gym import TrainingRun\n",
+    "\n",
+    "run = TrainingRun.from_id(\"<training_run_id>\")\n",
+    "train_result = run.result()  # block for the TrainResult\n",
+    "\n",
+    "# Or stop it early:\n",
+    "run.function_call.cancel(terminate_containers=True)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-012",
+   "metadata": {},
+   "source": [
+    "## Wait for the result (optional)\n",
+    "\n",
+    "`run.result()` blocks until training finishes and returns the\n",
+    "`TrainResult`. Interrupting the wait does **not** stop the run \u2014 with\n",
+    "`TrainConfig.detach=True` (the default) an interrupted wait leaves training\n",
+    "going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.\n",
+    "\n",
+    "Skip this cell entirely if you just want to launch and walk away."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_result = run.result()\n",
+    "print(f\"Training complete: {train_result.training_run_id}\")"
    ]
   }
  ],

--- a/tutorials/multinode/001_kimi_k26/001_kimi_k26.ipynb
+++ b/tutorials/multinode/001_kimi_k26/001_kimi_k26.ipynb
@@ -197,9 +197,10 @@
     "## Wait for the result (optional)\n",
     "\n",
     "`run.result()` blocks until training finishes and returns the\n",
-    "`TrainResult`. Interrupting the wait does **not** stop the run \u2014 with\n",
-    "`TrainConfig.detach=True` (the default) an interrupted wait leaves training\n",
-    "going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.\n",
+    "`TrainResult`. Interrupting the wait does **not** stop the run: a launched\n",
+    "run always lives in a detached Modal app, so Ctrl-C here only stops\n",
+    "waiting. To actually stop training, cancel the call:\n",
+    "`run.function_call.cancel(terminate_containers=True)`.\n",
     "\n",
     "Skip this cell entirely if you just want to launch and walk away."
    ]

--- a/tutorials/multinode/001_kimi_k26/001_kimi_k26.py
+++ b/tutorials/multinode/001_kimi_k26/001_kimi_k26.py
@@ -27,9 +27,6 @@
 
 import modal
 
-import modal
-
-from modal_training_gym.common.modal_urls import modal_app_dashboard_url
 from modal_training_gym import (
     HuggingFaceDataset,
     Kimi_K2_6,
@@ -54,10 +51,15 @@ class MathDataset(HuggingFaceDataset):
     apply_chat_template = True
     always_prepare = True
 
-# ## Build and launch training
+# ## Launch training
 #
-# Build the training config, construct the Modal app, and spawn
-# the training function as a detached call.
+# `TrainConfig.launch()` starts the Modal app **detached** and returns a
+# `TrainingRun` handle as soon as training is spawned. Detached means the run
+# survives this process: closing the notebook, dropping your connection, or
+# hitting Ctrl-C leaves the 16 nodes training on Modal.
+#
+# The handle records the Modal app id and the `train` function-call id, so the
+# run can be waited on — or cancelled — from anywhere later.
 
 def build_training_config() -> TrainConfig:
     return TrainConfig(
@@ -80,16 +82,38 @@ def _main_impl() -> None:
         ) from e
 
     training_run = build_training_config()
-    app = training_run._build_app()
+    run = training_run.launch()
 
-    with modal.enable_output():
-        with app.run():
-            modal_app_id = app.app_id or ""
-            function_call = app.train.spawn(
-                modal_app_id=modal_app_id,
-                modal_app_url=modal_app_dashboard_url(modal_app_id),
-            )
-            print(f"Spawned train function call: {function_call.object_id}")
+    print(f"Training run:  {run.training_run_id}")
+    print(f"Modal app:     {run.modal_app_url}")
+    print(f"Function call: {run.function_call_id}")
+
+    # ## Reattach later
+    #
+    # A launched run is addressable by id from any process — the handle is
+    # reconstructed from the persisted `function_call_id`, so you don't need to
+    # keep this session open:
+    #
+    # ```python
+    # from modal_training_gym import TrainingRun
+    #
+    # run = TrainingRun.from_id("<training_run_id>")
+    # train_result = run.result()  # block for the TrainResult
+    #
+    # # Or stop it early:
+    # run.function_call.cancel(terminate_containers=True)
+    # ```
+    # ## Wait for the result (optional)
+    #
+    # `run.result()` blocks until training finishes and returns the
+    # `TrainResult`. Interrupting the wait does **not** stop the run — with
+    # `TrainConfig.detach=True` (the default) an interrupted wait leaves training
+    # going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    #
+    # Skip this cell entirely if you just want to launch and walk away.
+
+    train_result = run.result()
+    print(f"Training complete: {train_result.training_run_id}")
 
 @tutorial_cli_app.local_entrypoint()
 def main() -> None:

--- a/tutorials/multinode/001_kimi_k26/001_kimi_k26.py
+++ b/tutorials/multinode/001_kimi_k26/001_kimi_k26.py
@@ -106,9 +106,10 @@ def _main_impl() -> None:
     # ## Wait for the result (optional)
     #
     # `run.result()` blocks until training finishes and returns the
-    # `TrainResult`. Interrupting the wait does **not** stop the run — with
-    # `TrainConfig.detach=True` (the default) an interrupted wait leaves training
-    # going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    # `TrainResult`. Interrupting the wait does **not** stop the run: a launched
+    # run always lives in a detached Modal app, so Ctrl-C here only stops
+    # waiting. To actually stop training, cancel the call:
+    # `run.function_call.cancel(terminate_containers=True)`.
     #
     # Skip this cell entirely if you just want to launch and walk away.
 

--- a/tutorials/multinode/003_qwen27b/003_qwen27b.ipynb
+++ b/tutorials/multinode/003_qwen27b/003_qwen27b.ipynb
@@ -197,9 +197,10 @@
     "## Wait for the result (optional)\n",
     "\n",
     "`run.result()` blocks until training finishes and returns the\n",
-    "`TrainResult`. Interrupting the wait does **not** stop the run \u2014 with\n",
-    "`TrainConfig.detach=True` (the default) an interrupted wait leaves training\n",
-    "going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.\n",
+    "`TrainResult`. Interrupting the wait does **not** stop the run: a launched\n",
+    "run always lives in a detached Modal app, so Ctrl-C here only stops\n",
+    "waiting. To actually stop training, cancel the call:\n",
+    "`run.function_call.cancel(terminate_containers=True)`.\n",
     "\n",
     "Skip this cell entirely if you just want to launch and walk away."
    ]

--- a/tutorials/multinode/003_qwen27b/003_qwen27b.ipynb
+++ b/tutorials/multinode/003_qwen27b/003_qwen27b.ipynb
@@ -90,9 +90,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import modal\n",
-    "\n",
-    "from modal_training_gym.common.modal_urls import modal_app_dashboard_url\n",
     "from modal_training_gym import (\n",
     "    HuggingFaceDataset,\n",
     "    Qwen3_6_27B,\n",
@@ -137,10 +134,15 @@
    "id": "cell-009",
    "metadata": {},
    "source": [
-    "## Build and launch training\n",
+    "## Launch training\n",
     "\n",
-    "Build the training config, construct the Modal app, and spawn\n",
-    "the training function as a detached call."
+    "`TrainConfig.launch()` starts the Modal app **detached** and returns a\n",
+    "`TrainingRun` handle as soon as training is spawned. Detached means the run\n",
+    "survives this process: closing the notebook, dropping your connection, or\n",
+    "hitting Ctrl-C leaves the 4 nodes training on Modal.\n",
+    "\n",
+    "The handle records the Modal app id and the `train` function-call id, so the\n",
+    "run can be waited on \u2014 or cancelled \u2014 from anywhere later."
    ]
   },
   {
@@ -158,16 +160,59 @@
     "    )\n",
     "\n",
     "training_run = build_training_config()\n",
-    "app = training_run._build_app()\n",
+    "run = training_run.launch()\n",
     "\n",
-    "with modal.enable_output():\n",
-    "    with app.run():\n",
-    "        modal_app_id = app.app_id or \"\"\n",
-    "        function_call = app.train.spawn(\n",
-    "            modal_app_id=modal_app_id,\n",
-    "            modal_app_url=modal_app_dashboard_url(modal_app_id),\n",
-    "        )\n",
-    "        print(f\"Spawned train function call: {function_call.object_id}\")"
+    "print(f\"Training run:  {run.training_run_id}\")\n",
+    "print(f\"Modal app:     {run.modal_app_url}\")\n",
+    "print(f\"Function call: {run.function_call_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-011",
+   "metadata": {},
+   "source": [
+    "## Reattach later\n",
+    "\n",
+    "A launched run is addressable by id from any process \u2014 the handle is\n",
+    "reconstructed from the persisted `function_call_id`, so you don't need to\n",
+    "keep this session open:\n",
+    "\n",
+    "```python\n",
+    "from modal_training_gym import TrainingRun\n",
+    "\n",
+    "run = TrainingRun.from_id(\"<training_run_id>\")\n",
+    "train_result = run.result()  # block for the TrainResult\n",
+    "\n",
+    "# Or stop it early:\n",
+    "run.function_call.cancel(terminate_containers=True)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-012",
+   "metadata": {},
+   "source": [
+    "## Wait for the result (optional)\n",
+    "\n",
+    "`run.result()` blocks until training finishes and returns the\n",
+    "`TrainResult`. Interrupting the wait does **not** stop the run \u2014 with\n",
+    "`TrainConfig.detach=True` (the default) an interrupted wait leaves training\n",
+    "going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.\n",
+    "\n",
+    "Skip this cell entirely if you just want to launch and walk away."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_result = run.result()\n",
+    "print(f\"Training complete: {train_result.training_run_id}\")"
    ]
   }
  ],

--- a/tutorials/multinode/003_qwen27b/003_qwen27b.py
+++ b/tutorials/multinode/003_qwen27b/003_qwen27b.py
@@ -27,9 +27,6 @@
 
 import modal
 
-import modal
-
-from modal_training_gym.common.modal_urls import modal_app_dashboard_url
 from modal_training_gym import (
     HuggingFaceDataset,
     Qwen3_6_27B,
@@ -54,10 +51,15 @@ class MathDataset(HuggingFaceDataset):
     apply_chat_template = True
     always_prepare = True
 
-# ## Build and launch training
+# ## Launch training
 #
-# Build the training config, construct the Modal app, and spawn
-# the training function as a detached call.
+# `TrainConfig.launch()` starts the Modal app **detached** and returns a
+# `TrainingRun` handle as soon as training is spawned. Detached means the run
+# survives this process: closing the notebook, dropping your connection, or
+# hitting Ctrl-C leaves the 4 nodes training on Modal.
+#
+# The handle records the Modal app id and the `train` function-call id, so the
+# run can be waited on — or cancelled — from anywhere later.
 
 def build_training_config() -> TrainConfig:
     return TrainConfig(
@@ -80,16 +82,38 @@ def _main_impl() -> None:
         ) from e
 
     training_run = build_training_config()
-    app = training_run._build_app()
+    run = training_run.launch()
 
-    with modal.enable_output():
-        with app.run():
-            modal_app_id = app.app_id or ""
-            function_call = app.train.spawn(
-                modal_app_id=modal_app_id,
-                modal_app_url=modal_app_dashboard_url(modal_app_id),
-            )
-            print(f"Spawned train function call: {function_call.object_id}")
+    print(f"Training run:  {run.training_run_id}")
+    print(f"Modal app:     {run.modal_app_url}")
+    print(f"Function call: {run.function_call_id}")
+
+    # ## Reattach later
+    #
+    # A launched run is addressable by id from any process — the handle is
+    # reconstructed from the persisted `function_call_id`, so you don't need to
+    # keep this session open:
+    #
+    # ```python
+    # from modal_training_gym import TrainingRun
+    #
+    # run = TrainingRun.from_id("<training_run_id>")
+    # train_result = run.result()  # block for the TrainResult
+    #
+    # # Or stop it early:
+    # run.function_call.cancel(terminate_containers=True)
+    # ```
+    # ## Wait for the result (optional)
+    #
+    # `run.result()` blocks until training finishes and returns the
+    # `TrainResult`. Interrupting the wait does **not** stop the run — with
+    # `TrainConfig.detach=True` (the default) an interrupted wait leaves training
+    # going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    #
+    # Skip this cell entirely if you just want to launch and walk away.
+
+    train_result = run.result()
+    print(f"Training complete: {train_result.training_run_id}")
 
 @tutorial_cli_app.local_entrypoint()
 def main() -> None:

--- a/tutorials/multinode/003_qwen27b/003_qwen27b.py
+++ b/tutorials/multinode/003_qwen27b/003_qwen27b.py
@@ -106,9 +106,10 @@ def _main_impl() -> None:
     # ## Wait for the result (optional)
     #
     # `run.result()` blocks until training finishes and returns the
-    # `TrainResult`. Interrupting the wait does **not** stop the run — with
-    # `TrainConfig.detach=True` (the default) an interrupted wait leaves training
-    # going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    # `TrainResult`. Interrupting the wait does **not** stop the run: a launched
+    # run always lives in a detached Modal app, so Ctrl-C here only stops
+    # waiting. To actually stop training, cancel the call:
+    # `run.function_call.cancel(terminate_containers=True)`.
     #
     # Skip this cell entirely if you just want to launch and walk away.
 

--- a/tutorials/tutorial_generator/multinode/000_kimi_k25.py
+++ b/tutorials/tutorial_generator/multinode/000_kimi_k25.py
@@ -153,9 +153,10 @@ def _wait_intro():
     ## Wait for the result (optional)
 
     `run.result()` blocks until training finishes and returns the
-    `TrainResult`. Interrupting the wait does **not** stop the run — with
-    `TrainConfig.detach=True` (the default) an interrupted wait leaves training
-    going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    `TrainResult`. Interrupting the wait does **not** stop the run: a launched
+    run always lives in a detached Modal app, so Ctrl-C here only stops
+    waiting. To actually stop training, cancel the call:
+    `run.function_call.cancel(terminate_containers=True)`.
 
     Skip this cell entirely if you just want to launch and walk away.
     """

--- a/tutorials/tutorial_generator/multinode/000_kimi_k25.py
+++ b/tutorials/tutorial_generator/multinode/000_kimi_k25.py
@@ -10,6 +10,7 @@ TUTORIAL_METADATA = {
         "Kimi_K2_5",
         "Kimi_K2_5_LoRA_Recipe",
         "TrainConfig",
+        "TrainingRun",
     ],
 }
 
@@ -60,9 +61,6 @@ def _install():
 
 @code
 def _imports():
-    import modal
-
-    from modal_training_gym.common.modal_urls import modal_app_dashboard_url
     from modal_training_gym import (
         HuggingFaceDataset,
         Kimi_K2_5,
@@ -99,10 +97,15 @@ def _define_dataset():
 @markdown
 def _train_intro():
     """
-    ## Build and launch training
+    ## Launch training
 
-    Build the training config, construct the Modal app, and spawn
-    the training function as a detached call.
+    `TrainConfig.launch()` starts the Modal app **detached** and returns a
+    `TrainingRun` handle as soon as training is spawned. Detached means the run
+    survives this process: closing the notebook, dropping your connection, or
+    hitting Ctrl-C leaves the 16 nodes training on Modal.
+
+    The handle records the Modal app id and the `train` function-call id, so the
+    run can be waited on — or cancelled — from anywhere later.
     """
 
 
@@ -116,13 +119,49 @@ def _build_and_run():
         )
 
     training_run = build_training_config()
-    app = training_run._build_app()
+    run = training_run.launch()
 
-    with modal.enable_output():
-        with app.run():
-            modal_app_id = app.app_id or ""
-            function_call = app.train.spawn(
-                modal_app_id=modal_app_id,
-                modal_app_url=modal_app_dashboard_url(modal_app_id),
-            )
-            print(f"Spawned train function call: {function_call.object_id}")
+    print(f"Training run:  {run.training_run_id}")
+    print(f"Modal app:     {run.modal_app_url}")
+    print(f"Function call: {run.function_call_id}")
+
+
+@markdown
+def _reattach():
+    """
+    ## Reattach later
+
+    A launched run is addressable by id from any process — the handle is
+    reconstructed from the persisted `function_call_id`, so you don't need to
+    keep this session open:
+
+    ```python
+    from modal_training_gym import TrainingRun
+
+    run = TrainingRun.from_id("<training_run_id>")
+    train_result = run.result()  # block for the TrainResult
+
+    # Or stop it early:
+    run.function_call.cancel(terminate_containers=True)
+    ```
+    """
+
+
+@markdown
+def _wait_intro():
+    """
+    ## Wait for the result (optional)
+
+    `run.result()` blocks until training finishes and returns the
+    `TrainResult`. Interrupting the wait does **not** stop the run — with
+    `TrainConfig.detach=True` (the default) an interrupted wait leaves training
+    going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+
+    Skip this cell entirely if you just want to launch and walk away.
+    """
+
+
+@code
+def _wait_for_result():
+    train_result = run.result()
+    print(f"Training complete: {train_result.training_run_id}")

--- a/tutorials/tutorial_generator/multinode/001_kimi_k26.py
+++ b/tutorials/tutorial_generator/multinode/001_kimi_k26.py
@@ -10,6 +10,7 @@ TUTORIAL_METADATA = {
         "Kimi_K2_6",
         "Kimi_K2_6_LoRA_Recipe",
         "TrainConfig",
+        "TrainingRun",
     ],
 }
 
@@ -60,9 +61,6 @@ def _install():
 
 @code
 def _imports():
-    import modal
-
-    from modal_training_gym.common.modal_urls import modal_app_dashboard_url
     from modal_training_gym import (
         HuggingFaceDataset,
         Kimi_K2_6,
@@ -99,10 +97,15 @@ def _define_dataset():
 @markdown
 def _train_intro():
     """
-    ## Build and launch training
+    ## Launch training
 
-    Build the training config, construct the Modal app, and spawn
-    the training function as a detached call.
+    `TrainConfig.launch()` starts the Modal app **detached** and returns a
+    `TrainingRun` handle as soon as training is spawned. Detached means the run
+    survives this process: closing the notebook, dropping your connection, or
+    hitting Ctrl-C leaves the 16 nodes training on Modal.
+
+    The handle records the Modal app id and the `train` function-call id, so the
+    run can be waited on — or cancelled — from anywhere later.
     """
 
 
@@ -116,13 +119,49 @@ def _build_and_run():
         )
 
     training_run = build_training_config()
-    app = training_run._build_app()
+    run = training_run.launch()
 
-    with modal.enable_output():
-        with app.run():
-            modal_app_id = app.app_id or ""
-            function_call = app.train.spawn(
-                modal_app_id=modal_app_id,
-                modal_app_url=modal_app_dashboard_url(modal_app_id),
-            )
-            print(f"Spawned train function call: {function_call.object_id}")
+    print(f"Training run:  {run.training_run_id}")
+    print(f"Modal app:     {run.modal_app_url}")
+    print(f"Function call: {run.function_call_id}")
+
+
+@markdown
+def _reattach():
+    """
+    ## Reattach later
+
+    A launched run is addressable by id from any process — the handle is
+    reconstructed from the persisted `function_call_id`, so you don't need to
+    keep this session open:
+
+    ```python
+    from modal_training_gym import TrainingRun
+
+    run = TrainingRun.from_id("<training_run_id>")
+    train_result = run.result()  # block for the TrainResult
+
+    # Or stop it early:
+    run.function_call.cancel(terminate_containers=True)
+    ```
+    """
+
+
+@markdown
+def _wait_intro():
+    """
+    ## Wait for the result (optional)
+
+    `run.result()` blocks until training finishes and returns the
+    `TrainResult`. Interrupting the wait does **not** stop the run — with
+    `TrainConfig.detach=True` (the default) an interrupted wait leaves training
+    going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+
+    Skip this cell entirely if you just want to launch and walk away.
+    """
+
+
+@code
+def _wait_for_result():
+    train_result = run.result()
+    print(f"Training complete: {train_result.training_run_id}")

--- a/tutorials/tutorial_generator/multinode/001_kimi_k26.py
+++ b/tutorials/tutorial_generator/multinode/001_kimi_k26.py
@@ -153,9 +153,10 @@ def _wait_intro():
     ## Wait for the result (optional)
 
     `run.result()` blocks until training finishes and returns the
-    `TrainResult`. Interrupting the wait does **not** stop the run — with
-    `TrainConfig.detach=True` (the default) an interrupted wait leaves training
-    going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    `TrainResult`. Interrupting the wait does **not** stop the run: a launched
+    run always lives in a detached Modal app, so Ctrl-C here only stops
+    waiting. To actually stop training, cancel the call:
+    `run.function_call.cancel(terminate_containers=True)`.
 
     Skip this cell entirely if you just want to launch and walk away.
     """

--- a/tutorials/tutorial_generator/multinode/003_qwen27b.py
+++ b/tutorials/tutorial_generator/multinode/003_qwen27b.py
@@ -10,6 +10,7 @@ TUTORIAL_METADATA = {
         "Qwen3_6_27B",
         "Qwen3_6_27b_Recipe",
         "TrainConfig",
+        "TrainingRun",
     ],
 }
 
@@ -60,9 +61,6 @@ def _install():
 
 @code
 def _imports():
-    import modal
-
-    from modal_training_gym.common.modal_urls import modal_app_dashboard_url
     from modal_training_gym import (
         HuggingFaceDataset,
         Qwen3_6_27B,
@@ -99,10 +97,15 @@ def _define_dataset():
 @markdown
 def _train_intro():
     """
-    ## Build and launch training
+    ## Launch training
 
-    Build the training config, construct the Modal app, and spawn
-    the training function as a detached call.
+    `TrainConfig.launch()` starts the Modal app **detached** and returns a
+    `TrainingRun` handle as soon as training is spawned. Detached means the run
+    survives this process: closing the notebook, dropping your connection, or
+    hitting Ctrl-C leaves the 4 nodes training on Modal.
+
+    The handle records the Modal app id and the `train` function-call id, so the
+    run can be waited on — or cancelled — from anywhere later.
     """
 
 
@@ -116,13 +119,49 @@ def _build_and_run():
         )
 
     training_run = build_training_config()
-    app = training_run._build_app()
+    run = training_run.launch()
 
-    with modal.enable_output():
-        with app.run():
-            modal_app_id = app.app_id or ""
-            function_call = app.train.spawn(
-                modal_app_id=modal_app_id,
-                modal_app_url=modal_app_dashboard_url(modal_app_id),
-            )
-            print(f"Spawned train function call: {function_call.object_id}")
+    print(f"Training run:  {run.training_run_id}")
+    print(f"Modal app:     {run.modal_app_url}")
+    print(f"Function call: {run.function_call_id}")
+
+
+@markdown
+def _reattach():
+    """
+    ## Reattach later
+
+    A launched run is addressable by id from any process — the handle is
+    reconstructed from the persisted `function_call_id`, so you don't need to
+    keep this session open:
+
+    ```python
+    from modal_training_gym import TrainingRun
+
+    run = TrainingRun.from_id("<training_run_id>")
+    train_result = run.result()  # block for the TrainResult
+
+    # Or stop it early:
+    run.function_call.cancel(terminate_containers=True)
+    ```
+    """
+
+
+@markdown
+def _wait_intro():
+    """
+    ## Wait for the result (optional)
+
+    `run.result()` blocks until training finishes and returns the
+    `TrainResult`. Interrupting the wait does **not** stop the run — with
+    `TrainConfig.detach=True` (the default) an interrupted wait leaves training
+    going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+
+    Skip this cell entirely if you just want to launch and walk away.
+    """
+
+
+@code
+def _wait_for_result():
+    train_result = run.result()
+    print(f"Training complete: {train_result.training_run_id}")

--- a/tutorials/tutorial_generator/multinode/003_qwen27b.py
+++ b/tutorials/tutorial_generator/multinode/003_qwen27b.py
@@ -153,9 +153,10 @@ def _wait_intro():
     ## Wait for the result (optional)
 
     `run.result()` blocks until training finishes and returns the
-    `TrainResult`. Interrupting the wait does **not** stop the run — with
-    `TrainConfig.detach=True` (the default) an interrupted wait leaves training
-    going on Modal; set `detach=False` if you'd rather Ctrl-C tear the app down.
+    `TrainResult`. Interrupting the wait does **not** stop the run: a launched
+    run always lives in a detached Modal app, so Ctrl-C here only stops
+    waiting. To actually stop training, cancel the call:
+    `run.function_call.cancel(terminate_containers=True)`.
 
     Skip this cell entirely if you just want to launch and walk away.
     """


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->