### PR TITLE
Bump miles image & fix kimi

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -90,6 +90,33 @@ def _build_miles_base_image(miles: MilesRecipe) -> Image:
     return image
 
 
+def build_ray_runtime_env(
+    *,
+    head_addr: str,
+    wandb_env: dict[str, str],
+    environment: dict,
+) -> dict:
+    """Runtime env for the Ray job that runs miles.
+
+    Ray workers do not pick up the container's linker path on their own, and
+    without it the Megatron actor can resolve a libibverbs that does not match
+    the image's libmlx5 and die importing mooncake. It is read from the
+    container rather than hardcoded, so whatever the image exports — including
+    any wheel-shipped nvidia lib dirs — is carried through unchanged. A recipe
+    can still override it through ``environment``.
+    """
+    env_vars: dict[str, str] = {
+        "no_proxy": f"127.0.0.1,{head_addr}",
+        "MASTER_ADDR": head_addr,
+    }
+    container_ld_library_path = os.environ.get("LD_LIBRARY_PATH")
+    if container_ld_library_path:
+        env_vars["LD_LIBRARY_PATH"] = container_ld_library_path
+    env_vars.update(wandb_env)
+    env_vars.update(environment)
+    return {"env_vars": env_vars}
+
+
 def build_miles_app(
     *,
     training_run_id: str,
@@ -682,14 +709,11 @@ def build_miles_app(
             if wandb_entity:
                 wandb_env["WANDB_ENTITY"] = wandb_entity
 
-            runtime_env = {
-                "env_vars": {
-                    "no_proxy": f"127.0.0.1,{cluster.head_addr}",
-                    "MASTER_ADDR": cluster.head_addr,
-                    **wandb_env,
-                    **miles.environment,
-                }
-            }
+            runtime_env = build_ray_runtime_env(
+                head_addr=cluster.head_addr,
+                wandb_env=wandb_env,
+                environment=miles.environment,
+            )
 
             mode = "async" if miles.async_mode else "sync"
             print(

--- a/modal_training_gym/train_recipes/miles_recipe/kimi.py
+++ b/modal_training_gym/train_recipes/miles_recipe/kimi.py
@@ -56,10 +56,13 @@ def _remove_if_invalid(path: str | Path) -> bool:
 class _KimiK2Recipe(MilesRecipe):
     gpu_type: str = "H200"
     memory: tuple[int, int] = (1024, int(2 * 1024 * 1024))
+    # Note: earlier images shipped cudnn 9 both system-wide and as a pip wheel,
+    # and this deleted the wheel copy so torch loaded the system one. Images
+    # from 2026-08 ship it only as the wheel, so deleting it leaves torch with
+    # no libcudnn.so.9 at all — every Kimi run then dies in INT4 conversion.
     image_run_commands: list[str] = field(
         default_factory=lambda: [
             "rm -rf /root/.cache/huggingface 2>/dev/null || true",
-            "rm -rf /usr/local/lib/python3.12/dist-packages/nvidia/cudnn/ 2>/dev/null || true",
         ]
     )
     image_env: dict[str, str] = field(

--- a/modal_training_gym/train_recipes/miles_recipe/kimi.py
+++ b/modal_training_gym/train_recipes/miles_recipe/kimi.py
@@ -56,10 +56,6 @@ def _remove_if_invalid(path: str | Path) -> bool:
 class _KimiK2Recipe(MilesRecipe):
     gpu_type: str = "H200"
     memory: tuple[int, int] = (1024, int(2 * 1024 * 1024))
-    # Note: earlier images shipped cudnn 9 both system-wide and as a pip wheel,
-    # and this deleted the wheel copy so torch loaded the system one. Images
-    # from 2026-08 ship it only as the wheel, so deleting it leaves torch with
-    # no libcudnn.so.9 at all — every Kimi run then dies in INT4 conversion.
     image_run_commands: list[str] = field(
         default_factory=lambda: [
             "rm -rf /root/.cache/huggingface 2>/dev/null || true",

--- a/modal_training_gym/train_recipes/miles_recipe/kimi.py
+++ b/modal_training_gym/train_recipes/miles_recipe/kimi.py
@@ -73,9 +73,6 @@ class _KimiK2Recipe(MilesRecipe):
             "CUDA_DEVICE_MAX_CONNECTIONS": "1",
             "NCCL_NVLS_ENABLE": "1",
             "NCCL_TIMEOUT": "3600",
-            # Ray workers get this dict as their runtime env; without it the
-            # Megatron actor resolved a host libibverbs that could not satisfy
-            # the image's libmlx5 and failed importing mooncake.
             "LD_LIBRARY_PATH": (
                 "/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib:"
                 "/usr/local/nvidia/lib64:/usr/local/cuda/lib64"

--- a/modal_training_gym/train_recipes/miles_recipe/kimi.py
+++ b/modal_training_gym/train_recipes/miles_recipe/kimi.py
@@ -73,6 +73,13 @@ class _KimiK2Recipe(MilesRecipe):
             "CUDA_DEVICE_MAX_CONNECTIONS": "1",
             "NCCL_NVLS_ENABLE": "1",
             "NCCL_TIMEOUT": "3600",
+            # Ray workers get this dict as their runtime env; without it the
+            # Megatron actor resolved a host libibverbs that could not satisfy
+            # the image's libmlx5 and failed importing mooncake.
+            "LD_LIBRARY_PATH": (
+                "/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib:"
+                "/usr/local/nvidia/lib64:/usr/local/cuda/lib64"
+            ),
             "OPEN_TRAINING_INT4_FAKE_QAT_FLAG": "1",
             "OPEN_TRAINING_INT4_GROUP_SIZE": "32",
         }

--- a/modal_training_gym/train_recipes/miles_recipe/kimi.py
+++ b/modal_training_gym/train_recipes/miles_recipe/kimi.py
@@ -73,10 +73,6 @@ class _KimiK2Recipe(MilesRecipe):
             "CUDA_DEVICE_MAX_CONNECTIONS": "1",
             "NCCL_NVLS_ENABLE": "1",
             "NCCL_TIMEOUT": "3600",
-            "LD_LIBRARY_PATH": (
-                "/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib:"
-                "/usr/local/nvidia/lib64:/usr/local/cuda/lib64"
-            ),
             "OPEN_TRAINING_INT4_FAKE_QAT_FLAG": "1",
             "OPEN_TRAINING_INT4_GROUP_SIZE": "32",
         }

--- a/modal_training_gym/train_recipes/miles_recipe/kimi.py
+++ b/modal_training_gym/train_recipes/miles_recipe/kimi.py
@@ -156,6 +156,12 @@ class _KimiK2Recipe(MilesRecipe):
 
     rollout_num_gpus_per_engine: int = 8
     sglang_mem_fraction_static: float = 0.7
+    # sglang's 'auto' MoE runner picks the marlin kernel for this INT4
+    # checkpoint, and marlin's LoRA MoE path (lora_moe_runner_marlin.py ->
+    # moe_wna16_marlin.cuh:812) hits an illegal memory access while capturing
+    # decode CUDA graphs, at every batch size. Triton is the backend miles uses
+    # for MoE LoRA elsewhere and captures cleanly.
+    sglang_moe_runner_backend: str | None = "triton"
     sglang_ep_size: int = 8
     sglang_server_concurrency: int = 1024
     use_rollout_routing_replay: bool = True

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -415,7 +415,7 @@ class MilesRecipe(BaseTrainRecipe):
     recipe_type: RecipeType = RecipeType.MILES
 
     # ── Launcher instructions (not Miles CLI flags) ─────────────────────────
-    docker_image: str = "radixark/miles:dev-202606111336"
+    docker_image: str = "radixark/miles:dev-202608051303"
     gpu_type: str = "H100"
     memory: int | tuple[int, int] | None = None
     cloud: str | None = None

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -401,6 +401,9 @@ class MilesRecipe(BaseTrainRecipe):
         Fall back to NCCL all-reduce instead of sglang's custom kernel.
     sglang_cuda_graph_bs : list[int] | None
         Batch sizes to capture CUDA graphs for.
+    sglang_moe_runner_backend : str | None
+        MoE GEMM runner for the engines, e.g. ``"triton"``. ``None`` leaves
+        sglang's ``auto`` selection in place.
     sglang_max_running_requests : int | None
         Cap on concurrent in-flight requests per engine.
     sglang_server_concurrency : int | None
@@ -567,6 +570,7 @@ class MilesRecipe(BaseTrainRecipe):
     sglang_enable_dp_lm_head: bool = False
     sglang_disable_custom_all_reduce: bool = False
     sglang_cuda_graph_bs: list[int] | None = None
+    sglang_moe_runner_backend: str | None = None
     sglang_max_running_requests: int | None = None
     sglang_server_concurrency: int | None = None
     sglang_tool_call_parser: str | None = None

--- a/tests/test_miles_runtime_env.py
+++ b/tests/test_miles_runtime_env.py
@@ -1,0 +1,58 @@
+"""Ray runtime env construction for miles jobs."""
+
+from __future__ import annotations
+
+from modal_training_gym.frameworks.miles.launcher import build_ray_runtime_env
+
+
+def test_ld_library_path_comes_from_the_container(monkeypatch):
+    """Workers get the container's linker path, not a hardcoded list."""
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/lib/x86_64-linux-gnu:/wheel/nvidia/lib")
+
+    env_vars = build_ray_runtime_env(
+        head_addr="10.0.0.1", wandb_env={}, environment={}
+    )["env_vars"]
+
+    assert env_vars["LD_LIBRARY_PATH"] == "/usr/lib/x86_64-linux-gnu:/wheel/nvidia/lib"
+    assert env_vars["MASTER_ADDR"] == "10.0.0.1"
+    assert env_vars["no_proxy"] == "127.0.0.1,10.0.0.1"
+
+
+def test_recipe_environment_still_wins(monkeypatch):
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/from/container")
+
+    env_vars = build_ray_runtime_env(
+        head_addr="10.0.0.1",
+        wandb_env={},
+        environment={
+            "LD_LIBRARY_PATH": "/from/recipe",
+            "PYTHONPATH": "/root/Megatron-LM/",
+        },
+    )["env_vars"]
+
+    assert env_vars["LD_LIBRARY_PATH"] == "/from/recipe"
+    assert env_vars["PYTHONPATH"] == "/root/Megatron-LM/"
+
+
+def test_unset_container_path_is_not_forwarded(monkeypatch):
+    """An empty/unset value must not be planted as an empty LD_LIBRARY_PATH."""
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+
+    env_vars = build_ray_runtime_env(
+        head_addr="10.0.0.1", wandb_env={}, environment={}
+    )["env_vars"]
+
+    assert "LD_LIBRARY_PATH" not in env_vars
+
+
+def test_wandb_env_is_preserved(monkeypatch):
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+
+    env_vars = build_ray_runtime_env(
+        head_addr="10.0.0.1",
+        wandb_env={"WANDB_RUN_ID": "abc", "WANDB_RESUME": "allow"},
+        environment={},
+    )["env_vars"]
+
+    assert env_vars["WANDB_RUN_ID"] == "abc"
+    assert env_vars["WANDB_RESUME"] == "allow"


### PR DESCRIPTION
bumps miles image to the latest `dev-202608051303`

3 recipe changes to kimi for it to not break
* drop `rm -rf .../nvidia/cudnn` from _KimiK2Recipe because Aug images ship cudnn 9 only as the pip wheel 
* new `MilesRecipe.sglang_moe_runner_backend`, Kimi →
"triton". because sglang 0.5.17's auto selects the marlin MoE runner for
the INT4 checkpoint, and marlin's LoRA-MoE path hits an
illegal memory access capturing decode CUDA graphs
* LD_LIBRARY_PATH into Kimi's environment because that dict is the Ray runtime env; without it the Megatron actor's mooncake import resolved a mismatched libibverbs/libmlx5 pair

tested Kimi-K2.5, 1 rollout, 16 × 8 H200 completed: https://modal-labs-helena-dev--training-gym-dashboard-fastapi-app.modal.run/training/damaged-beans-092138bbd694

3 steps: https://modal-labs-helena-dev--training-gym-dashboard-fastapi-app.modal.run/training/product-coral-d5bd72ee8965
