### PR TITLE
Redirect old /tutorials/tools/ URLs to the new guides

### DIFF
--- a/docs-next/astro.config.mjs
+++ b/docs-next/astro.config.mjs
@@ -9,6 +9,11 @@ export default defineConfig({
     rehypePlugins: [rehypeTableWrapper],
   },
   site: 'https://gym.modal.dev',
+  redirects: {
+    '/tutorials/tools/000_observability_dashboard':
+      '/guides/tools/observability-dashboard/',
+    '/tutorials/tools/001_wandb_integration': '/guides/tools/wandb-integration/',
+  },
   integrations: [
     starlight({
       title: 'Training Gym',


### PR DESCRIPTION
Fast follow to #393 ([review comment](https://github.com/modal-projects/training-gym/pull/393#discussion_r3787203012)): moving the two tools tutorials into Guides drops their old slugs, which were published in `llms.txt` and may be linked externally. Since `disable404Route: true`, those paths would 404 silently.

Adds Astro `redirects` mapping:

```
/tutorials/tools/000_observability_dashboard -> /guides/tools/observability-dashboard/
/tutorials/tools/001_wandb_integration       -> /guides/tools/wandb-integration/
```

Static build emits meta-refresh pages with `noindex` + `canonical` at the old paths; verified locally with `npm run build` (the redirect stubs are excluded from the sitemap).

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/f112fe83a4b64230a0eb7e3a2db3a9f9
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->