### PR TITLE
Clear stale error_message on a retried run that completes

### DIFF
--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -399,8 +399,6 @@ def mark_training_attempt_started(
     run.ended_at = None
     run.completed_at = None
     run.duration_seconds = None
-    # A retry re-fetches the failed attempt's record, so clear its error too —
-    # otherwise the dashboard shows that failure banner for the whole new attempt.
     run.error_message = None
     run.metadata = metadata
     return attempt_count

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -399,6 +399,9 @@ def mark_training_attempt_started(
     run.ended_at = None
     run.completed_at = None
     run.duration_seconds = None
+    # A retry re-fetches the failed attempt's record, so clear its error too —
+    # otherwise the dashboard shows that failure banner for the whole new attempt.
+    run.error_message = None
     run.metadata = metadata
     return attempt_count
 


### PR DESCRIPTION
a run with status complete should not show a previous try's error message on the dashboard because it is confusing

did this by clearing `error_message` in `mark_training_attempt_started` alongside clearing `completed_at`, `ended_at`, and `duration_seconds`