### PR TITLE
Stop the Modal app when reconciling an orphaned running run

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -361,7 +361,8 @@ def reconcile() -> None:
     if outcome.runs:
         print(f"Reconciled {len(outcome.runs)} orphaned run(s):")
         for result in outcome.runs:
-            print(f"  {result.training_run_id}: {result.reason}")
+            stopped = " (stopped Modal app)" if result.stopped_modal_app else ""
+            print(f"  {result.training_run_id}: {result.reason}{stopped}")
     else:
         print("No orphaned runs to reconcile.")
 

--- a/modal_training_gym/common/run_reconciler.py
+++ b/modal_training_gym/common/run_reconciler.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from modal_training_gym.common.modal_lifecycle import resolve_app_liveness
+from modal_training_gym.common.modal_lifecycle import resolve_app_liveness, stop_app
 from modal_training_gym.common.run import TrainingRun, TrainingRunStatus
 from modal_training_gym.utils.metadata import (
     MetadataStore,
@@ -40,6 +40,7 @@ class ReconcileResult:
     training_run_id: str
     reason: str
     previous_status: str
+    stopped_modal_app: bool = False
 
 
 def _has_modal_app(run: TrainingRun) -> bool:
@@ -188,10 +189,12 @@ def reconcile_orphan_runs(
     now: int | None = None,
     get_lifecycle_state: Callable[[str], int | None] | None = None,
     has_train_result: Callable[[str], bool] | None = None,
+    stop_modal_app: Callable[[str], None] | None = None,
 ) -> list[ReconcileResult]:
     """Terminalize orphaned ``running`` runs. Returns reconciled run summaries."""
     now_ts = int(now if now is not None else time.time())
     has_result = has_train_result or _default_has_train_result
+    stop = stop_modal_app or stop_app
 
     results: list[ReconcileResult] = []
     for run in _load_running_runs():
@@ -227,14 +230,25 @@ def reconcile_orphan_runs(
         if run.started_at:
             run.duration_seconds = max(0, finished_at - run.started_at)
 
+        # A launched run lives in a detached Modal app, so terminalizing the
+        # metadata alone leaves the cluster billing. Stop any app that isn't
+        # already known-dead before writing the terminal state.
+        stopped_modal_app = bool(app_id) and app_live is not False
+
         result = ReconcileResult(
             training_run_id=run.training_run_id,
             reason=decision.reason,
             previous_status=previous_status,
+            stopped_modal_app=stopped_modal_app,
         )
         if dry_run:
             results.append(result)
             continue
+
+        if stopped_modal_app:
+            stop(app_id)
+            metadata["stopped_modal_app_at"] = finished_at
+            run.metadata = metadata
 
         try:
             run.save()

--- a/tests/test_run_reconciler.py
+++ b/tests/test_run_reconciler.py
@@ -297,3 +297,91 @@ def test_load_running_runs_reads_canonical_store_not_only_summary(fake_volume):
 
     loaded = _load_running_runs()
     assert {run.training_run_id for run in loaded} == {"canonical-only"}
+
+
+def test_reconcile_stops_modal_app_of_still_live_orphan(fake_volume, monkeypatch):
+    now = int(time.time())
+    stale_run = _run(
+        training_run_id="orphan-queued",
+        modal_app_id="ap-queued",
+        updated_at=now - 60,
+        metadata={
+            "framework_progress": {
+                "phase": "download_model",
+                "is_active": False,
+                "updated_at": now - QUEUED_STAGE_TIMEOUT_SECONDS - 60,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.run_reconciler._load_running_runs",
+        lambda: [stale_run],
+    )
+    stopped: list[str] = []
+
+    results = reconcile_orphan_runs(
+        now=now,
+        get_lifecycle_state=lambda _app_id: 1,
+        has_train_result=lambda _run_id: False,
+        stop_modal_app=stopped.append,
+    )
+    assert [r.reason for r in results] == ["stale_queued_stage"]
+    assert results[0].stopped_modal_app is True
+    assert stopped == ["ap-queued"]
+    assert stale_run.metadata["stopped_modal_app_at"] == now
+
+
+def test_reconcile_does_not_stop_already_dead_modal_app(fake_volume, monkeypatch):
+    now = int(time.time())
+    stale_run = _run(
+        training_run_id="orphan-dead",
+        modal_app_id="ap-dead",
+        updated_at=now - 120,
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.run_reconciler._load_running_runs",
+        lambda: [stale_run],
+    )
+    stopped: list[str] = []
+
+    results = reconcile_orphan_runs(
+        now=now,
+        get_lifecycle_state=lambda _app_id: 99,
+        has_train_result=lambda _run_id: False,
+        stop_modal_app=stopped.append,
+    )
+    assert [r.reason for r in results] == ["stale_modal_app_terminated"]
+    assert results[0].stopped_modal_app is False
+    assert stopped == []
+    assert "stopped_modal_app_at" not in (stale_run.metadata or {})
+
+
+def test_reconcile_dry_run_does_not_stop_modal_app(fake_volume, monkeypatch):
+    now = int(time.time())
+    stale_run = _run(
+        training_run_id="orphan-dry",
+        modal_app_id="ap-queued",
+        updated_at=now - 60,
+        metadata={
+            "framework_progress": {
+                "phase": "download_model",
+                "is_active": False,
+                "updated_at": now - QUEUED_STAGE_TIMEOUT_SECONDS - 60,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.run_reconciler._load_running_runs",
+        lambda: [stale_run],
+    )
+    stopped: list[str] = []
+
+    results = reconcile_orphan_runs(
+        dry_run=True,
+        now=now,
+        get_lifecycle_state=lambda _app_id: 1,
+        has_train_result=lambda _run_id: False,
+        stop_modal_app=stopped.append,
+    )
+    assert results[0].stopped_modal_app is True
+    assert stopped == []


### PR DESCRIPTION
The orphan reconciler only rewrote metadata — it flipped `status` to `CANCELLED` and saved, never touching the Modal app. For the two reasons that can fire while the app is still alive or unqueryable (`stale_queued_stage`, `stale_modal_app_unreachable` / `stale_running_no_update`), the cluster kept billing after the run was marked cancelled; the only bound was the train function's 24h timeout.

`reconcile_orphan_runs` now calls `stop_app(app_id)` before persisting the terminal state, skipping apps already known dead (`app_live is False`, i.e. `stale_modal_app_terminated`) and no-op'ing under `dry_run`:

```python
stopped_modal_app = bool(app_id) and app_live is not False
...
if stopped_modal_app:
    stop(app_id)
    metadata["stopped_modal_app_at"] = finished_at
```

`ReconcileResult` gains `stopped_modal_app: bool = False` so the half-hourly cron log says which runs had an app torn down. `stop_app` is best-effort and never raises. Injectable via a `stop_modal_app` parameter for tests.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.


Link to Devin session: https://modal.devinenterprise.com/sessions/f3f85eebb84547cf9884d14bf853f4c8
Requested by: @joyliu-q
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->