### PR TITLE
Build slime and Miles base images from Modal named Images by default

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -86,7 +86,10 @@ _REPORTING_PATCH_COMMANDS = (
 
 def _build_miles_base_image(miles: MilesRecipe) -> Image:
     image = (
-        Image.from_registry(miles.docker_image)
+        # docker_image is resolved as a Modal named Image (published by
+        # scripts/publish_framework_images.py); resolving a name never pulls
+        # from the registry or triggers a rebuild.
+        Image.from_name(miles.docker_image)
         .entrypoint([])
         .run_commands(
             f"rm -rf {HF_CACHE_PATH} 2>/dev/null || true",

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -89,8 +89,14 @@ from modal_training_gym.common.checkpoint import Checkpoint
 from modal_training_gym.common.framework import Framework
 
 SLIME_ROOT = "/root/slime"
-# Pin by digest to prevent mutable-tag drift.  Tag: nightly-dev-20260722a
-SLIME_IMAGE = "slimerl/slime@sha256:a97ec147e37bef050337a9b229036eda00b4aa9c4d02b31a0109dc850f8ca342"
+# Registry source published as the named Image below (see
+# scripts/publish_framework_images.py). Pinned by digest to prevent
+# mutable-tag drift.  Tag: nightly-dev-20260722a
+SLIME_REGISTRY_IMAGE = "slimerl/slime@sha256:a97ec147e37bef050337a9b229036eda00b4aa9c4d02b31a0109dc850f8ca342"
+# Modal named Image the launcher builds from. Resolving a name never pulls
+# from the registry or triggers a rebuild; run
+# scripts/publish_framework_images.py to (re)publish it.
+SLIME_IMAGE = "slimerl/slime:nightly-dev-20260722a"
 # v0.8.0+ makes per-task CPU/memory requests configurable via enforcement
 # policies ("limit"/"ignore"), letting sandboxes burst on Modal and bill by
 # actual CPU-/RAM-second usage instead of over-provisioning a static reservation.
@@ -151,7 +157,7 @@ _PATCH_SGLANG_PARALLEL_ALIASES_B64 = encode_patch(
 
 def _build_slime_base_image() -> "Image":
     return (
-        Image.from_registry(SLIME_IMAGE)
+        Image.from_name(SLIME_IMAGE)
         .entrypoint([])
         .run_commands(
             "rm -rf /root/.cache/huggingface",

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -115,7 +115,9 @@ class MilesRecipe(BaseTrainRecipe):
     ## Modal Launcher
 
     docker_image : str
-        Registry reference for the Miles image every container runs.
+        Modal named Image reference for the Miles image every container runs,
+        published from the upstream registry image by
+        ``scripts/publish_framework_images.py``.
     environment : dict
         Env vars for the training containers (Megatron ``PYTHONPATH``, NCCL tuning).
     async_mode : bool

--- a/scripts/fetch_slime_patch_snapshots.py
+++ b/scripts/fetch_slime_patch_snapshots.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 import modal
 
-from modal_training_gym.frameworks.slime.launcher import SLIME_IMAGE
+from modal_training_gym.frameworks.slime.launcher import (
+    SLIME_REGISTRY_IMAGE as SLIME_IMAGE,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTDATA_DIR = REPO_ROOT / "tests" / "testdata" / "slime"

--- a/scripts/publish_framework_images.py
+++ b/scripts/publish_framework_images.py
@@ -1,0 +1,61 @@
+"""Publish the slime and Miles registry images as Modal named Images.
+
+The launchers build from ``Image.from_name(...)`` (``SLIME_IMAGE`` in the slime
+launcher, ``MilesRecipe.docker_image``), so the names below must be published
+before the first training launch — and republished whenever the pinned
+registry references change. Resolving a name never pulls from the registry or
+triggers a rebuild, so launches keep using the last published image.
+
+Usage:
+
+    uv run scripts/publish_framework_images.py                    # both frameworks
+    uv run scripts/publish_framework_images.py --framework slime
+    uv run scripts/publish_framework_images.py --framework miles
+
+Names containing ``/`` are published under an environment prefix
+(``environment/name:tag``); the environment must already exist. Publishing
+into a *public* environment (usable across all workspaces) additionally
+requires a Modal admin identity and a globally deployed underlying image —
+that path is gated server-side and not exposed here.
+"""
+
+import argparse
+
+import modal
+
+from modal_training_gym.frameworks.slime.launcher import (
+    SLIME_IMAGE,
+    SLIME_REGISTRY_IMAGE,
+)
+from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+
+# framework -> (registry source, published named-Image ref)
+PUBLISHES: dict[str, tuple[str, str]] = {
+    "slime": (SLIME_REGISTRY_IMAGE, SLIME_IMAGE),
+    # For Miles the registry tag and the published name are the same string.
+    "miles": (MilesRecipe.docker_image, MilesRecipe.docker_image),
+}
+
+
+def publish(framework: str) -> None:
+    registry_ref, name = PUBLISHES[framework]
+    image = modal.Image.from_registry(registry_ref)
+    app = modal.App.lookup("training-gym-image-builds", create_if_missing=True)
+    with modal.enable_output():
+        built = image.build(app)
+    built.publish(name)
+    print(f"published {name} (from {registry_ref})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--framework", choices=["slime", "miles", "all"], default="all")
+    args = parser.parse_args()
+
+    frameworks = ["slime", "miles"] if args.framework == "all" else [args.framework]
+    for framework in frameworks:
+        publish(framework)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Successor to #381: instead of an opt-in `named_image` recipe arg, the launchers now resolve their base image via `Image.from_name(...)` unconditionally.

```python
# slime launcher
Image.from_registry("slimerl/slime@sha256:a97e...")   # before
Image.from_name("slimerl/slime:nightly-dev-20260722a")  # after (SLIME_IMAGE)

# miles launcher
Image.from_registry(miles.docker_image)  # before
Image.from_name(miles.docker_image)      # after ("radixark/miles:dev-202608051303")
```

- The built-in patches / entrypoint reset / HF-cache cleanup still layer on top via `run_commands`, so behavior is otherwise unchanged — only the base resolution changes from a registry pull to a named-Image lookup.
- The old digest pin is kept as `SLIME_REGISTRY_IMAGE` and used by `scripts/publish_framework_images.py`, which builds each registry image once and publishes it under the named ref (`slimerl/slime:nightly-dev-20260722a`, `radixark/miles:dev-202608051303`). Names with `/` publish under an environment prefix (`slimerl`, `radixark`), which must exist.
- `scripts/fetch_slime_patch_snapshots.py` keeps reading from the registry digest.

**Deployment note:** the names must be published once (`uv run scripts/publish_framework_images.py`) before launches resolve them — `from_name` fails until then. Bumping to a newer upstream tag (e.g. `slimerl/slime:nightly-dev-20260804a`) is a constant change plus a republish.

## Checklist

N/A — library change, not an example. Ran `ruff check`, `ruff format`, `compileall`, pre-commit, and the recipe/CLI test subset (230 passed).


Link to Devin session: https://modal.devinenterprise.com/sessions/ecdc4eabe1a0494bba278a0a786d7d87
Requested by: @joyliu-q