### PR TITLE
Move deployed_dashboard_url into common.dashboard to fix the cli↔common cycle

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -37,6 +37,7 @@ from modal_training_gym.common.config import (
     DASHBOARD_PROXY_AUTH_PATH,
     dashboard_requires_proxy_auth,
 )
+from modal_training_gym.common.dashboard import DASHBOARD_APP_NAME
 from modal_training_gym.common.run import FrameworkStatusUpdate, TrainingRun
 from modal_training_gym.common.run_list import (
     filter_run_summaries,
@@ -116,7 +117,7 @@ def _build_image() -> modal.Image:
 
 image = _build_image()
 
-app = modal.App("training-gym-dashboard", image=image)
+app = modal.App(DASHBOARD_APP_NAME, image=image)
 
 STATIC_DIR = "/app/frontend/dist"
 

--- a/modal_training_gym/cli/setup.py
+++ b/modal_training_gym/cli/setup.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 import os
 import webbrowser
 
-DASHBOARD_APP_NAME = "training-gym-dashboard"
-DASHBOARD_WEB_FUNCTION = "fastapi_app"
+from modal_training_gym.common.dashboard import (
+    DASHBOARD_APP_NAME,
+    deployed_dashboard_url,
+)
 
 
 def _load_dashboard_for_deploy(requires_proxy_auth: bool):
@@ -238,23 +240,6 @@ def open_dashboard() -> str | None:
     print(f"Opening dashboard: {web_url}")
     webbrowser.open(web_url)
     return web_url
-
-
-def deployed_dashboard_url() -> str | None:
-    """Return the live dashboard web URL if its app is deployed, else ``None``.
-
-    Authoritative check against Modal (not the local toml): looks up the
-    deployed ``fastapi_app`` function and returns its web URL. Any lookup
-    failure — not deployed, no credentials, network blip — yields ``None``.
-    """
-    import modal
-
-    try:
-        fn = modal.Function.from_name(DASHBOARD_APP_NAME, DASHBOARD_WEB_FUNCTION)
-        fn.hydrate()
-        return fn.get_web_url()
-    except Exception:
-        return None
 
 
 def ensure_dashboard_deployed() -> str | None:

--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -14,6 +14,8 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from modal_training_gym.common.dashboard import deployed_dashboard_url
+
 
 CONFIG_PATH = Path.home() / ".training-gym.toml"
 MODAL_CONFIG_PATH = Path(
@@ -77,9 +79,6 @@ def get_dashboard_proxy_auth() -> bool | None:
     identifies an authenticated deployment. The persisted mode remains a
     fallback for older or temporarily unreachable dashboards.
     """
-    # Imported here: ``cli`` imports this module, so a module-level import cycles.
-    from modal_training_gym.cli.setup import deployed_dashboard_url
-
     dashboard = load_config().get("dashboard")
     if not isinstance(dashboard, dict):
         dashboard = {}

--- a/modal_training_gym/common/dashboard.py
+++ b/modal_training_gym/common/dashboard.py
@@ -1,0 +1,27 @@
+"""Identity of the deployed training-gym dashboard app.
+
+Lives in ``common`` so library code — ``common.config``, the launchers — can
+resolve the live dashboard without importing ``cli``, which imports ``common``.
+"""
+
+from __future__ import annotations
+
+DASHBOARD_APP_NAME = "training-gym-dashboard"
+DASHBOARD_WEB_FUNCTION = "fastapi_app"
+
+
+def deployed_dashboard_url() -> str | None:
+    """Return the live dashboard web URL if its app is deployed, else ``None``.
+
+    Authoritative check against Modal (not the local toml): looks up the
+    deployed ``fastapi_app`` function and returns its web URL. Any lookup
+    failure — not deployed, no credentials, network blip — yields ``None``.
+    """
+    import modal
+
+    try:
+        fn = modal.Function.from_name(DASHBOARD_APP_NAME, DASHBOARD_WEB_FUNCTION)
+        fn.hydrate()
+        return fn.get_web_url()
+    except Exception:
+        return None


### PR DESCRIPTION
`common.config.get_dashboard_proxy_auth` needed `deployed_dashboard_url`, which lived in `cli/setup.py` — a `common → cli → common` cycle that #319 papered over with a function-local import.

New `modal_training_gym/common/dashboard.py` owns the deployed dashboard's identity and live lookup (`DASHBOARD_APP_NAME`, `DASHBOARD_WEB_FUNCTION`, `deployed_dashboard_url`). Nothing in it imports `common.config` or `cli`, so `common.config` imports it at module scope again and `cli/setup.py` re-exports the name (so `cli.setup.deployed_dashboard_url` keeps working, including the monkeypatch in `tests/test_dashboard_proxy_auth.py`). `_dashboard.py` now builds its `modal.App` from `DASHBOARD_APP_NAME` instead of a duplicated literal.

Behavior is unchanged; `deploy`/`setup` orchestration stays in the CLI.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/dbda7a742e0a4dbbb3f500379f9444eb
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->