### PR TITLE
Add miles model-support skills

### DIFF
--- a/skills/model-support/SKILL.md
+++ b/skills/model-support/SKILL.md
@@ -1,107 +1,39 @@
 ---
 name: model-support
 description: Use when adding, debugging, validating, or productionizing support for a new base model or
-  model-specific recipe in modal-training-gym, especially Slime recipes and model configs.
+  model-specific recipe in modal-training-gym, especially Slime and Miles recipes and model configs.
 ---
 
-## Adding a new model config to slime
+## Adding a new model config
 
-When asked to add a new model example to SlimeRecipe, you should output artifacts in a temporary directory in `.gym/new_models/[model_name]/` folder. Once you are finished, add the finished config to the recipes folder.
+When asked to add a new model example to SlimeRecipe or MilesRecipe, you should output artifacts in a temporary directory in `.gym/new_models/[model_name]/` folder. Once you are finished, add the finished config to the recipes folder.
 
-Always read the common gotchas.
+Read the reference for the framework whose recipe you are adding — each carries its own four phases and common gotchas:
 
-### Phase 1: Discovery
+| Framework | Reference |
+| --- | --- |
+| Slime (`SlimeRecipe`) | [references/slime.md](references/slime.md) |
+| Miles (`MilesRecipe`) | [references/miles.md](references/miles.md) |
 
-First try looking for the existing model running on slime. You can find examples in [slime model scripts](https://github.com/THUDM/slime/tree/main/scripts/models) or [slime examples](https://github.com/THUDM/slime/tree/main/examples). If you cannot find an existing model, find the model with the most similar architecture. Reference huggingface for model architecture.
+### Gates for every validation run
 
-**Check image/version compatibility FIRST — it is the most common blocker.** The gym pins the slime image by digest (`SLIME_IMAGE` in `modal_training_gym/frameworks/slime/launcher.py`). A model added to slime *after* that image was built will not run on it. Verify:
-- **When support landed upstream** — date the model script / plugin / bridge via the GitHub API:
-  `curl -s "https://api.github.com/repos/THUDM/slime/commits?path=scripts/models/<model>.sh&per_page=5"` (also check `slime_plugins/models/...` and any `slime_plugins/mbridge/...`).
-- **When the pinned image was built** — map the `SLIME_IMAGE` digest to its nightly tag/date on Docker Hub:
-  `curl -s "https://hub.docker.com/v2/repositories/slimerl/slime/tags?page_size=30&ordering=last_updated"`.
-- **The rollout backend's sglang version** — slime's Dockerfile pulls `slimerl/sglang:<tag>`; new attention backends (e.g. NSA/DSA) require a matching sglang bump, so check the Dockerfile at both the pinned commit and the model's support commit.
-- If the model postdates the image, bumping `SLIME_IMAGE` is a **shared-infra change** (re-bases every slime recipe) → flag it for the user and smoke-test an existing small recipe (Qwen3-0.6B) after the bump. A per-recipe base image override is NOT cleanly possible: the sglang binary lives in the base image, and `image_overlay` / `image_run_commands` / `image_env` / `local_slime` only layer on top of the fixed `SLIME_IMAGE`.
+Phase 2's single step and Phase 3's smoke test both have to show:
+1. The model output is not gibberish and actually makes sense.
+2. Step time **and substep times** on the dashboard — patches that break the gym's observability fail this gate even when training works.
+3. A non-zero raw reward, and by Phase 3 an increasing one. GSM8K saturates for strong bases, so pick a harder task rather than reading a flat curve as breakage.
 
-Then, output your first artifact, which is a file called `model_setup.md`, containing:
-- Is there this model or a model with the same architecture that is already validated on slime?
-- **Does upstream support postdate the pinned `SLIME_IMAGE`?** If so, note the required image bump + sglang version.
-- Is this model validated to be supported in megatron?
-- Is this model validated to be supported in sglang?
-- What is your plan for train configuration?
-- How long do you expect each step in training take?
-- How long do you expect each substep to take (e.g. rollout server initialization, weight sync, rollouts, etc)
+If reward doesn't climb, isolate which layer is at fault: data (`DatasetConfig` — check rendered prompts read correctly and labels match source rows), the run setup (reward function shape, too few steps / too small batches / too low lr), the recipe (sampling, stop tokens, response budget, masking, optimizer, parallelism), or framework plumbing (weight sync, stale weights, checkpoint conversion).
 
-**Scale/cost gate.** Very large models (700B+ needing dozens of nodes) make the Phase-2/3 runs expensive, cluster-reserving operations. Do not launch them without explicit user sign-off on GPU budget and cluster availability; write the recipe + config first (Phases 1 & 4) and leave the live run to the operator if unconfirmed.
+Then train 2 steps on a less standard dataset, with a less standard eval function and slightly different parallelism args.
 
-### Phase 2: Implementation
-
-Output a slime config you believe will work, then follow the one-step proof in
-[agent-driven-training](../agent-driven-training/SKILL.md). Output the config
-in `configs` directly and track progress in
-`progress_log_[attempt_count].md`.
-
-While tracking the progress, also make sure the timing lines up with your expectations in the `model_setup.md` artifact.
-
-If this step does not work, go back to phase 1: what assumptions did you make in phase 1 that were incorrect and caused this? Output an artifact if it fails with `failure_analysis_[attempt_count].md`.
-
-Record how long the step took, and how long each substep took. Make sure the model parser works and it is not generating gibberish.
-
-### Phase 3: Validation
-
-Follow the smoke-test loop in
-[agent-driven-training](../agent-driven-training/SKILL.md) with about 10
-steps. If it fails, create a minimal reproduction and address the cause.
-
-Record how long the step took, and how long each substep took. Make sure the model parser works and it is not generating gibberish.
-
-### Phase 4: Productionize
-
-Create a doc describing the slime config changes, and justify any patches you have made. If it's possible to not patch, do not patch.
-
-
-# Common gotchas
+### Common gotchas (both frameworks)
 
 Naming convention: For the model name in artifacts, it should be `_` separated by model family identifiers and replacing `.` for versioning (e.g. `Qwen3_4b`, `Qwen3_6_35b`, `Kimi_K2_6`).
-
-Slime by default use mbridge (`megatron_to_hf_mode=""`) instead of bridge (`megatron_to_hf_mode="bridge"`), which requires it to preconvert the weights. To determine if we should use bridge mode or mbridge, look upstream at the slime codebase at what was used for similar models.
 
 `--max-tokens-per-gpu` is a flag for training, whereas `--rollout-max-response-len` is a flag for rollouts.
 
 If it is a large MoE, you may need `--optimizer-cpu-offload`, `--use-precision-aware-optimizer`, and `--overlap-cpu-optimizer-d2h-h2d`
 
-## How the recipe maps to CLI flags (add flags without touching gym code)
+### Validate Model Configs
 
-`SlimeRecipe.cli_args` emits `--<field-name-with-dashes> <value>` for **every dataclass field** not listed in `_SLIME_SKIP` (recipe.py). So the way to add an arbitrary slime/sglang flag is simply to **declare it as a field on your recipe subclass** — no edits to `recipe.py` or the launcher. `glm_4_7.py` and `qwen3_6_35b_long_context.py` do exactly this for their `sglang_*` and perf flags. Rules `cli_args` follows:
-- `True` → bare flag (`--foo`); `False` / `None` / `""` → omitted entirely. So default an unwanted flag to `None`/`False`/`""`.
-- `list` → `--foo a b c`.
-- Fields in `YAML_CONFIG_FIELDS` (`eval_config`, `extra_config`, `sglang_config`) may be passed as a **dict** — `prepare_slime_config` materializes it to a YAML file at runtime and rewrites the value to the path (this is how SGLang PD-disaggregation `server_groups` are supplied). `JSON_CONFIG_FIELDS` (`train_env_vars`, `apply_chat_template_kwargs`, `multimodal_keys`) are passed as JSON.
-- Things in `_SLIME_SKIP` (e.g. `slime_model_script`, `megatron_conversion_hf_checkpoint`, `environment`) are launcher instructions, not CLI flags — they won't appear in `cli_args` output. That is expected, not a bug.
-
-## `slime_model_script` vs. `ModelArchitecture`
-
-When a model's args aren't representable in `ModelArchitecture` (DSA, MLA q/kv-lora, `--spec ...`, `--allgather-cp`, `--enable-experimental`, exotic MoE routing), set `slime_model_script = "scripts/models/<model>.sh"`. The launcher then `source`s that script and passes `${MODEL_ARGS[@]}`, and `recipe._model_to_fields` is **skipped** — the upstream args are used verbatim. This mirrors `GLM_4_7_Recipe`. The `ModelArchitecture` on the model class becomes informational (still useful for the `num_experts ÷ expert_model_parallel_size` validator).
-
-## Checkpoint conversion (torch_dist) constraints
-
-`get_checkpoint_conversion_policy` (modal_helpers/utils.py) decides the HF→torch_dist conversion layout. Gotchas:
-- It emits only **TP and PP** (plus `decoder-first/last-pipeline-num-layers`, `mtp-num-layers`, `make-vocab-size-divisible-by`) — **never EP/ETP**. torch_dist is reshardable, so training EP can differ from conversion; the model reloads fine. (This is why `GLM_4_7`/`GLM_5_2` convert without an explicit expert-parallel size.)
-- There is a **single** `decoder_first/last_pipeline_num_layers` pair shared between conversion and training. For models with pipeline-stage-placement assertions (e.g. DSA cross-layer index sharing requires each PP stage to *start* on a computing layer), keep **conversion PP == training PP** so the same split is valid for both. Overriding only conversion PP (`conversion_tensor_model_parallel_size` / `conversion_pipeline_model_parallel_size`) will pass a first/last split that no longer sums to the layer count.
-- MTP special case: if `tp==1 and pp==1 and mtp_num_layers`, conversion runs single-rank (world=1) to avoid corrupting the sharded state dict with the MTP head's duplicated embedding.
-
-## Dual-checkpoint models (BF16 train + FP8 rollout)
-
-Some models train in BF16 but roll out in FP8 (separate HF repos). The launcher's `download` step only calls `model.download()`, yet both `megatron_conversion_hf_checkpoint` (BF16) and `hf_checkpoint` (FP8) are later resolved with `local_files_only=True`. So **override the model's `download()` to fetch every repo the recipe references** (see `GLM_5_2.download()`), or a later step fails with a cache miss.
-
-## MTP / EAGLE speculative decoding
-
-Do NOT blindly copy `GLM_4_7`'s `_disable_mtp_in_config` (it zeroes `num_nextn_predict_layers`). That is a workaround for a PP>1 embedding collision in a model that does *not* use EAGLE. If the model uses its MTP layer for EAGLE spec decoding (`--sglang-speculative-algorithm EAGLE`), you must **keep** MTP — zeroing it breaks the draft model.
-
-## Registration checklist (Phase 4)
-
-Wiring a new `<Model>` + `<Model>_Recipe` requires edits in all of:
-1. `modal_training_gym/common/models/<model>.py` + export in `common/models/__init__.py` (import + `__all__`).
-2. `modal_training_gym/train_recipes/slime_recipe/<model>.py` + export in `slime_recipe/__init__.py` (import + `__all__`).
-3. Top-level `modal_training_gym/__init__.py`: add to `_EXPORTS` (lazy map) **and** `__all__`.
-4. `SlimeRecipe.get_base_recipe` (recipe.py): add the `model_name → Recipe()` branch.
-
-Verify with: `uv run -m compileall`, `uv run ruff check <files>`, and a quick `python -c "from modal_training_gym import <Model>, <Model>_Recipe; r=<Model>_Recipe(); print(r.gpu_allocation.summary())"` — instantiating the recipe runs the GPU-allocation and parallelism validators, catching bad TP/PP/EP/node math before any Modal run.
+`.github/workflows/validate-models.yml` guards against performance regressions and is manually triggered — required before merging a new model, so ping someone who can dispatch it (escalate to Joy Liu). Register the model in `common/models/validation.py: VALIDATION_CONFIGS` with its `Framework`; `run_on_pr=False` means dispatch-only (Kimi, at 16 x 8 H200), not disabled. The recipe is used as `get_base_recipe` returns it, image included, so validating a candidate image means bumping it on a branch and dispatching.

--- a/skills/model-support/SKILL.md
+++ b/skills/model-support/SKILL.md
@@ -24,8 +24,6 @@ Phase 2's single step and Phase 3's smoke test both have to show:
 
 If reward doesn't climb, isolate which layer is at fault: data (`DatasetConfig` — check rendered prompts read correctly and labels match source rows), the run setup (reward function shape, too few steps / too small batches / too low lr), the recipe (sampling, stop tokens, response budget, masking, optimizer, parallelism), or framework plumbing (weight sync, stale weights, checkpoint conversion).
 
-Then train 2 steps on a less standard dataset, with a less standard eval function and slightly different parallelism args.
-
 ### Common gotchas (both frameworks)
 
 Naming convention: For the model name in artifacts, it should be `_` separated by model family identifiers and replacing `.` for versioning (e.g. `Qwen3_4b`, `Qwen3_6_35b`, `Kimi_K2_6`).

--- a/skills/model-support/references/miles.md
+++ b/skills/model-support/references/miles.md
@@ -1,0 +1,116 @@
+# Adding a new model config to miles
+
+Read [../SKILL.md](../SKILL.md) first for the artifacts directory, the gotchas that apply to both frameworks, and the shared validation gates.
+
+Always read the common gotchas.
+
+### Phase 1: Discovery
+
+First try looking for the existing model running on miles. Upstream ships inside the pinned image at `/root/miles`: `scripts/models/<model>.sh` (the `MODEL_ARGS` a recipe sources), `scripts/run_<model>.py` (the validated cluster shape, parallelism and hyperparameters), `docs/models/<vendor>/<model>.md`, `miles_plugins/models/<model>/`, and `miles/backends/megatron_utils/megatron_to_hf/<model>.py` (the weight mapping selected by `model_name`). Probe the image to read them — `scripts/fetch_miles_patch_snapshots.py` is the working pattern. If you cannot find an existing model, find the model with the most similar architecture. Reference huggingface for model architecture.
+
+**Check image/version compatibility FIRST — it is the most common blocker.** The gym pins the miles image per recipe (`docker_image` on `MilesRecipe`, overridden on the recipe subclass), so a bump changes only the recipe you edit. A model added to miles *after* that image was built will not run on it. Verify:
+- **When support landed upstream** — the model plugin, the `megatron_to_hf` mapping, **and** the sglang inside the image all have to be new enough. A model with custom kernels needs an sglang that can serve them, not just the plugin.
+- **That the tag runs on Modal** — the named tag an upstream model doc recommends may be arm64-only (GB300), which will not run on H100/H200. The dated `dev-*` nightlies are multi-arch; prefer one pushed shortly after the upstream merge.
+- **That the tag still exists** — radixark prunes dated dev tags, so a pin that once worked can 404. Modal's cache still serves existing apps, so a stale pin is invisible until a cold pull in a fresh environment fails. Report one you find on a recipe you're not otherwise changing rather than bumping it silently.
+
+Then, output your first artifact, which is a file called `model_setup.md`, containing:
+- Is there this model or a model with the same architecture that is already validated on miles?
+- **Does upstream support postdate the recipe's pinned `docker_image`?** If so, note the required image bump + sglang version.
+- Is this model validated to be supported in megatron?
+- Is this model validated to be supported in sglang?
+- What is your plan for train configuration?
+- How long do you expect each step in training take?
+- How long do you expect each substep to take (e.g. rollout server initialization, weight sync, rollouts, etc)
+
+**Scale/cost gate.** The models that land on miles are large by construction. Do not launch a multi-node run without explicit user sign-off on GPU budget and cluster availability; write the recipe + config first (Phases 1 & 4) and leave the live run to the operator if unconfirmed.
+
+### Phase 2: Implementation
+
+Output a miles config you believe will work, then follow the one-step proof in
+[agent-driven-training](../../agent-driven-training/SKILL.md). Output the config
+in `configs` directly and track progress in
+`progress_log_[attempt_count].md`.
+
+While tracking the progress, also make sure the timing lines up with your expectations in the `model_setup.md` artifact.
+
+If this step does not work, go back to phase 1: what assumptions did you make in phase 1 that were incorrect and caused this? Output an artifact if it fails with `failure_analysis_[attempt_count].md`.
+
+Record how long the step took, and how long each substep took. Make sure the model parser works and it is not generating gibberish.
+
+### Phase 3: Validation
+
+Follow the smoke-test loop in
+[agent-driven-training](../../agent-driven-training/SKILL.md) with about 10
+steps. If it fails, create a minimal reproduction and address the cause.
+
+Record how long the step took, and how long each substep took. Make sure the model parser works and it is not generating gibberish.
+
+### Phase 4: Productionize
+
+Create a doc describing the miles config changes, and justify any patches you have made. If it's possible to not patch, do not patch.
+
+
+# Common gotchas
+
+`patch_files` (patch scripts applied at image build) and `local_miles` (a local checkout mounted over the image's copy, no rebuild) are the two patching levers. Gate model-specific patches on the model — the hardcoded 30s router bind timeout and the VL prompt preprocessing are both patched that way. Patching miles' own sources has a snapshot contract — `tests/testdata/miles/*.input|.output` plus `validate-miles-patch-snapshots.yml`, refreshed with `uv run modal run scripts/fetch_miles_patch_snapshots.py` — so changing `docker_image` can break that CI even with no patch change. Prove a patch applied by printing the patched source out of the image; "didn't apply" and "applied and didn't help" look identical in a training log.
+
+`megatron_to_hf_mode` picks the checkpoint path: `"bridge"` uses megatron-bridge, `"raw"` turns on HF → torch_dist conversion, `""` disables export. Only the non-bridge path needs Megatron's torch_dist save patches.
+
+Miles registers every sglang `ServerArgs` option under a `--sglang-` prefix, so any rollout-engine knob is reachable as an `sglang_*` field with no gym code.
+
+## How the recipe maps to CLI flags (add flags without touching gym code)
+
+`MilesRecipe` inherits `BaseTrainRecipe.cli_args`, which emits `--<field-name-with-dashes> <value>` for **every dataclass field** not listed in `_MILES_SKIP` (recipe.py). So the way to add an arbitrary miles/sglang flag is simply to **declare it as a field on your recipe subclass** — no edits to `recipe.py` or the launcher. The existing recipes do exactly this for their `sglang_*` and perf flags. Rules `cli_args` follows:
+- `True` → bare flag (`--foo`); `False` / `None` / `""` → omitted entirely. So default an unwanted flag to `None`/`False`/`""`.
+- `list` → `--foo a b c`.
+- Fields in `YAML_CONFIG_FIELDS` (`eval_config`, `extra_config`, `sglang_config`) may be passed as a **dict** — `prepare_miles_config` materializes it to a YAML file at runtime and rewrites the value to the path. `JSON_CONFIG_FIELDS` (`train_env_vars`, `apply_chat_template_kwargs`, `multimodal_keys`) are passed as JSON. `extra_config` is the escape hatch: its keys become miles args and override same-named fields.
+- Things in `_MILES_SKIP` (e.g. `miles_model_script`, `megatron_conversion_hf_checkpoint`, `environment`) are launcher instructions, not CLI flags — they won't appear in `cli_args` output. That is expected, not a bug.
+- `${MODEL_ARGS[@]}` are emitted **before** the recipe's flags (`build_train_cmd`), so a recipe field overrides the same flag baked into the model script. That is how `custom_model_provider_path` swaps a provider without forking the script.
+
+## `miles_model_script` vs. `ModelArchitecture`
+
+When a model's args aren't representable in `ModelArchitecture` (custom kernels, exotic MoE routing, a custom model provider), set `miles_model_script = "scripts/models/<model>.sh"`. The launcher then `source`s that script and passes `${MODEL_ARGS[@]}`, and the upstream args are used verbatim. The model class then leaves `architecture = None`. Arch args are not re-derived for the conversion step, so the script is the single source of truth. Also set `model_name` when the megatron→HF weight mapping is selected by name rather than by config.
+
+## Checkpoint conversion (torch_dist) constraints
+
+`get_checkpoint_conversion_policy` (modal_helpers/utils.py) decides the HF→torch_dist conversion layout. Gotchas:
+- It emits only **TP and PP** — never EP/ETP. torch_dist is reshardable, so training parallelism can differ from conversion — converting at TP8/PP1/EP8 while training at TP4/PP8/EP4 reloads fine. `CONVERT_KEEP_PP1=1` stops `convert_hf_to_torch_dist.py` auto-bumping PP toward the rank count and rewriting the decoder split.
+- **A Modal Volume cannot absorb a large sharded write.** The writer dies in `inline_container.cc` with `unexpected pos` when `--save` points at the Volume at 42 layers (fine at 4 and 8). `convert_via_local_staging` writes to local disk and moves shards over afterwards; budget `convert_ephemeral_disk_mb` for the whole checkpoint plus the in-flight shard, and expect the Volume copy to dominate (~45 min of a ~58 min conversion at 550 GB).
+- **A crashed conversion can register as a cache hit.** `.metadata` is written last, so it is what separates a finished save from a dead one; without that check partial weights feed training.
+- **`no_save_optim` must be paired with `no_load_optim`**, or resuming a params-only checkpoint dies with `KeyError: 'optimizer'`. Saving params only is often mandatory at scale — params plus distributed-optimizer state runs to terabytes, and the Volume buffers all of it to container-local disk — at the cost of restarting Adam moments on resume.
+
+## Shipped callables and hooks
+
+Miles takes custom functions as import paths; the gym ships the callable by value and writes the resolved path, via `_HOOK_PATH_FLAGS`, `_HOOK_PATH_CONFIG_KEYS` and `_HOOK_WRAPPER_PATHS` in recipe.py. The wrappers live in `frameworks/miles/phase_reporting.py` and run phase reporting and dashboard capture before delegating to yours — so **setting a raw `--*-path` yourself replaces the wrapper and the run trains fine while reporting no substep times**, failing the Phase-2 dashboard gate. Pass the callable on the recipe field instead. Prefer `custom_reward_post_process_function` over a dotted path: a `__main__` function has no importable module name and miles' `import_module` fails inside the Ray actor. `capture_trace` + `trace_sample_limit` attach a per-sample generate/reward/tool-call timeline, useful when diagnosing gibberish.
+
+## LoRA
+
+Ship a full-parameter and a `*_LoRA_Recipe` variant on a shared private base, matching whichever upstream gates in CI. They differ on more than the adapter: full-param pins `use_dynamic_batch_size=False` + `micro_batch_size=1` (dynamic packing exposes a PP-p2p × EP-all-to-all NCCL race on varlen shapes) and offloads the optimizer, while LoRA packs dynamically, keeps both runtimes resident (`no_offload_train` / `no_offload_rollout`) and syncs only the adapter — ~3 s vs ~50 s per rollout.
+- **Upstream's LoRA learning rate is a trap.** Its 5e-6 default reads as "not learning" because zero-initialized B factors need hundreds of rollouts to show a delta; 2e-4 is the validated value. Suspect this before the reward function.
+- Set `sglang_moe_runner_backend = "triton"` for MoE LoRA. sglang's `auto` picks marlin for INT4 checkpoints, whose LoRA MoE path hits an illegal memory access capturing decode CUDA graphs at every batch size.
+- Keep `sglang_max_lora_rank == lora_rank` and `sglang_max_loras_per_batch = 1`; RL serves exactly the current policy's adapter.
+- `experts_shared_outer_loras=True` shares one outer factor across routed experts, with expert-specific factors following EP.
+- PEFT adapter export is not supported for every architecture, so "train LoRA, ship an adapter" may not be deliverable even when training works.
+
+## Multimodal
+
+Three layers have to line up: the **model** (a multimodal `custom_model_provider_path` overriding the text provider from the model script — the towers load from `--hf-checkpoint` and never enter the torch_dist checkpoint, so no re-conversion), the **rollout** (`sglang_enable_multimodal`, plus `use_rollout_routing_replay` indexed over the media-expanded sequence so replay stays aligned after each `<image>` expands), and the **data** (`multimodal_keys`, which `MultimodalDataset` emits and `MilesRecipe` forwards). Override `_fields` on the recipe to select the multimodal provider automatically when the attached dataset has `multimodal_keys`.
+
+The failure modes are silent, so check the rendered prompt before believing a bad reward: a missing `<image>` placeholder means the image never reaches the model and every sample scores unparseable, images must be materialized files rather than URLs, `apply_chat_template` must be off, and a coordinate-scale mismatch floors every sample (a model answering on a 0–1000 grid against a reward expecting 0–1 fractions scores zero on correct answers).
+
+## Known upstream conflicts
+
+`--use-dynamic-batch-size` conflicts with `--qkv-format bshd`. `--use-rollout-routing-replay` reads `num_experts_per_tok`, which some configs don't expose. Activation recompute can hit `save_for_backward` on tuple-returning layers. Raise `rollout_health_check_first_wait` a lot when deepgemm compiles, or engines get killed during startup.
+
+`WandbConfig` is effectively unsupported: the launcher passes an empty run id because the driver and the `RolloutManager` both `wandb.init()` under a shared `WANDB_RUN_ID` and the second dies with "run ID … is in use". Use the dashboard for step/substep timing.
+
+## Registration checklist (Phase 4)
+
+Wiring a new `<Model>` + `<Model>_Recipe` (usually plus `<Model>_LoRA_Recipe`) requires edits in all of:
+1. `modal_training_gym/common/models/<model>.py` + export in `common/models/__init__.py` (import + `__all__`).
+2. `modal_training_gym/train_recipes/miles_recipe/<model>.py` + export in `miles_recipe/__init__.py` (import + `__all__`) — export every variant.
+3. Top-level `modal_training_gym/__init__.py`: add to `_EXPORTS` (lazy map) **and** `__all__`.
+4. `MilesRecipe.get_base_recipe` (recipe.py): add the `model_name → Recipe()` branch. Without it the model gets no preset and every caller must pass a recipe explicitly.
+5. `common/models/validation.py: VALIDATION_CONFIGS`: `_ValidationConfig("<Name>", <Model>, Framework.MILES)`, with `run_on_pr=False` if the shape is too expensive for every PR. Step 4 is a prerequisite — `build_miles_validation` raises if `get_base_recipe` returns `None` — and the dataset it picks is DAPO-Math-17k, so a non-math recipe needs that backend widened.
+
+Verify with: `uv run -m compileall`, `uv run ruff check <files>`, `uv run pytest tests/test_miles_recipe_hooks.py tests/test_miles_runtime_env.py tests/test_miles_patches.py`, and a quick `python -c "from modal_training_gym import <Model>, <Model>_Recipe; r=<Model>_Recipe(); print(r.gpu_allocation.summary())"` — instantiating the recipe runs the GPU-allocation and parallelism validators, catching bad TP/PP/EP/node math before any Modal run.

--- a/skills/model-support/references/slime.md
+++ b/skills/model-support/references/slime.md
@@ -1,0 +1,96 @@
+# Adding a new model config to slime
+
+Read [../SKILL.md](../SKILL.md) first for the artifacts directory, the gotchas that apply to both frameworks, and the shared validation gates.
+
+Always read the common gotchas.
+
+### Phase 1: Discovery
+
+First try looking for the existing model running on slime. You can find examples in [slime model scripts](https://github.com/THUDM/slime/tree/main/scripts/models) or [slime examples](https://github.com/THUDM/slime/tree/main/examples). If you cannot find an existing model, find the model with the most similar architecture. Reference huggingface for model architecture.
+
+**Check image/version compatibility FIRST — it is the most common blocker.** The gym pins the slime image by digest (`SLIME_IMAGE` in `modal_training_gym/frameworks/slime/launcher.py`). A model added to slime *after* that image was built will not run on it. Verify:
+- **When support landed upstream** — date the model script / plugin / bridge via the GitHub API:
+  `curl -s "https://api.github.com/repos/THUDM/slime/commits?path=scripts/models/<model>.sh&per_page=5"` (also check `slime_plugins/models/...` and any `slime_plugins/mbridge/...`).
+- **When the pinned image was built** — map the `SLIME_IMAGE` digest to its nightly tag/date on Docker Hub:
+  `curl -s "https://hub.docker.com/v2/repositories/slimerl/slime/tags?page_size=30&ordering=last_updated"`.
+- **The rollout backend's sglang version** — slime's Dockerfile pulls `slimerl/sglang:<tag>`; new attention backends (e.g. NSA/DSA) require a matching sglang bump, so check the Dockerfile at both the pinned commit and the model's support commit.
+- If the model postdates the image, bumping `SLIME_IMAGE` is a **shared-infra change** (re-bases every slime recipe) → flag it for the user and smoke-test an existing small recipe (Qwen3-0.6B) after the bump. A per-recipe base image override is NOT cleanly possible: the sglang binary lives in the base image, and `image_overlay` / `image_run_commands` / `image_env` / `local_slime` only layer on top of the fixed `SLIME_IMAGE`.
+
+Then, output your first artifact, which is a file called `model_setup.md`, containing:
+- Is there this model or a model with the same architecture that is already validated on slime?
+- **Does upstream support postdate the pinned `SLIME_IMAGE`?** If so, note the required image bump + sglang version.
+- Is this model validated to be supported in megatron?
+- Is this model validated to be supported in sglang?
+- What is your plan for train configuration?
+- How long do you expect each step in training take?
+- How long do you expect each substep to take (e.g. rollout server initialization, weight sync, rollouts, etc)
+
+**Scale/cost gate.** Very large models (700B+ needing dozens of nodes) make the Phase-2/3 runs expensive, cluster-reserving operations. Do not launch them without explicit user sign-off on GPU budget and cluster availability; write the recipe + config first (Phases 1 & 4) and leave the live run to the operator if unconfirmed.
+
+### Phase 2: Implementation
+
+Output a slime config you believe will work, then follow the one-step proof in
+[agent-driven-training](../../agent-driven-training/SKILL.md). Output the config
+in `configs` directly and track progress in
+`progress_log_[attempt_count].md`.
+
+While tracking the progress, also make sure the timing lines up with your expectations in the `model_setup.md` artifact.
+
+If this step does not work, go back to phase 1: what assumptions did you make in phase 1 that were incorrect and caused this? Output an artifact if it fails with `failure_analysis_[attempt_count].md`.
+
+Record how long the step took, and how long each substep took. Make sure the model parser works and it is not generating gibberish.
+
+### Phase 3: Validation
+
+Follow the smoke-test loop in
+[agent-driven-training](../../agent-driven-training/SKILL.md) with about 10
+steps. If it fails, create a minimal reproduction and address the cause.
+
+Record how long the step took, and how long each substep took. Make sure the model parser works and it is not generating gibberish.
+
+### Phase 4: Productionize
+
+Create a doc describing the slime config changes, and justify any patches you have made. If it's possible to not patch, do not patch.
+
+
+# Common gotchas
+
+Slime by default use mbridge (`megatron_to_hf_mode=""`) instead of bridge (`megatron_to_hf_mode="bridge"`), which requires it to preconvert the weights. To determine if we should use bridge mode or mbridge, look upstream at the slime codebase at what was used for similar models.
+
+## How the recipe maps to CLI flags (add flags without touching gym code)
+
+`SlimeRecipe.cli_args` emits `--<field-name-with-dashes> <value>` for **every dataclass field** not listed in `_SLIME_SKIP` (recipe.py). So the way to add an arbitrary slime/sglang flag is simply to **declare it as a field on your recipe subclass** — no edits to `recipe.py` or the launcher. `glm_4_7.py` and `qwen3_6_35b_long_context.py` do exactly this for their `sglang_*` and perf flags. Rules `cli_args` follows:
+- `True` → bare flag (`--foo`); `False` / `None` / `""` → omitted entirely. So default an unwanted flag to `None`/`False`/`""`.
+- `list` → `--foo a b c`.
+- Fields in `YAML_CONFIG_FIELDS` (`eval_config`, `extra_config`, `sglang_config`) may be passed as a **dict** — `prepare_slime_config` materializes it to a YAML file at runtime and rewrites the value to the path (this is how SGLang PD-disaggregation `server_groups` are supplied). `JSON_CONFIG_FIELDS` (`train_env_vars`, `apply_chat_template_kwargs`, `multimodal_keys`) are passed as JSON.
+- Things in `_SLIME_SKIP` (e.g. `slime_model_script`, `megatron_conversion_hf_checkpoint`, `environment`) are launcher instructions, not CLI flags — they won't appear in `cli_args` output. That is expected, not a bug.
+
+## `slime_model_script` vs. `ModelArchitecture`
+
+When a model's args aren't representable in `ModelArchitecture` (DSA, MLA q/kv-lora, `--spec ...`, `--allgather-cp`, `--enable-experimental`, exotic MoE routing), set `slime_model_script = "scripts/models/<model>.sh"`. The launcher then `source`s that script and passes `${MODEL_ARGS[@]}`, and `recipe._model_to_fields` is **skipped** — the upstream args are used verbatim. This mirrors `GLM_4_7_Recipe`. The `ModelArchitecture` on the model class becomes informational (still useful for the `num_experts ÷ expert_model_parallel_size` validator).
+
+## Checkpoint conversion (torch_dist) constraints
+
+`get_checkpoint_conversion_policy` (modal_helpers/utils.py) decides the HF→torch_dist conversion layout. Gotchas:
+- It emits only **TP and PP** (plus `decoder-first/last-pipeline-num-layers`, `mtp-num-layers`, `make-vocab-size-divisible-by`) — **never EP/ETP**. torch_dist is reshardable, so training EP can differ from conversion; the model reloads fine. (This is why `GLM_4_7`/`GLM_5_2` convert without an explicit expert-parallel size.)
+- There is a **single** `decoder_first/last_pipeline_num_layers` pair shared between conversion and training. For models with pipeline-stage-placement assertions (e.g. DSA cross-layer index sharing requires each PP stage to *start* on a computing layer), keep **conversion PP == training PP** so the same split is valid for both. Overriding only conversion PP (`conversion_tensor_model_parallel_size` / `conversion_pipeline_model_parallel_size`) will pass a first/last split that no longer sums to the layer count.
+- MTP special case: if `tp==1 and pp==1 and mtp_num_layers`, conversion runs single-rank (world=1) to avoid corrupting the sharded state dict with the MTP head's duplicated embedding.
+
+## Dual-checkpoint models (BF16 train + FP8 rollout)
+
+Some models train in BF16 but roll out in FP8 (separate HF repos). The launcher's `download` step only calls `model.download()`, yet both `megatron_conversion_hf_checkpoint` (BF16) and `hf_checkpoint` (FP8) are later resolved with `local_files_only=True`. So **override the model's `download()` to fetch every repo the recipe references** (see `GLM_5_2.download()`), or a later step fails with a cache miss.
+
+## MTP / EAGLE speculative decoding
+
+Do NOT blindly copy `GLM_4_7`'s `_disable_mtp_in_config` (it zeroes `num_nextn_predict_layers`). That is a workaround for a PP>1 embedding collision in a model that does *not* use EAGLE. If the model uses its MTP layer for EAGLE spec decoding (`--sglang-speculative-algorithm EAGLE`), you must **keep** MTP — zeroing it breaks the draft model.
+
+## Registration checklist (Phase 4)
+
+Wiring a new `<Model>` + `<Model>_Recipe` requires edits in all of:
+1. `modal_training_gym/common/models/<model>.py` + export in `common/models/__init__.py` (import + `__all__`).
+2. `modal_training_gym/train_recipes/slime_recipe/<model>.py` + export in `slime_recipe/__init__.py` (import + `__all__`).
+3. Top-level `modal_training_gym/__init__.py`: add to `_EXPORTS` (lazy map) **and** `__all__`.
+4. `SlimeRecipe.get_base_recipe` (recipe.py): add the `model_name → Recipe()` branch.
+5. `common/models/validation.py: VALIDATION_CONFIGS`: `_ValidationConfig("<Name>", <Model>, Framework.SLIME)`.
+
+Verify with: `uv run -m compileall`, `uv run ruff check <files>`, and a quick `python -c "from modal_training_gym import <Model>, <Model>_Recipe; r=<Model>_Recipe(); print(r.gpu_allocation.summary())"` — instantiating the recipe runs the GPU-allocation and parallelism validators, catching bad TP/PP/EP/node math before any Modal run.


### PR DESCRIPTION
Added skills to onboard miles recipes, added validation steps from the [Contributing Guide](https://app.notion.com/p/modal-com/Training-Gym-Contributing-Guide-3aa1e7f1694980b2bc26d99edec9b6bd)

Restructured like this: 

```
skills/model-support/
    SKILL.md              # entry, validation, common gotchas
    references/slime.md   # original SKILL.md, everything Slime-specific
    references/miles.md   # Miles equivalent of slime.md
```