### PR TITLE
Serve dashboard requests concurrently and keep summary rebuilds off the read path

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -378,6 +378,11 @@ def reconcile() -> None:
     min_containers=1,
     secrets=_function_secrets(),
 )
+# Without this a container takes one request at a time, so the SPA's own poll --
+# runs, deployments and evals every five seconds -- queues behind itself, and a
+# held-open log stream blocks every other request for as long as it is open.
+# Requests here wait on the volume and on Modal far more than they compute.
+@modal.concurrent(max_inputs=50, target_inputs=20)
 @modal.asgi_app(requires_proxy_auth=dashboard_requires_proxy_auth())
 def fastapi_app():
     import base64
@@ -389,6 +394,7 @@ def fastapi_app():
         HTTPException,
     )  # Request imported at module scope
     from fastapi.concurrency import run_in_threadpool
+    from fastapi.middleware.gzip import GZipMiddleware
     from fastapi.responses import (
         FileResponse,
         JSONResponse,
@@ -402,11 +408,14 @@ def fastapi_app():
         MetadataStore,
         summary_items_from_payload,
         vol_get,
-        vol_get_summary_items_healed,
+        vol_get_summary_items,
         vol_put_summary_items,
     )
 
     web = FastAPI()
+    # The list endpoints answer with the whole summary, which is mostly repeated
+    # keys and ids and compresses to a fraction of itself.
+    web.add_middleware(GZipMiddleware, minimum_size=500)
 
     # ── Optional password protection ──────────────────────────────────────
     # When DASHBOARD_PASSWORD is set we gate the whole app behind HTTP Basic
@@ -617,7 +626,12 @@ def fastapi_app():
     async def load_list_summary(
         summary_store: MetadataStore,
     ) -> list[JsonDict]:
-        items = await run_in_threadpool(vol_get_summary_items_healed, summary_store)
+        # Deliberately the plain read, not the healing one: a rebuild reads every
+        # canonical file and rewrites the whole summary, which is far too much to
+        # put behind a list request. ``compact_summaries`` already runs it on a
+        # schedule, and a summary that is briefly short of a run costs less than
+        # a list endpoint that can take minutes.
+        items = await run_in_threadpool(vol_get_summary_items, summary_store)
         if not items:
             return []
         items, changed = add_modal_app_urls(items)

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -323,6 +323,11 @@ def vol_count_items(store: MetadataStore | str) -> int:
     A single directory listing, used to cheaply detect a collapsed summary
     (summary item count < canonical file count) before paying for a full
     rebuild via ``vol_list``.
+
+    Non-recursive, because a store writes its items as ``<store>/<id>.json`` and
+    only those can ever reach a summary. Anything nested under the store counted
+    here instead holds the count permanently above the summary, and every reader
+    then rebuilds the whole summary trying to close a gap that cannot close.
     """
     from modal.exception import NotFoundError
 
@@ -330,7 +335,9 @@ def vol_count_items(store: MetadataStore | str) -> int:
     _safe_reload(vol)
     try:
         return sum(
-            1 for e in vol.iterdir(_store_path(store)) if e.path.endswith(".json")
+            1
+            for e in vol.iterdir(_store_path(store), recursive=False)
+            if e.path.endswith(".json")
         )
     except (FileNotFoundError, NotFoundError):
         return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,12 +62,16 @@ class FakeVolume:
             raise FileNotFoundError(path)
         del self.files[path]
 
-    def _iterdir(self, path: str):
+    def _iterdir(self, path: str, *, recursive: bool = True):
         prefix = path.rstrip("/") + "/"
-        return [self._DirEntry(f) for f in self.files if f.startswith(prefix)]
+        return [
+            self._DirEntry(f)
+            for f in self.files
+            if f.startswith(prefix) and (recursive or "/" not in f[len(prefix) :])
+        ]
 
-    async def _iterdir_async(self, path: str):
-        for entry in self._iterdir(path):
+    async def _iterdir_async(self, path: str, *, recursive: bool = True):
+        for entry in self._iterdir(path, recursive=recursive):
             yield entry
 
     def batch_upload(self, force: bool = False):

--- a/tests/test_dashboard_runs_route.py
+++ b/tests/test_dashboard_runs_route.py
@@ -80,7 +80,7 @@ def test_get_run_route_returns_one_typed_summary(fake_volume, monkeypatch, tmp_p
     def fail_summary_scan(_store):
         raise AssertionError("single-run route must not scan summary stores")
 
-    monkeypatch.setattr(metadata, "vol_get_summary_items_healed", fail_summary_scan)
+    monkeypatch.setattr(metadata, "vol_get_summary_items", fail_summary_scan)
 
     with _client(monkeypatch, tmp_path) as client:
         response = client.get("/api/runs/run-route-1")
@@ -138,14 +138,14 @@ def test_runs_route_keeps_runs_when_train_result_store_fails(
     fake_volume, monkeypatch, tmp_path
 ):
     _save_records()
-    original = metadata.vol_get_summary_items_healed
+    original = metadata.vol_get_summary_items
 
     def fail_results(store):
         if store is MetadataStore.TRAIN_RESULTS_SUMMARY:
             raise RuntimeError("result store unavailable")
         return original(store)
 
-    monkeypatch.setattr(metadata, "vol_get_summary_items_healed", fail_results)
+    monkeypatch.setattr(metadata, "vol_get_summary_items", fail_results)
 
     with _client(monkeypatch, tmp_path) as client:
         response = client.get("/api/runs")

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -20,7 +20,7 @@ from modal_training_gym.common import run as run_mod
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.train_result import TrainResult
 from modal_training_gym.common.training_rollout import TrainingRolloutResult
-from modal_training_gym.utils.metadata import MetadataStore
+from modal_training_gym.utils.metadata import MetadataStore, vol_count_items
 
 
 @pytest.mark.parametrize("fw", list(Framework))
@@ -30,6 +30,21 @@ def test_training_run_save_survives_unmounted_volume(fake_volume, fw):
 
     blob = fake_volume.files[f"{MetadataStore.TRAINING_RUNS.value}/t1.json"]
     assert json.loads(blob)["framework"] == fw.value
+
+
+def test_count_items_ignores_files_nested_under_the_store(fake_volume):
+    """Only ``<store>/<id>.json`` counts, so the summary can catch up with it.
+
+    A file nested deeper never reaches a summary, so counting it would hold the
+    count permanently above the summary and make every reader rebuild.
+    """
+    run_mod.TrainingRun(
+        training_run_id="t1", framework=Framework.SLIME, config={}
+    ).save()
+    store = MetadataStore.TRAINING_RUNS.value
+    fake_volume.files[f"{store}/Qwen/Qwen3-4B/notes.json"] = b"{}"
+
+    assert vol_count_items(MetadataStore.TRAINING_RUNS) == 1
 
 
 @pytest.mark.parametrize("fw", list(Framework))


### PR DESCRIPTION
devin accident