### PR TITLE
Register backend dataset modules with Modal's vendored cloudpickle

### DIFF
--- a/scripts/validate_model_configs.py
+++ b/scripts/validate_model_configs.py
@@ -20,6 +20,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import cloudpickle
+from modal._vendor import cloudpickle as modal_cloudpickle
 
 try:
     # Run as a script: sys.path[0] is scripts/, matching download_perf_baseline.
@@ -192,11 +193,15 @@ def _ship_dataset_definition(dataset) -> None:
     Nothing under ``scripts/`` is importable inside the training image, so the
     container would fail to unpickle it during data preparation. Classes that
     ship with the package are importable remotely and stay by reference.
+
+    Modal serializes with its own vendored copy of cloudpickle, which keeps a
+    registry separate from the installed one, so both have to be told.
     """
     module = sys.modules.get(type(dataset).__module__)
     if module is None or module.__name__.startswith("modal_training_gym"):
         return
     cloudpickle.register_pickle_by_value(module)
+    modal_cloudpickle.register_pickle_by_value(module)
 
 
 def run_base_training(

--- a/tests/test_model_validation_registry.py
+++ b/tests/test_model_validation_registry.py
@@ -168,20 +168,24 @@ def test_validation_dataset_unpickles_without_the_scripts_directory(config, tmp_
     image, so a dataset pickled by reference crashes remotely during data
     preparation. Unpickling in a subprocess whose ``sys.path`` has no
     ``scripts/`` entry reproduces that container exactly.
+
+    Pickled with ``modal._serialization``, which is what actually ships the
+    dataset: it uses Modal's vendored cloudpickle, whose by-value registry is
+    separate from the installed cloudpickle's.
     """
     import base64
     import subprocess
     import sys
     import textwrap
 
-    import cloudpickle
+    from modal._serialization import serialize
 
     from scripts.validate_model_configs import _ship_dataset_definition
 
     _, dataset = build_recipe_and_dataset(config.framework, config.model_config(), 1)
 
     _ship_dataset_definition(dataset)
-    payload = cloudpickle.dumps(dataset)
+    payload = serialize(dataset)
 
     # Blocking the import is a truer stand-in for the image than trimming
     # sys.path: modal_training_gym is installed from this same tree, so the


### PR DESCRIPTION
Fixes the model-validation CI regression: every train container crash-looped with

```
modal.exception.DeserializationError: Deserialization failed because the
'validation_backends' module is not available in the remote environment.
```

#352 moved the validation dataset classes into `scripts/validation_backends/{slime,miles}.py`. They previously lived in `validate_model_configs.py` run as `__main__`, which cloudpickle always pickles by value; from a real module under `scripts/` — absent from the training image — they need explicit by-value registration.

`_ship_dataset_definition` did register them, but with the wrong pickler:

```python
import cloudpickle                               # site-packages copy
cloudpickle.register_pickle_by_value(module)     # -> cloudpickle._PICKLE_BY_VALUE_MODULES
```

Modal serializes with `modal._vendor.cloudpickle` (vendored so client and container agree on a version), which has its own `_PICKLE_BY_VALUE_MODULES`. The registration never reached it, so the dataset went out by reference. Register with both.

The regression test that was supposed to cover this pickled with the installed cloudpickle, which honored the registration — so it passed while production failed. It now pickles with `modal._serialization.serialize`, the path that actually ships the dataset; without the fix it fails for all 13 targets.

Verified locally on `Gsm8kDataset`: before, `serialize(dataset)` raises the production `ModuleNotFoundError` in a subprocess that can't import `validation_backends`, while `cloudpickle.dumps(dataset)` of the same object unpickles fine; after, both unpickle.

Not addressed here: `resolve_caller_context` (`common/launcher_helpers.py`) has the same single-pickler registration. It is harmless today because it skips `__main__` and every non-`__main__` caller so far ships from an importable package — but a tutorial imported as a module would hit the same bug.

## Checklist

Not applicable — this is a CI harness fix, not an example.

Link to Devin session: https://modal.devinenterprise.com/sessions/2aafbc48c77e45b191dc92de04973918
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->