### PR TITLE
Fix Qwen35b example error

### DIFF
--- a/tutorials/singlenode/000_qwen35b/000_qwen35b.ipynb
+++ b/tutorials/singlenode/000_qwen35b/000_qwen35b.ipynb
@@ -145,7 +145,7 @@
    "outputs": [],
    "source": [
     "rows = dataset.load()\n",
-    "for row in rows[:2]:\n",
+    "for row in rows.select(range(2)):\n",
     "    prompt = row[\"prompt\"]\n",
     "    if isinstance(prompt, list):\n",
     "        prompt = prompt[0][\"content\"] if prompt else \"\"\n",

--- a/tutorials/tutorial_generator/singlenode/000_qwen35b.py
+++ b/tutorials/tutorial_generator/singlenode/000_qwen35b.py
@@ -121,7 +121,7 @@ def _dataset_preview():
 @code
 def _dataset_preview_code():
     rows = dataset.load()
-    for row in rows[:2]:
+    for row in rows.select(range(2)):
         prompt = row["prompt"]
         if isinstance(prompt, list):
             prompt = prompt[0]["content"] if prompt else ""


### PR DESCRIPTION
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[25], line 3
      1 rows = dataset.load()
      2 for row in rows[:2]:
----> 3     prompt = row["prompt"]
      4     if isinstance(prompt, list):
      5         prompt = prompt[0]["content"] if prompt else ""

TypeError: string indices must be integers, not 'str'
```

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


## Outside contributors

You're great! Thanks for your contribution.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->