### PR TITLE
fix quickstart eg to use 8xh100

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ result = TrainConfig(
     dataset=MathDataset(n_rows=120),
     recipe=Qwen3_5_4b_Recipe(
         rm_type="deepscaler",
-        actor_num_gpus_per_node=1,
+        gpu_type="H100",
+        colocate=True,
+        tensor_model_parallel_size=1,
+        sequence_parallel=False,
+        rollout_num_gpus_per_engine=1,
         num_rollout=1,
         n_samples_per_prompt=4,
         rollout_batch_size=8,

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -20,7 +20,11 @@ def main() -> None:
         dataset=MathDataset(n_rows=120),
         recipe=Qwen3_4b_Recipe(
             rm_type="deepscaler",
-            actor_num_gpus_per_node=1,
+            gpu_type="H100",
+            colocate=True,
+            tensor_model_parallel_size=1,
+            sequence_parallel=False,
+            rollout_num_gpus_per_engine=1,
             num_rollout=1,
             n_samples_per_prompt=4,
             rollout_batch_size=8,


### PR DESCRIPTION
Fixes OOM for quickstart by bumping to 8xH100.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->