### PR TITLE
Add Miles SWE-Agent example

### DIFF
--- a/examples/miles_swe_agent.py
+++ b/examples/miles_swe_agent.py
@@ -40,12 +40,16 @@ class SWEAgentDataset(DatasetConfig):
 
     The ``metadata`` dict carries ``instance_id`` (which Harbor maps to a task
     directory) plus the original sample fields and ``agent_name``.
+
+    This example does not define a held-out eval split, so tell the launcher
+    not to materialize a companion ``eval.*`` file.
     """
 
     input_key: str = "prompt"
     label_key: str = ""
     apply_chat_template: bool = False
     output_format: str = "jsonl"
+    writes_eval_paths: bool = False
 
     hf_repo: str = "SWE-Gym/SWE-Gym"
     hf_split: str = "train"
@@ -190,13 +194,9 @@ recipe = MilesRecipe(
         "CUDA_DEVICE_MAX_CONNECTIONS": "1",
         "NCCL_NVLS_ENABLE": "1",
         "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
-        "AGENT_SERVER_URL": os.environ.get(
-            "AGENT_SERVER_URL", "http://<agent-server>:30000"
-        ),
+        "AGENT_SERVER_URL": os.environ.get("AGENT_SERVER_URL", ""),
         "AGENT_MODEL_NAME": os.environ.get("AGENT_MODEL_NAME", "model"),
-        "MILES_ROUTER_EXTERNAL_HOST": os.environ.get(
-            "MILES_ROUTER_EXTERNAL_HOST", "<router-host>"
-        ),
+        "MILES_ROUTER_EXTERNAL_HOST": os.environ.get("MILES_ROUTER_EXTERNAL_HOST", ""),
         "HARBOR_TASKS_DIR": os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks"),
     },
     extra_config={
@@ -213,7 +213,22 @@ recipe = MilesRecipe(
 )
 
 
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise TrainingGymConfigError(
+            f"{name} must be set before running this example. "
+            "See the Prerequisites section in the file docstring."
+        )
+    return value
+
+
 def main() -> None:
+    recipe.environment["AGENT_SERVER_URL"] = _require_env("AGENT_SERVER_URL")
+    recipe.environment["MILES_ROUTER_EXTERNAL_HOST"] = _require_env(
+        "MILES_ROUTER_EXTERNAL_HOST"
+    )
+
     result = TrainConfig(
         model=model,
         dataset=dataset,

--- a/examples/miles_swe_agent.py
+++ b/examples/miles_swe_agent.py
@@ -1,0 +1,226 @@
+"""Miles SWE-Agent training on Modal via modal-training-gym.
+
+Mirrors the upstream ``radixark/miles/examples/swe-agent`` setup:
+https://github.com/radixark/miles/blob/b1860dd264e17c96d5d92da96c957d88cfd3a1f8/examples/swe-agent/README.md
+
+Prerequisites
+-------------
+* A Harbor agent server running and reachable from the Modal cluster.
+  See the Miles README for how to start it.
+* Modal Secrets: ``huggingface-secret`` (HF_TOKEN) and optionally
+  ``wandb-secret`` (WANDB_API_KEY).
+* Fill in ``AGENT_SERVER_URL`` and ``MILES_ROUTER_EXTERNAL_HOST`` below.
+
+If you need to patch Miles or the base image, fork ``radixark/miles``, build the
+image, and set ``docker_image`` to your fork's image tag.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import modal
+
+from modal_training_gym import MilesRecipe, TrainConfig
+from modal_training_gym.common.dataset import DatasetConfig
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.models import HFModelConfiguration
+
+
+class GLM_4_7_Flash(HFModelConfiguration):
+    """GLM-4.7-Flash checkpoint for the Miles agentic-coding recipe."""
+
+    model_name = "zai-org/GLM-4.7-Flash"
+
+
+class SWEAgentDataset(DatasetConfig):
+    """Converts a HuggingFace JSONL into the Miles ``prompt``/``metadata`` format.
+
+    The ``metadata`` dict carries ``instance_id`` (which Harbor maps to a task
+    directory) plus the original sample fields and ``agent_name``.
+    """
+
+    input_key: str = "prompt"
+    label_key: str = ""
+    apply_chat_template: bool = False
+    output_format: str = "jsonl"
+
+    hf_repo: str = "SWE-Gym/SWE-Gym"
+    hf_split: str = "train"
+    prompt_key: str = "problem_statement"
+    agent_name: str = "mini-swe-agent"
+    n_rows: int | None = None
+
+    def _validate(self) -> None:
+        # Miles only needs an ``input_key`` and a separate ``metadata`` column;
+        # we skip the generic ``label_key`` requirement.
+        if not self.input_key:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} requires `input_key` to be set."
+            )
+
+    def load(self, split: str = "all") -> list[dict[str, object]]:
+        from datasets import load_dataset
+
+        ds = load_dataset(self.hf_repo, split=self.hf_split)
+        if self.n_rows:
+            ds = ds.select(range(min(self.n_rows, len(ds))))
+
+        rows: list[dict[str, object]] = []
+        for i, ex in enumerate(ds):
+            instance = dict(ex)
+            metadata = {
+                **instance,
+                "agent_name": self.agent_name,
+                "split": self.hf_split,
+            }
+            if "instance_id" not in metadata:
+                metadata["instance_id"] = instance.get("id", str(i))
+
+            prompt = instance.get(self.prompt_key, "")
+            for fallback in ("problem_statement", "instruction", "prompt"):
+                if not prompt:
+                    prompt = instance.get(fallback, "")
+
+            rows.append({"prompt": prompt, "metadata": metadata})
+        return rows
+
+    def prepare(self, path: str, eval_paths: dict[str, str] | None = None) -> None:
+        import os
+
+        rows = self.load()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            for row in rows:
+                f.write(json.dumps(row, default=str) + "\n")
+
+        if eval_paths:
+            for eval_path in eval_paths.values():
+                os.makedirs(os.path.dirname(eval_path), exist_ok=True)
+                with open(eval_path, "w") as f:
+                    for row in rows:
+                        f.write(json.dumps(row, default=str) + "\n")
+
+
+def swe_agent_reward(args, samples, **kwargs):
+    """Reward is pre-computed by the Harbor agent server and stored in metadata."""
+    if isinstance(samples, list):
+        return [s.metadata.get("reward", 0.0) for s in samples]
+    return samples.metadata.get("reward", 0.0)
+
+
+def image_overlay(image: modal.Image) -> modal.Image:
+    """Copy the agent helper into the container so Miles can import it by name."""
+    helper = Path(__file__).resolve().parent / "miles_swe_agent_function.py"
+    if helper.exists():
+        image = image.add_local_file(
+            str(helper),
+            remote_path="/root/miles_swe_agent_function.py",
+            copy=True,
+        )
+    return image
+
+
+dataset = SWEAgentDataset(
+    hf_repo="SWE-Gym/SWE-Gym",
+    prompt_key="problem_statement",
+    agent_name="mini-swe-agent",
+    n_rows=4,  # smoke-size; remove for a real run
+)
+
+model = GLM_4_7_Flash()
+
+recipe = MilesRecipe(
+    docker_image="radixark/miles:dev-202606111336",
+    miles_model_script="scripts/models/glm4.7-flash.sh",
+    hf_checkpoint="zai-org/GLM-4.7-Flash",
+    ref_load="/checkpoints/GLM-4.7-Flash-torch-dist",
+    megatron_to_hf_mode="raw",
+    actor_num_nodes=1,
+    actor_num_gpus_per_node=8,
+    rollout_num_gpus=8,
+    tensor_model_parallel_size=4,
+    pipeline_model_parallel_size=1,
+    context_parallel_size=1,
+    expert_model_parallel_size=8,
+    expert_tensor_parallel_size=1,
+    sequence_parallel=True,
+    recompute_granularity="full",
+    recompute_method="uniform",
+    recompute_num_layers=1,
+    use_dynamic_batch_size=True,
+    max_tokens_per_gpu=16384,
+    optimizer_cpu_offload=True,
+    overlap_cpu_optimizer_d2h_h2d=True,
+    use_precision_aware_optimizer=True,
+    attention_backend="flash",
+    num_rollout=1,  # smoke; set to 3000 for the full run
+    rollout_batch_size=4,
+    n_samples_per_prompt=8,
+    global_batch_size=32,
+    rollout_max_response_len=8192,
+    rollout_temperature=0.8,
+    rollout_shuffle=True,
+    balance_data=True,
+    lr=1e-6,
+    weight_decay=0.1,
+    adam_beta1=0.9,
+    adam_beta2=0.98,
+    lr_decay_style="constant",
+    optimizer="adam",
+    advantage_estimator="grpo",
+    use_kl_loss=True,
+    kl_loss_coef=0.01,
+    kl_loss_type="low_var_kl",
+    eps_clip=0.2,
+    eps_clip_high=0.28,
+    entropy_coef=0.0,
+    save_interval=100,
+    sglang_mem_fraction_static=0.7,
+    sglang_tool_call_parser="glm47",
+    sglang_reasoning_parser="glm45",
+    rollout_num_gpus_per_engine=1,
+    colocate=True,
+    custom_rm_function=swe_agent_reward,
+    image_overlay=image_overlay,
+    environment={
+        "PYTHONPATH": "/root/Megatron-LM/:/root",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        "NCCL_NVLS_ENABLE": "1",
+        "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
+        "AGENT_SERVER_URL": os.environ.get(
+            "AGENT_SERVER_URL", "http://<agent-server>:30000"
+        ),
+        "AGENT_MODEL_NAME": os.environ.get("AGENT_MODEL_NAME", "model"),
+        "MILES_ROUTER_EXTERNAL_HOST": os.environ.get(
+            "MILES_ROUTER_EXTERNAL_HOST", "<router-host>"
+        ),
+        "HARBOR_TASKS_DIR": os.environ.get("HARBOR_TASKS_DIR", "/root/harbor_tasks"),
+    },
+    extra_config={
+        "custom_generate_function_path": "miles.rollout.generate_hub.agentic_tool_call.generate",
+        "custom_agent_function_path": "miles_swe_agent_function.run",
+        "tito_model": "glm47",
+        "use_session_server": True,
+        "session_server_port": [30000],
+        "sglang_router_port": 31000,
+        "max_seq_len": 65536,
+        "metadata_key": "metadata",
+        "dynamic_sampling_filter_path": "miles.rollout.filter_hub.dynamic_sampling_filters.check_no_aborted",
+    },
+)
+
+
+def main() -> None:
+    result = TrainConfig(
+        model=model,
+        dataset=dataset,
+        recipe=recipe,
+    ).train()
+    print(result.training_run_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/miles_swe_agent_function.py
+++ b/examples/miles_swe_agent_function.py
@@ -1,0 +1,143 @@
+"""Harbor agent client for the Miles SWE-agent example.
+
+This module is the value passed to `--custom-agent-function-path` in Miles. It is
+called once per rollout sample and forwards the request to an external Harbor
+agent server, returning the reward and agent metrics.
+"""
+
+import asyncio
+import logging
+import os
+import socket
+from typing import Any
+from urllib.parse import urlparse, urlsplit, urlunparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_agent_server_client: httpx.AsyncClient | None = None
+
+
+def _get_agent_server_client() -> httpx.AsyncClient:
+    """Return a long-lived client with TCP keepalive for idle network paths."""
+    global _agent_server_client
+    if _agent_server_client is None:
+        socket_options = [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+            (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPIDLE", 4), 60),
+            (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPINTVL", 5), 30),
+            (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPCNT", 6), 5),
+        ]
+        transport = httpx.AsyncHTTPTransport(socket_options=socket_options)
+        _agent_server_client = httpx.AsyncClient(
+            transport=transport,
+            limits=httpx.Limits(max_connections=64, max_keepalive_connections=32),
+            timeout=None,
+        )
+    return _agent_server_client
+
+
+async def _post_agent_server(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    client = _get_agent_server_client()
+    response = await client.post(url, json=payload)
+    response.raise_for_status()
+    return response.json()
+
+
+async def run(
+    base_url: str,
+    prompt: Any,
+    request_kwargs: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    **kwargs,
+) -> dict[str, Any] | None:
+    """Run a single task instance through the Harbor agent server."""
+    metadata = metadata or {}
+    request_kwargs = request_kwargs or {}
+
+    agent_server_url = os.getenv(
+        "AGENT_SERVER_URL",
+        os.getenv("SWE_AGENT_URL", "http://localhost:11000"),
+    )
+    model_name = os.getenv(
+        "AGENT_MODEL_NAME",
+        os.getenv("SWE_AGENT_MODEL_NAME", "model"),
+    )
+
+    session_url = f"{base_url}/v1"
+    external_host = os.getenv("MILES_ROUTER_EXTERNAL_HOST")
+    if external_host:
+        parsed = urlparse(session_url)
+        port = parsed.port
+        netloc = f"{external_host}:{port}" if port else external_host
+        session_url = urlunparse(parsed._replace(netloc=netloc))
+
+    request: dict[str, Any] = {
+        **metadata,
+        "base_url": session_url,
+        "model": f"openai/{model_name}",
+        "sampling_params": request_kwargs,
+    }
+
+    max_seq_len = metadata.get("max_seq_len")
+    if max_seq_len is not None:
+        request["max_seq_len"] = int(max_seq_len)
+
+    session_server_id = metadata.get("session_server_id")
+    if session_server_id is not None:
+        if external_host:
+            port = urlsplit(f"http://{session_server_id}").port
+            session_server_id = f"{external_host}:{port}"
+        request["session_server_id"] = session_server_id
+
+    session_server_instance_id = metadata.get("session_server_instance_id")
+    if session_server_instance_id is not None:
+        request["session_server_instance_id"] = session_server_instance_id
+
+    try:
+        response = await asyncio.wait_for(
+            _post_agent_server(f"{agent_server_url}/run", request),
+            timeout=3600,
+        )
+    except asyncio.TimeoutError:
+        logger.error("Agent server call timed out after 3600s")
+        return None
+    except asyncio.CancelledError:
+        logger.warning("Agent server call cancelled")
+        return None
+    except Exception as e:
+        logger.error(f"Agent server call failed: {e}")
+        return None
+
+    return {
+        "reward": response.get("reward", 0.0),
+        "exit_status": response.get("exit_status", ""),
+        "eval_report": response.get("eval_report", {}),
+        "agent_metrics": response.get("agent_metrics", {}),
+    }
+
+
+async def abort(args) -> None:
+    """Best-effort flush of in-flight agent tasks on rollout abort."""
+    agent_server_url = os.getenv("AGENT_SERVER_URL", os.getenv("SWE_AGENT_URL"))
+    instance_id = getattr(args, "session_server_instance_id", None)
+    if not agent_server_url or not instance_id:
+        return
+
+    headers = None
+    admin_secret = os.getenv("HARBOR_ADMIN_SECRET")
+    if admin_secret:
+        headers = {"Authorization": f"Bearer {admin_secret}"}
+
+    try:
+        client = _get_agent_server_client()
+        result = await client.post(
+            f"{agent_server_url.rstrip('/')}/flush",
+            json={"session_server_instance_id": instance_id},
+            headers=headers,
+        )
+        result.raise_for_status()
+        logger.info(f"Flushed agent server {agent_server_url}: {result.json()}")
+    except Exception as e:
+        logger.warning(f"Failed to flush agent server {agent_server_url}: {e}")

--- a/examples/miles_swe_agent_function.py
+++ b/examples/miles_swe_agent_function.py
@@ -10,7 +10,7 @@ import logging
 import os
 import socket
 from typing import Any
-from urllib.parse import urlparse, urlsplit, urlunparse
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
@@ -36,6 +36,18 @@ def _get_agent_server_client() -> httpx.AsyncClient:
             timeout=None,
         )
     return _agent_server_client
+
+
+def _rewrite_host_port(original: str, external_host: str) -> str:
+    """Replace the host in a ``host:port`` string while preserving the port."""
+    if ":" in original:
+        host, _, port_str = original.rpartition(":")
+        try:
+            port = int(port_str)
+            return f"{external_host}:{port}"
+        except ValueError:
+            return external_host
+    return external_host
 
 
 async def _post_agent_server(url: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -85,10 +97,8 @@ async def run(
         request["max_seq_len"] = int(max_seq_len)
 
     session_server_id = metadata.get("session_server_id")
-    if session_server_id is not None:
-        if external_host:
-            port = urlsplit(f"http://{session_server_id}").port
-            session_server_id = f"{external_host}:{port}"
+    if session_server_id is not None and external_host:
+        session_server_id = _rewrite_host_port(session_server_id, external_host)
         request["session_server_id"] = session_server_id
 
     session_server_instance_id = metadata.get("session_server_instance_id")
@@ -105,7 +115,7 @@ async def run(
         return None
     except asyncio.CancelledError:
         logger.warning("Agent server call cancelled")
-        return None
+        raise
     except Exception as e:
         logger.error(f"Agent server call failed: {e}")
         return None


### PR DESCRIPTION
Adds a runnable `examples/miles_swe_agent.py` that ports the `radixark/miles/examples/swe-agent` flow to `modal-training-gym`'s `MilesRecipe`.

## Summary

- `examples/miles_swe_agent.py`: launcher with `GLM-4.7-Flash`, Harbor agent integration, and the same GRPO/sampling flags used in the upstream Miles example.
- `examples/miles_swe_agent_function.py`: client that forwards each rollout to a Harbor agent server and returns `reward` / `agent_metrics`.
- Data is converted to Miles' `prompt` + `metadata.instance_id` format on the fly from a HuggingFace dataset.
- The container image is pinned to `radixark/miles:dev-202606111336`; users can swap it for a fork-built image via `docker_image` if they need to patch Miles.

## Checklist

- [x] Example is documented with comments throughout.
- [x] Example does not require third-party dependencies (`httpx`, `miles`) to be installed locally; the helper is only imported inside the remote container.
- [x] Container image is pinned to a stable Miles dev tag.


Link to Devin session: https://modal.devinenterprise.com/sessions/edae363f51324597a98d1f94656ff507
Requested by: @joyliu-q