### PR TITLE
Fix stale run path in singlenode Qwen3.6-35B tutorial

### DIFF
--- a/tutorials/singlenode/000_qwen35b/000_qwen35b.py
+++ b/tutorials/singlenode/000_qwen35b/000_qwen35b.py
@@ -20,7 +20,7 @@
 # before training, enabling fast batched weight sync during training steps.
 # Run with:
 # ```
-# uv run modal run -d tutorials/rl/004_qwen35b/004_qwen35b.py
+# uv run modal run -d tutorials/singlenode/000_qwen35b/000_qwen35b.py
 # ```
 # ## Prerequisites
 #

--- a/tutorials/tutorial_generator/singlenode/000_qwen35b.py
+++ b/tutorials/tutorial_generator/singlenode/000_qwen35b.py
@@ -52,7 +52,7 @@ def _run_instructions():
     """
     Run with:
     ```
-    uv run modal run -d tutorials/rl/004_qwen35b/004_qwen35b.py
+    uv run modal run -d tutorials/singlenode/000_qwen35b/000_qwen35b.py
     ```
     """
 


### PR DESCRIPTION
Addresses [this review comment](https://github.com/modal-projects/training-gym/pull/348#discussion_r3731507540): the tutorial's run instructions pointed at `tutorials/rl/004_qwen35b/004_qwen35b.py`, which doesn't exist. The tutorial lives at `tutorials/singlenode/000_qwen35b/000_qwen35b.py`.

Edited the generator source and regenerated artifacts.

## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/d73b951511ec41b6a0eb29f9a612ed93
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->