### PR TITLE
standardize font sizing

### DIFF
--- a/docs-next/src/styles/custom.css
+++ b/docs-next/src/styles/custom.css
@@ -714,11 +714,6 @@ body::before {
   margin-top: 0;
 }
 
-.sl-markdown-content > p:first-of-type {
-  color: var(--sl-color-gray-2);
-  font-size: 1.03rem;
-}
-
 .sl-markdown-content h2 {
   color: var(--sl-color-white);
   font-size: var(--sl-text-h2);


### PR DESCRIPTION
Removes unnecessary first paragraph font enlargement for all pages. A before and after:

<img width="1733" height="999" alt="Screenshot 2026-08-13 at 12 16 00 PM" src="https://github.com/user-attachments/assets/c73a4b64-f1cc-45fb-9ed0-2873d5b5b8a5" />

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->