### PR TITLE
add all endpoint flags as params in `Endpoint.launch`

### DIFF
--- a/modal_training_gym/common/__init__.py
+++ b/modal_training_gym/common/__init__.py
@@ -36,6 +36,12 @@ def modal_tag_value(value: object) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "-", raw_name).strip("-_.")
 
 
+def hf_token() -> str | None:
+    """Return ``HF_TOKEN`` or ``HUGGING_FACE_HUB_TOKEN`` from the launching process."""
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    return token or None
+
+
 def hf_secrets() -> list:
     """Return a list of Modal Secrets providing ``HF_TOKEN`` to containers.
 
@@ -48,9 +54,9 @@ def hf_secrets() -> list:
     """
     from modal import Secret
 
-    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    if hf_token:
-        return [Secret.from_dict({"HF_TOKEN": hf_token})]
+    token = hf_token()
+    if token:
+        return [Secret.from_dict({"HF_TOKEN": token})]
 
     try:
         secret = Secret.from_name("huggingface-secret")
@@ -92,6 +98,7 @@ __all__ = [
     "modal_tag_value",
     "register_modal_cloudpickle_reducers",
     "hf_secrets",
+    "hf_token",
     "proxy_auth_secrets",
     "vol_get",
     "vol_list",

--- a/modal_training_gym/common/endpoint.py
+++ b/modal_training_gym/common/endpoint.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 import modal
 
+from modal_training_gym.common import hf_token
 from modal_training_gym.common.checkpoint import (
     Checkpoint,
     convert_megatron_checkpoint_to_hf,
@@ -31,7 +32,7 @@ def _create_endpoint_and_wait_for_url(
     colocate_compute: bool,
     custom_hf_repo: str | None,
     custom_hf_revision: str | None,
-    custom_hf_token: str | None,
+    resolved_hf_token: str | None,
     wait_timeout_sec: float,
     recreate_if_existing: bool,
 ) -> str:
@@ -76,8 +77,8 @@ def _create_endpoint_and_wait_for_url(
         command.extend(["--custom-hf-repo", custom_hf_repo])
     if custom_hf_revision:
         command.extend(["--custom-hf-revision", custom_hf_revision])
-    if custom_hf_token:
-        command.extend(["--custom-hf-token", custom_hf_token])
+    if resolved_hf_token:
+        command.extend(["--custom-hf-token", resolved_hf_token])
 
     if checkpoint:
         command.extend(["--custom-volume-name", checkpoint.checkpoints_volume_name])
@@ -162,7 +163,6 @@ class Endpoint:
         colocate_compute: bool = False,
         custom_hf_repo: str | None = None,
         custom_hf_revision: str | None = None,
-        custom_hf_token: str | None = None,
         wait_timeout_sec: float = 300,
         recreate_if_existing: bool = False,
     ):
@@ -177,8 +177,9 @@ class Endpoint:
         Endpoints require proxy auth if ``unauthenticated=False``.
         ``colocate_compute=True`` keeps containers in the routing region, and
         ``custom_hf_repo`` serves fine-tuned weights from Hugging Face.
-        ``custom_hf_revision`` and ``custom_hf_token`` apply only with that
-        repo. A ``checkpoint`` and ``custom_hf_repo`` cannot be combined.
+        ``custom_hf_revision`` applies only with that repo. A repo also
+        requires ``HF_TOKEN`` or ``HUGGING_FACE_HUB_TOKEN`` in the launching
+        shell. A ``checkpoint`` and ``custom_hf_repo`` cannot be combined.
 
         ``modal endpoint create`` fails when the name already exists. Pass
         ``recreate_if_existing=True`` to stop an endpoint with the same name
@@ -196,10 +197,17 @@ class Endpoint:
             raise TrainingGymConfigError(
                 "checkpoint and custom_hf_repo cannot both be set"
             )
-        if (custom_hf_revision or custom_hf_token) and not custom_hf_repo:
-            raise TrainingGymConfigError(
-                "custom_hf_revision and custom_hf_token require custom_hf_repo"
-            )
+        if custom_hf_repo:
+            resolved_hf_token = hf_token()
+            if resolved_hf_token is None:
+                raise TrainingGymConfigError(
+                    "custom_hf_repo requires HF_TOKEN or HUGGING_FACE_HUB_TOKEN "
+                    "in the launching shell"
+                )
+        elif custom_hf_revision:
+            raise TrainingGymConfigError("custom_hf_revision requires custom_hf_repo")
+        else:
+            resolved_hf_token = None
 
         if checkpoint:
             model_config = (
@@ -247,7 +255,7 @@ class Endpoint:
             colocate_compute=colocate_compute,
             custom_hf_repo=custom_hf_repo,
             custom_hf_revision=custom_hf_revision,
-            custom_hf_token=custom_hf_token,
+            resolved_hf_token=resolved_hf_token,
             wait_timeout_sec=wait_timeout_sec,
             recreate_if_existing=recreate_if_existing,
         )

--- a/modal_training_gym/common/endpoint.py
+++ b/modal_training_gym/common/endpoint.py
@@ -10,7 +10,6 @@ from typing import Any
 import httpx
 import modal
 
-from modal_training_gym.common import hf_token
 from modal_training_gym.common.checkpoint import (
     Checkpoint,
     convert_megatron_checkpoint_to_hf,
@@ -30,9 +29,6 @@ def _create_endpoint_and_wait_for_url(
     routing_region: str | None,
     environment: str | None,
     colocate_compute: bool,
-    custom_hf_repo: str | None,
-    custom_hf_revision: str | None,
-    resolved_hf_token: str | None,
     wait_timeout_sec: float,
     recreate_if_existing: bool,
 ) -> str:
@@ -73,12 +69,6 @@ def _create_endpoint_and_wait_for_url(
         command.extend(["--env", environment])
     if colocate_compute:
         command.append("--colocate-compute")
-    if custom_hf_repo:
-        command.extend(["--custom-hf-repo", custom_hf_repo])
-    if custom_hf_revision:
-        command.extend(["--custom-hf-revision", custom_hf_revision])
-    if resolved_hf_token:
-        command.extend(["--custom-hf-token", resolved_hf_token])
 
     if checkpoint:
         command.extend(["--custom-volume-name", checkpoint.checkpoints_volume_name])
@@ -161,8 +151,6 @@ class Endpoint:
         routing_region: str | None = None,
         environment: str | None = None,
         colocate_compute: bool = False,
-        custom_hf_repo: str | None = None,
-        custom_hf_revision: str | None = None,
         wait_timeout_sec: float = 300,
         recreate_if_existing: bool = False,
     ):
@@ -175,11 +163,11 @@ class Endpoint:
         When ``endpoint_name`` is omitted, an endpoint name is derived for you.
 
         Endpoints require proxy auth if ``unauthenticated=False``.
-        ``colocate_compute=True`` keeps containers in the routing region, and
-        ``custom_hf_repo`` serves fine-tuned weights from Hugging Face.
-        ``custom_hf_revision`` applies only with that repo. A repo also
-        requires ``HF_TOKEN`` or ``HUGGING_FACE_HUB_TOKEN`` in the launching
-        shell. A ``checkpoint`` and ``custom_hf_repo`` cannot be combined.
+        ``colocate_compute=True`` keeps containers in the routing region.
+
+        Every ``modal endpoint create`` flag has a parameter here. Custom
+        weights are a ``Checkpoint`` passed as ``checkpoint``, which maps to
+        ``--custom-volume-name`` and ``--custom-volume-path``.
 
         ``modal endpoint create`` fails when the name already exists. Pass
         ``recreate_if_existing=True`` to stop an endpoint with the same name
@@ -193,22 +181,6 @@ class Endpoint:
         Megatron training checkpoints are converted to Hugging Face format
         before create.
         """
-        if checkpoint and custom_hf_repo:
-            raise TrainingGymConfigError(
-                "checkpoint and custom_hf_repo cannot both be set"
-            )
-        if custom_hf_repo:
-            resolved_hf_token = hf_token()
-            if resolved_hf_token is None:
-                raise TrainingGymConfigError(
-                    "custom_hf_repo requires HF_TOKEN or HUGGING_FACE_HUB_TOKEN "
-                    "in the launching shell"
-                )
-        elif custom_hf_revision:
-            raise TrainingGymConfigError("custom_hf_revision requires custom_hf_repo")
-        else:
-            resolved_hf_token = None
-
         if checkpoint:
             model_config = (
                 model
@@ -235,10 +207,6 @@ class Endpoint:
                 )
             if colocate_compute:
                 spec["colocate_compute"] = True
-            if custom_hf_repo:
-                spec["custom_hf_repo"] = custom_hf_repo
-            if custom_hf_repo and custom_hf_revision:
-                spec["custom_hf_revision"] = custom_hf_revision
 
             digest = hashlib.sha256(
                 json.dumps(spec, sort_keys=True, separators=(",", ":")).encode()
@@ -253,9 +221,6 @@ class Endpoint:
             routing_region=routing_region,
             environment=environment,
             colocate_compute=colocate_compute,
-            custom_hf_repo=custom_hf_repo,
-            custom_hf_revision=custom_hf_revision,
-            resolved_hf_token=resolved_hf_token,
             wait_timeout_sec=wait_timeout_sec,
             recreate_if_existing=recreate_if_existing,
         )

--- a/modal_training_gym/common/endpoint.py
+++ b/modal_training_gym/common/endpoint.py
@@ -26,10 +26,14 @@ def _create_endpoint_and_wait_for_url(
     model_name: str,
     checkpoint: Checkpoint | None,
     unauthenticated: bool,
-    environment: str | None,
     routing_region: str | None,
+    colocate_compute: bool,
+    custom_hf_repo: str | None,
+    custom_hf_revision: str | None,
+    custom_hf_token: str | None,
     wait_timeout_sec: float,
     recreate_if_existing: bool,
+    environment: str | None,
 ) -> str:
     if recreate_if_existing:
         stop = [
@@ -66,6 +70,14 @@ def _create_endpoint_and_wait_for_url(
         command.append("--unauthenticated")
     if routing_region:
         command.extend(["--routing-region", routing_region])
+    if colocate_compute:
+        command.append("--colocate-compute")
+    if custom_hf_repo:
+        command.extend(["--custom-hf-repo", custom_hf_repo])
+    if custom_hf_revision:
+        command.extend(["--custom-hf-revision", custom_hf_revision])
+    if custom_hf_token:
+        command.extend(["--custom-hf-token", custom_hf_token])
 
     if checkpoint:
         command.extend(["--custom-volume-name", checkpoint.checkpoints_volume_name])
@@ -145,10 +157,14 @@ class Endpoint:
         *,
         endpoint_name: str | None = None,
         unauthenticated: bool = True,
-        environment: str | None = None,
         routing_region: str | None = None,
+        colocate_compute: bool = False,
+        custom_hf_repo: str | None = None,
+        custom_hf_revision: str | None = None,
+        custom_hf_token: str | None = None,
         wait_timeout_sec: float = 300,
         recreate_if_existing: bool = False,
+        environment: str | None = None,
     ):
         """Provision a Modal endpoint for ``model`` and return a handle to it.
 
@@ -159,6 +175,10 @@ class Endpoint:
         When ``endpoint_name`` is omitted, an endpoint name is derived for you.
 
         Endpoints require proxy auth if ``unauthenticated=False``.
+        ``colocate_compute=True`` keeps containers in the routing region, and
+        ``custom_hf_repo`` serves fine-tuned weights from Hugging Face.
+        ``custom_hf_revision`` and ``custom_hf_token`` apply only with that
+        repo. A ``checkpoint`` and ``custom_hf_repo`` cannot be combined.
 
         ``modal endpoint create`` fails when the name already exists. Pass
         ``recreate_if_existing=True`` to stop an endpoint with the same name
@@ -172,6 +192,15 @@ class Endpoint:
         Megatron training checkpoints are converted to Hugging Face format
         before create.
         """
+        if checkpoint and custom_hf_repo:
+            raise TrainingGymConfigError(
+                "checkpoint and custom_hf_repo cannot both be set"
+            )
+        if (custom_hf_revision or custom_hf_token) and not custom_hf_repo:
+            raise TrainingGymConfigError(
+                "custom_hf_revision and custom_hf_token require custom_hf_repo"
+            )
+
         if checkpoint:
             model_config = (
                 model
@@ -196,6 +225,12 @@ class Endpoint:
                         "checkpoint_name": checkpoint.name,
                     }
                 )
+            if colocate_compute:
+                spec["colocate_compute"] = True
+            if custom_hf_repo:
+                spec["custom_hf_repo"] = custom_hf_repo
+            if custom_hf_repo and custom_hf_revision:
+                spec["custom_hf_revision"] = custom_hf_revision
 
             digest = hashlib.sha256(
                 json.dumps(spec, sort_keys=True, separators=(",", ":")).encode()
@@ -207,8 +242,12 @@ class Endpoint:
             model_name=model_name,
             checkpoint=checkpoint,
             unauthenticated=unauthenticated,
-            environment=environment,
             routing_region=routing_region,
+            environment=environment,
+            colocate_compute=colocate_compute,
+            custom_hf_repo=custom_hf_repo,
+            custom_hf_revision=custom_hf_revision,
+            custom_hf_token=custom_hf_token,
             wait_timeout_sec=wait_timeout_sec,
             recreate_if_existing=recreate_if_existing,
         )

--- a/modal_training_gym/common/endpoint.py
+++ b/modal_training_gym/common/endpoint.py
@@ -27,13 +27,13 @@ def _create_endpoint_and_wait_for_url(
     checkpoint: Checkpoint | None,
     unauthenticated: bool,
     routing_region: str | None,
+    environment: str | None,
     colocate_compute: bool,
     custom_hf_repo: str | None,
     custom_hf_revision: str | None,
     custom_hf_token: str | None,
     wait_timeout_sec: float,
     recreate_if_existing: bool,
-    environment: str | None,
 ) -> str:
     if recreate_if_existing:
         stop = [
@@ -64,12 +64,12 @@ def _create_endpoint_and_wait_for_url(
         model_name,
     ]
 
-    if environment:
-        command.extend(["--env", environment])
     if unauthenticated:
         command.append("--unauthenticated")
     if routing_region:
         command.extend(["--routing-region", routing_region])
+    if environment:
+        command.extend(["--env", environment])
     if colocate_compute:
         command.append("--colocate-compute")
     if custom_hf_repo:
@@ -158,13 +158,13 @@ class Endpoint:
         endpoint_name: str | None = None,
         unauthenticated: bool = True,
         routing_region: str | None = None,
+        environment: str | None = None,
         colocate_compute: bool = False,
         custom_hf_repo: str | None = None,
         custom_hf_revision: str | None = None,
         custom_hf_token: str | None = None,
         wait_timeout_sec: float = 300,
         recreate_if_existing: bool = False,
-        environment: str | None = None,
     ):
         """Provision a Modal endpoint for ``model`` and return a handle to it.
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 from typing import Any
 
 import httpx
 import modal
 import pytest
+from modal.cli.endpoint import create as modal_endpoint_create
 
 from modal_training_gym.common import endpoint as endpoint_module
 from modal_training_gym.common.checkpoint import Checkpoint, CheckpointType
@@ -99,12 +101,6 @@ class _FakeModalCli:
 
     def flag_value(self, flag: str) -> str:
         return self.last_command[self.last_command.index(flag) + 1]
-
-
-@pytest.fixture(autouse=True)
-def _clean_hf_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("HF_TOKEN", raising=False)
-    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
 
 
 @pytest.fixture
@@ -209,76 +205,6 @@ def test_launch_appends_colocate_compute(fake_modal_cli) -> None:
     Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, colocate_compute=True)
 
     assert "--colocate-compute" in cli.last_command
-
-
-def test_launch_forwards_custom_hf_flags(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cli = fake_modal_cli()
-    monkeypatch.setenv("HF_TOKEN", "hf_token")
-
-    Endpoint.launch(
-        "Qwen/Qwen3-4B",
-        unauthenticated=True,
-        custom_hf_repo="org/model",
-        custom_hf_revision="abc123",
-    )
-
-    assert cli.flag_value("--custom-hf-repo") == "org/model"
-    assert cli.flag_value("--custom-hf-revision") == "abc123"
-    assert cli.flag_value("--custom-hf-token") == "hf_token"
-
-
-def test_launch_forwards_legacy_hub_token(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cli = fake_modal_cli()
-    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "hf_legacy")
-
-    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model")
-
-    assert cli.flag_value("--custom-hf-token") == "hf_legacy"
-
-
-def test_launch_omits_unset_custom_hf_revision(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cli = fake_modal_cli()
-    monkeypatch.setenv("HF_TOKEN", "hf_token")
-
-    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model")
-
-    assert cli.flag_value("--custom-hf-repo") == "org/model"
-    assert "--custom-hf-revision" not in cli.last_command
-    assert cli.flag_value("--custom-hf-token") == "hf_token"
-
-
-def test_launch_requires_env_token_for_custom_hf_repo(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cli = fake_modal_cli()
-    monkeypatch.delenv("HF_TOKEN", raising=False)
-    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
-
-    with pytest.raises(
-        TrainingGymConfigError, match="HF_TOKEN or HUGGING_FACE_HUB_TOKEN"
-    ):
-        Endpoint.launch(
-            "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
-        )
-
-    assert cli.commands == []
-
-
-def test_launch_omits_hf_token_flag_without_custom_hf_repo(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cli = fake_modal_cli()
-    monkeypatch.setenv("HF_TOKEN", "hf_token")
-
-    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
-
-    assert "--custom-hf-token" not in cli.last_command
 
 
 def _checkpoint(
@@ -396,36 +322,47 @@ def test_launch_skips_conversion_for_hub_models(
     Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
 
 
-def test_launch_rejects_checkpoint_with_custom_hf_repo(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_launch_covers_every_pinned_endpoint_create_flag() -> None:
+    named_by_launch = {
+        "name",
+        "model",
+        "env",
+        "unauthenticated",
+        "routing_region",
+        "colocate_compute",
+    }
+    named_by_checkpoint = {"custom_volume_name", "custom_volume_path"}
+    unsupported = {"custom_hf_repo", "custom_hf_revision", "custom_hf_token"}
+
+    click_dests = frozenset(
+        param.name for param in modal_endpoint_create.params if param.name
+    )
+    assert click_dests == named_by_launch | named_by_checkpoint | unsupported
+
+    launch_params = set(inspect.signature(Endpoint.launch).parameters)
+    assert "kwargs" not in launch_params
+    assert not unsupported & launch_params
+
+
+def test_launch_rejects_unknown_endpoint_options(fake_modal_cli) -> None:
     cli = fake_modal_cli()
 
-    def convert(*args, **kwargs):
-        raise AssertionError("xor launch converted a checkpoint")
-
-    monkeypatch.setattr(endpoint_module, "convert_megatron_checkpoint_to_hf", convert)
-
-    with pytest.raises(TrainingGymConfigError, match="checkpoint and custom_hf_repo"):
+    with pytest.raises(TypeError):
         Endpoint.launch(
             "Qwen/Qwen3-4B",
-            _checkpoint(),
             unauthenticated=True,
-            custom_hf_repo="org/model",
+            custom_hf_token="hf_test_token",
         )
 
     assert cli.commands == []
 
 
-def test_launch_rejects_custom_hf_revision_without_repo(fake_modal_cli) -> None:
+def test_launch_never_puts_an_hf_token_on_the_command_line(fake_modal_cli) -> None:
     cli = fake_modal_cli()
 
-    with pytest.raises(TrainingGymConfigError, match="requires custom_hf_repo"):
-        Endpoint.launch(
-            "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_revision="abc123"
-        )
+    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
 
-    assert cli.commands == []
+    assert cli.last_command.count("--custom-hf-token") == 0
 
 
 def test_launch_derives_stable_names_from_the_serving_spec(fake_modal_cli) -> None:
@@ -465,53 +402,17 @@ def test_launch_derives_stable_names_from_the_serving_spec(fake_modal_cli) -> No
     assert public.endpoint_name == "training-gym-814a133f9cff"
 
 
-def test_launch_derived_name_changes_for_colocate_and_custom_hf(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+def test_launch_derived_name_changes_for_colocate(
+    fake_modal_cli,
 ) -> None:
     fake_modal_cli()
-    monkeypatch.setenv("HF_TOKEN", "hf_token")
 
     default = Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
     colocated = Endpoint.launch(
         "Qwen/Qwen3-4B", unauthenticated=True, colocate_compute=True
     )
-    repo = Endpoint.launch(
-        "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
-    )
-    repo_revision = Endpoint.launch(
-        "Qwen/Qwen3-4B",
-        unauthenticated=True,
-        custom_hf_repo="org/model",
-        custom_hf_revision="abc123",
-    )
 
-    assert (
-        len(
-            {
-                default.endpoint_name,
-                colocated.endpoint_name,
-                repo.endpoint_name,
-                repo_revision.endpoint_name,
-            }
-        )
-        == 4
-    )
-
-
-def test_launch_derived_name_ignores_custom_hf_token(
-    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    fake_modal_cli()
-    monkeypatch.setenv("HF_TOKEN", "token-a")
-    repo = Endpoint.launch(
-        "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
-    )
-    monkeypatch.setenv("HF_TOKEN", "token-b")
-    other = Endpoint.launch(
-        "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
-    )
-
-    assert repo.endpoint_name == other.endpoint_name
+    assert default.endpoint_name != colocated.endpoint_name
 
 
 def test_launch_uses_an_explicit_endpoint_name(fake_modal_cli) -> None:

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -164,6 +164,10 @@ def test_launch_creates_a_public_endpoint(fake_modal_cli) -> None:
     assert "--env" not in cli.last_command
     assert "--routing-region" not in cli.last_command
     assert "--custom-volume-name" not in cli.last_command
+    assert "--colocate-compute" not in cli.last_command
+    assert "--custom-hf-repo" not in cli.last_command
+    assert "--custom-hf-revision" not in cli.last_command
+    assert "--custom-hf-token" not in cli.last_command
     assert cli.run_kwargs[-1] == {"check": True, "timeout": 120}
     assert endpoint.model_name == "Qwen/Qwen3-4B"
     assert endpoint.requires_proxy_auth is False
@@ -191,6 +195,40 @@ def test_launch_forwards_environment_and_routing_region(fake_modal_cli) -> None:
     assert cli.flag_value("--env") == "dev"
     assert cli.flag_value("--routing-region") == "us-east"
     assert cli.servers[-1][2] == "dev"
+
+
+def test_launch_appends_colocate_compute(fake_modal_cli) -> None:
+    cli = fake_modal_cli()
+
+    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, colocate_compute=True)
+
+    assert "--colocate-compute" in cli.last_command
+
+
+def test_launch_forwards_custom_hf_flags(fake_modal_cli) -> None:
+    cli = fake_modal_cli()
+
+    Endpoint.launch(
+        "Qwen/Qwen3-4B",
+        unauthenticated=True,
+        custom_hf_repo="org/model",
+        custom_hf_revision="abc123",
+        custom_hf_token="hf_token",
+    )
+
+    assert cli.flag_value("--custom-hf-repo") == "org/model"
+    assert cli.flag_value("--custom-hf-revision") == "abc123"
+    assert cli.flag_value("--custom-hf-token") == "hf_token"
+
+
+def test_launch_omits_unset_custom_hf_revision_and_token(fake_modal_cli) -> None:
+    cli = fake_modal_cli()
+
+    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model")
+
+    assert cli.flag_value("--custom-hf-repo") == "org/model"
+    assert "--custom-hf-revision" not in cli.last_command
+    assert "--custom-hf-token" not in cli.last_command
 
 
 def _checkpoint(
@@ -308,6 +346,46 @@ def test_launch_skips_conversion_for_hub_models(
     Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
 
 
+def test_launch_rejects_checkpoint_with_custom_hf_repo(
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cli = fake_modal_cli()
+
+    def convert(*args, **kwargs):
+        raise AssertionError("xor launch converted a checkpoint")
+
+    monkeypatch.setattr(endpoint_module, "convert_megatron_checkpoint_to_hf", convert)
+
+    with pytest.raises(TrainingGymConfigError, match="checkpoint and custom_hf_repo"):
+        Endpoint.launch(
+            "Qwen/Qwen3-4B",
+            _checkpoint(),
+            unauthenticated=True,
+            custom_hf_repo="org/model",
+        )
+
+    assert cli.commands == []
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"custom_hf_revision": "abc123"},
+        {"custom_hf_token": "hf_token"},
+        {"custom_hf_revision": "abc123", "custom_hf_token": "hf_token"},
+    ],
+)
+def test_launch_rejects_custom_hf_revision_or_token_without_repo(
+    fake_modal_cli, kwargs: dict[str, str]
+) -> None:
+    cli = fake_modal_cli()
+
+    with pytest.raises(TrainingGymConfigError, match="require custom_hf_repo"):
+        Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, **kwargs)
+
+    assert cli.commands == []
+
+
 def test_launch_derives_stable_names_from_the_serving_spec(fake_modal_cli) -> None:
     fake_modal_cli()
 
@@ -342,6 +420,61 @@ def test_launch_derives_stable_names_from_the_serving_spec(fake_modal_cli) -> No
         )
         == 6
     )
+    assert public.endpoint_name == "training-gym-814a133f9cff"
+
+
+def test_launch_derived_name_changes_for_colocate_and_custom_hf(
+    fake_modal_cli,
+) -> None:
+    fake_modal_cli()
+
+    default = Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
+    colocated = Endpoint.launch(
+        "Qwen/Qwen3-4B", unauthenticated=True, colocate_compute=True
+    )
+    repo = Endpoint.launch(
+        "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
+    )
+    repo_revision = Endpoint.launch(
+        "Qwen/Qwen3-4B",
+        unauthenticated=True,
+        custom_hf_repo="org/model",
+        custom_hf_revision="abc123",
+    )
+
+    assert (
+        len(
+            {
+                default.endpoint_name,
+                colocated.endpoint_name,
+                repo.endpoint_name,
+                repo_revision.endpoint_name,
+            }
+        )
+        == 4
+    )
+
+
+def test_launch_derived_name_ignores_custom_hf_token(fake_modal_cli) -> None:
+    fake_modal_cli()
+
+    repo = Endpoint.launch(
+        "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
+    )
+    token_a = Endpoint.launch(
+        "Qwen/Qwen3-4B",
+        unauthenticated=True,
+        custom_hf_repo="org/model",
+        custom_hf_token="token-a",
+    )
+    token_b = Endpoint.launch(
+        "Qwen/Qwen3-4B",
+        unauthenticated=True,
+        custom_hf_repo="org/model",
+        custom_hf_token="token-b",
+    )
+
+    assert repo.endpoint_name == token_a.endpoint_name == token_b.endpoint_name
 
 
 def test_launch_uses_an_explicit_endpoint_name(fake_modal_cli) -> None:

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -101,6 +101,12 @@ class _FakeModalCli:
         return self.last_command[self.last_command.index(flag) + 1]
 
 
+@pytest.fixture(autouse=True)
+def _clean_hf_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+
 @pytest.fixture
 def clock(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
     fake = _FakeClock()
@@ -205,15 +211,17 @@ def test_launch_appends_colocate_compute(fake_modal_cli) -> None:
     assert "--colocate-compute" in cli.last_command
 
 
-def test_launch_forwards_custom_hf_flags(fake_modal_cli) -> None:
+def test_launch_forwards_custom_hf_flags(
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+) -> None:
     cli = fake_modal_cli()
+    monkeypatch.setenv("HF_TOKEN", "hf_token")
 
     Endpoint.launch(
         "Qwen/Qwen3-4B",
         unauthenticated=True,
         custom_hf_repo="org/model",
         custom_hf_revision="abc123",
-        custom_hf_token="hf_token",
     )
 
     assert cli.flag_value("--custom-hf-repo") == "org/model"
@@ -221,13 +229,55 @@ def test_launch_forwards_custom_hf_flags(fake_modal_cli) -> None:
     assert cli.flag_value("--custom-hf-token") == "hf_token"
 
 
-def test_launch_omits_unset_custom_hf_revision_and_token(fake_modal_cli) -> None:
+def test_launch_forwards_legacy_hub_token(
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+) -> None:
     cli = fake_modal_cli()
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "hf_legacy")
+
+    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model")
+
+    assert cli.flag_value("--custom-hf-token") == "hf_legacy"
+
+
+def test_launch_omits_unset_custom_hf_revision(
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cli = fake_modal_cli()
+    monkeypatch.setenv("HF_TOKEN", "hf_token")
 
     Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model")
 
     assert cli.flag_value("--custom-hf-repo") == "org/model"
     assert "--custom-hf-revision" not in cli.last_command
+    assert cli.flag_value("--custom-hf-token") == "hf_token"
+
+
+def test_launch_requires_env_token_for_custom_hf_repo(
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cli = fake_modal_cli()
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+    with pytest.raises(
+        TrainingGymConfigError, match="HF_TOKEN or HUGGING_FACE_HUB_TOKEN"
+    ):
+        Endpoint.launch(
+            "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
+        )
+
+    assert cli.commands == []
+
+
+def test_launch_omits_hf_token_flag_without_custom_hf_repo(
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cli = fake_modal_cli()
+    monkeypatch.setenv("HF_TOKEN", "hf_token")
+
+    Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
+
     assert "--custom-hf-token" not in cli.last_command
 
 
@@ -367,21 +417,13 @@ def test_launch_rejects_checkpoint_with_custom_hf_repo(
     assert cli.commands == []
 
 
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        {"custom_hf_revision": "abc123"},
-        {"custom_hf_token": "hf_token"},
-        {"custom_hf_revision": "abc123", "custom_hf_token": "hf_token"},
-    ],
-)
-def test_launch_rejects_custom_hf_revision_or_token_without_repo(
-    fake_modal_cli, kwargs: dict[str, str]
-) -> None:
+def test_launch_rejects_custom_hf_revision_without_repo(fake_modal_cli) -> None:
     cli = fake_modal_cli()
 
-    with pytest.raises(TrainingGymConfigError, match="require custom_hf_repo"):
-        Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True, **kwargs)
+    with pytest.raises(TrainingGymConfigError, match="requires custom_hf_repo"):
+        Endpoint.launch(
+            "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_revision="abc123"
+        )
 
     assert cli.commands == []
 
@@ -424,9 +466,10 @@ def test_launch_derives_stable_names_from_the_serving_spec(fake_modal_cli) -> No
 
 
 def test_launch_derived_name_changes_for_colocate_and_custom_hf(
-    fake_modal_cli,
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fake_modal_cli()
+    monkeypatch.setenv("HF_TOKEN", "hf_token")
 
     default = Endpoint.launch("Qwen/Qwen3-4B", unauthenticated=True)
     colocated = Endpoint.launch(
@@ -455,26 +498,20 @@ def test_launch_derived_name_changes_for_colocate_and_custom_hf(
     )
 
 
-def test_launch_derived_name_ignores_custom_hf_token(fake_modal_cli) -> None:
+def test_launch_derived_name_ignores_custom_hf_token(
+    fake_modal_cli, monkeypatch: pytest.MonkeyPatch
+) -> None:
     fake_modal_cli()
-
+    monkeypatch.setenv("HF_TOKEN", "token-a")
     repo = Endpoint.launch(
         "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
     )
-    token_a = Endpoint.launch(
-        "Qwen/Qwen3-4B",
-        unauthenticated=True,
-        custom_hf_repo="org/model",
-        custom_hf_token="token-a",
-    )
-    token_b = Endpoint.launch(
-        "Qwen/Qwen3-4B",
-        unauthenticated=True,
-        custom_hf_repo="org/model",
-        custom_hf_token="token-b",
+    monkeypatch.setenv("HF_TOKEN", "token-b")
+    other = Endpoint.launch(
+        "Qwen/Qwen3-4B", unauthenticated=True, custom_hf_repo="org/model"
     )
 
-    assert repo.endpoint_name == token_a.endpoint_name == token_b.endpoint_name
+    assert repo.endpoint_name == other.endpoint_name
 
 
 def test_launch_uses_an_explicit_endpoint_name(fake_modal_cli) -> None:

--- a/tests/test_hf_secrets.py
+++ b/tests/test_hf_secrets.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from modal_training_gym.common import hf_secrets
+from modal_training_gym.common import hf_secrets, hf_token
 
 
 def _mock_secret_cls():
@@ -15,6 +15,31 @@ def _mock_secret_cls():
 def _clean_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+
+def test_hf_token_reads_hf_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HF_TOKEN", "hf_test_token_123")
+    assert hf_token() == "hf_test_token_123"
+
+
+def test_hf_token_reads_legacy_hub_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "hf_legacy_456")
+    assert hf_token() == "hf_legacy_456"
+
+
+def test_hf_token_prefers_hf_token(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HF_TOKEN", "hf_primary")
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "hf_legacy")
+    assert hf_token() == "hf_primary"
+
+
+def test_hf_token_empty_string_is_absent(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HF_TOKEN", "")
+    assert hf_token() is None
+
+
+def test_hf_token_missing_is_none():
+    assert hf_token() is None
 
 
 def test_local_hf_token(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Adds `colocate_compute` and disallows `custom_hf_repo`, `custom_hf_revision`, and `custom_hf_token` in favor of checkpoints.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->