### PR TITLE
Serve dashboard requests concurrently

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -378,6 +378,11 @@ def reconcile() -> None:
     min_containers=1,
     secrets=_function_secrets(),
 )
+# Without this a container takes one request at a time, so the SPA's own poll --
+# runs, deployments and evals every five seconds -- queues behind itself, and a
+# held-open log stream blocks every other request for as long as it is open.
+# Requests here wait on the volume and on Modal far more than they compute.
+@modal.concurrent(max_inputs=50, target_inputs=20)
 @modal.asgi_app(requires_proxy_auth=dashboard_requires_proxy_auth())
 def fastapi_app():
     import base64
@@ -389,6 +394,7 @@ def fastapi_app():
         HTTPException,
     )  # Request imported at module scope
     from fastapi.concurrency import run_in_threadpool
+    from fastapi.middleware.gzip import GZipMiddleware
     from fastapi.responses import (
         FileResponse,
         JSONResponse,
@@ -407,6 +413,9 @@ def fastapi_app():
     )
 
     web = FastAPI()
+    # The list endpoints answer with the whole summary, which is mostly repeated
+    # keys and ids and compresses to a fraction of itself.
+    web.add_middleware(GZipMiddleware, minimum_size=500)
 
     # ── Optional password protection ──────────────────────────────────────
     # When DASHBOARD_PASSWORD is set we gate the whole app behind HTTP Basic

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -378,10 +378,6 @@ def reconcile() -> None:
     min_containers=1,
     secrets=_function_secrets(),
 )
-# Without this a container takes one request at a time, so the SPA's own poll --
-# runs, deployments and evals every five seconds -- queues behind itself, and a
-# held-open log stream blocks every other request for as long as it is open.
-# Requests here wait on the volume and on Modal far more than they compute.
 @modal.concurrent(max_inputs=50, target_inputs=20)
 @modal.asgi_app(requires_proxy_auth=dashboard_requires_proxy_auth())
 def fastapi_app():
@@ -394,7 +390,6 @@ def fastapi_app():
         HTTPException,
     )  # Request imported at module scope
     from fastapi.concurrency import run_in_threadpool
-    from fastapi.middleware.gzip import GZipMiddleware
     from fastapi.responses import (
         FileResponse,
         JSONResponse,
@@ -413,9 +408,6 @@ def fastapi_app():
     )
 
     web = FastAPI()
-    # The list endpoints answer with the whole summary, which is mostly repeated
-    # keys and ids and compresses to a fraction of itself.
-    web.add_middleware(GZipMiddleware, minimum_size=500)
 
     # ── Optional password protection ──────────────────────────────────────
     # When DASHBOARD_PASSWORD is set we gate the whole app behind HTTP Basic


### PR DESCRIPTION
`fastapi_app` never got a `@modal.concurrent`, so Modal defaults to a single input per container and the dashboard serves one request at a time.

Measured against the deployed dashboard, eight parallel fetches of a ~500-byte `favicon.svg` — a static file, no server work at all — return in a stair-step:

```
0.45  0.99  1.53  2.26  2.81  3.17  3.72  4.44   (seconds)
```

The SPA polls `/api/runs`, `/api/deployments` and `/api/evals` every five seconds, so it queues behind itself, and a held-open `/logs/stream` SSE connection is worse: it occupies the container's only slot for as long as the tab is open. These requests spend nearly all their time waiting on the Volume and on Modal rather than computing, so they overlap well — `docs-next/docs_next_app.py:48` already does the same thing.

`max_inputs=50` rather than the docs app's 100: blocking work goes through `run_in_threadpool`, and anyio's default thread limiter is 40, so a higher cap just moves the queue onto threads. `target_inputs=20` keeps autoscaling scaling out instead of concentrating load on one container.

After the change the same eight fetches land flat at ~0.68–0.86s, and eight parallel `/api/runs` complete together instead of serially.