### PR TITLE
Add named_image recipe field for slime and Miles base images

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -85,15 +85,21 @@ _REPORTING_PATCH_COMMANDS = (
 
 
 def _build_miles_base_image(miles: MilesRecipe) -> Image:
-    image = (
-        Image.from_registry(miles.docker_image)
-        .entrypoint([])
-        .run_commands(
-            f"rm -rf {HF_CACHE_PATH} 2>/dev/null || true",
-            f"echo {_PATCH_SGLANG_ABORT_B64} | base64 -d | python3",
-            *_REPORTING_PATCH_COMMANDS,
+    if miles.named_image:
+        # A published named Image already carries the entrypoint reset and the
+        # built-in patches (see scripts/publish_framework_images.py), and
+        # referencing it by name never triggers a rebuild.
+        image = Image.from_name(miles.named_image)
+    else:
+        image = (
+            Image.from_registry(miles.docker_image)
+            .entrypoint([])
+            .run_commands(
+                f"rm -rf {HF_CACHE_PATH} 2>/dev/null || true",
+                f"echo {_PATCH_SGLANG_ABORT_B64} | base64 -d | python3",
+                *_REPORTING_PATCH_COMMANDS,
+            )
         )
-    )
     if miles.image_env:
         image = image.env(miles.image_env)
     if miles.image_run_commands:

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -6,6 +6,7 @@ import subprocess
 import shutil
 import tempfile
 import time
+import warnings
 from collections.abc import Callable
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -89,6 +90,12 @@ def _build_miles_base_image(miles: MilesRecipe) -> Image:
         # A published named Image already carries the entrypoint reset and the
         # built-in patches (see scripts/publish_framework_images.py), and
         # referencing it by name never triggers a rebuild.
+        if miles.docker_image != MilesRecipe.docker_image:
+            warnings.warn(
+                f"named_image={miles.named_image!r} takes precedence over "
+                f"docker_image={miles.docker_image!r}; the registry image is ignored.",
+                stacklevel=2,
+            )
         image = Image.from_name(miles.named_image)
     else:
         image = (

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -149,7 +149,12 @@ _PATCH_SGLANG_PARALLEL_ALIASES_B64 = encode_patch(
 )
 
 
-def _build_slime_base_image() -> "Image":
+def _build_slime_base_image(named_image: str | None = None) -> "Image":
+    if named_image:
+        # A published named Image already carries the entrypoint reset and the
+        # built-in patches (see scripts/publish_framework_images.py), and
+        # referencing it by name never triggers a rebuild.
+        return Image.from_name(named_image)
     return (
         Image.from_registry(SLIME_IMAGE)
         .entrypoint([])
@@ -429,7 +434,7 @@ def build_slime_app(
     _caller_module, caller_script = resolve_caller_context()
 
     # ── Image ────────────────────────────────────────────────────────────────
-    image = _build_slime_base_image()
+    image = _build_slime_base_image(slime.named_image)
 
     # Hybrid models have layers with different parameter sets (e.g. GDN
     # layers carry linear_attn.dt_bias that standard attention layers lack).

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -41,6 +41,7 @@ _MILES_SKIP = {
     "image_overlay",
     "image_run_commands",
     "image_env",
+    "named_image",
     "local_miles",
     "patch_files",
     "wandb",
@@ -144,6 +145,15 @@ class MilesRecipe(BaseTrainRecipe):
         Extra shell commands run while building the image.
     image_env : dict[str, str]
         Extra env vars baked into the image.
+    named_image : str | None
+        Modal named Image reference (``[[workspace/]environment/]name[:tag]``)
+        used as the base image instead of pulling ``docker_image`` from the
+        registry and applying the built-in patches. The referenced image is
+        expected to be a published Miles base image (see
+        ``scripts/publish_framework_images.py``); referencing it never
+        triggers a rebuild. Recipe-level image customizations
+        (``image_overlay``, ``patch_files``, ``image_run_commands``,
+        ``image_env``) still apply on top.
     capture_trace : bool
         Attach miles' per-sample execution trace (generate/reward/tool-call
         timeline) to recorded rollouts for the dashboard.
@@ -451,6 +461,7 @@ class MilesRecipe(BaseTrainRecipe):
     image_overlay: Callable[[modal.Image], modal.Image] | None = None
     image_run_commands: list[str] = field(default_factory=list)
     image_env: dict[str, str] = field(default_factory=dict)
+    named_image: str | None = None
     local_miles: str | None = None
     patch_files: list[str] = field(default_factory=list)
 

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -62,6 +62,7 @@ _SLIME_SKIP = {
     "patch_files",
     "image_run_commands",
     "image_env",
+    "named_image",
     "train_function_kwargs",
     "conversion_pipeline_model_parallel_size",
     "conversion_tensor_model_parallel_size",
@@ -180,6 +181,15 @@ class SlimeRecipe(BaseTrainRecipe):
         Extra shell commands run while building the image.
     image_env : dict
         Extra env vars baked into the image.
+    named_image : str | None
+        Modal named Image reference (``[[workspace/]environment/]name[:tag]``)
+        used as the base image instead of pulling ``SLIME_IMAGE`` from the
+        registry and applying the built-in patches. The referenced image is
+        expected to be a published slime base image (see
+        ``scripts/publish_framework_images.py``); referencing it never
+        triggers a rebuild. Recipe-level image customizations
+        (``image_overlay``, ``patch_files``, ``image_run_commands``,
+        ``image_env``) still apply on top.
     train_function_kwargs : dict
         Extra Modal Function options for the train function; supported keys:
         ``secrets``, ``experimental_options``, ``ephemeral_disk``.
@@ -503,6 +513,7 @@ class SlimeRecipe(BaseTrainRecipe):
     patch_files: list[str] = field(default_factory=list)
     image_run_commands: list[str] = field(default_factory=list)
     image_env: dict[str, str] = field(default_factory=dict)
+    named_image: str | None = None
     train_function_kwargs: dict[str, Any] = field(default_factory=dict)
 
     # ── Per-sample execution tracing (dashboard timeline) ───────────────────

--- a/scripts/publish_framework_images.py
+++ b/scripts/publish_framework_images.py
@@ -1,0 +1,81 @@
+"""Build and publish the slime and Miles base images as Modal named Images.
+
+Named Images let launchers reference a prebuilt image with
+``Image.from_name(...)`` (via the ``named_image`` recipe field) instead of
+pulling the registry image and applying the built-in patches on every app
+build. Referencing a name never triggers a rebuild, so training launches keep
+using the last successfully published image.
+
+Usage:
+
+    uv run scripts/publish_framework_images.py                    # both frameworks
+    uv run scripts/publish_framework_images.py --framework slime
+    uv run scripts/publish_framework_images.py --framework miles --tag v1
+
+Each publish writes ``<name>:latest`` plus an optional extra ``--tag``. The
+default names are ``slime-base`` and ``miles-base``; pass ``--name-prefix`` to
+publish under an ``environment/`` prefix. Publishing into a *public*
+environment (so other workspaces can consume the name) additionally requires
+a Modal admin identity and a globally deployed underlying image — that path
+is gated server-side and not exposed here.
+"""
+
+import argparse
+
+import modal
+
+from modal_training_gym.frameworks.miles.launcher import _build_miles_base_image
+from modal_training_gym.frameworks.slime.launcher import _build_slime_base_image
+from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+
+DEFAULT_NAMES = {"slime": "slime-base", "miles": "miles-base"}
+
+
+def _base_image(framework: str) -> modal.Image:
+    if framework == "slime":
+        return _build_slime_base_image()
+    # Only the launcher-level fields with defaults matter for the base image;
+    # construct without validation since MilesRecipe requires training fields.
+    miles = MilesRecipe.__new__(MilesRecipe)
+    object.__setattr__(miles, "named_image", None)
+    object.__setattr__(miles, "docker_image", MilesRecipe.docker_image)
+    object.__setattr__(miles, "image_env", {})
+    object.__setattr__(miles, "image_run_commands", [])
+    return _build_miles_base_image(miles)
+
+
+def publish(framework: str, *, name_prefix: str, tag: str | None) -> None:
+    image = _base_image(framework)
+    name = DEFAULT_NAMES[framework]
+    ref = f"{name_prefix}/{name}" if name_prefix else name
+
+    app = modal.App.lookup("training-gym-image-builds", create_if_missing=True)
+    with modal.enable_output():
+        built = image.build(app)
+    built.publish(f"{ref}:latest")
+    print(f"published {ref}:latest")
+    if tag:
+        built.publish(f"{ref}:{tag}")
+        print(f"published {ref}:{tag}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--framework", choices=["slime", "miles", "all"], default="all")
+    parser.add_argument(
+        "--tag", default=None, help="Extra tag to publish in addition to :latest"
+    )
+    parser.add_argument(
+        "--name-prefix",
+        default="",
+        help="Optional 'environment' prefix for the published name",
+    )
+    args = parser.parse_args()
+
+    frameworks = ["slime", "miles"] if args.framework == "all" else [args.framework]
+    for framework in frameworks:
+        publish(framework, name_prefix=args.name_prefix, tag=args.tag)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lets recipes consume a prebuilt Modal [Named Image](https://modal.com/docs/guide/named-images) instead of pulling the registry image and re-applying the built-in patches on every app build.

```python
SlimeRecipe(named_image="slime-base")                 # or "env/slime-base:tag"
MilesRecipe(named_image="modal/public-env/miles-base")  # cross-workspace via a public environment
```

- New `named_image: str | None` field on `SlimeRecipe` and `MilesRecipe` (launcher-only; excluded from framework CLI args via `_SLIME_SKIP`/`_MILES_SKIP`).
- When set, `_build_slime_base_image` / `_build_miles_base_image` return `Image.from_name(named_image)` — the published image is expected to already carry the entrypoint reset and built-in patches. Recipe-level customizations (`image_overlay`, `patch_files`, `image_run_commands`, `image_env`) still apply on top.
- When unset, behavior is unchanged (pinned `SLIME_IMAGE` / `miles.docker_image` from the registry).
- `scripts/publish_framework_images.py` builds the base images and publishes them as `slime-base:latest` / `miles-base:latest` (plus optional `--tag`, optional `--name-prefix` environment prefix).

Publishing into a *public* environment (usable across all workspaces) is gated server-side today (Modal admin + globally deployed image); once the pinned modal SDK exposes the public-publish option, the script can pass it through.

## Checklist

N/A — library change, not an example. Ran `ruff check`, `ruff format`, `compileall`, pre-commit, and the recipe/CLI test subset (230 passed).


Link to Devin session: https://modal.devinenterprise.com/sessions/ecdc4eabe1a0494bba278a0a786d7d87
Requested by: @joyliu-q
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->