### PR TITLE
add guide docs to gitignore

### DIFF
--- a/docs-next/.gitignore
+++ b/docs-next/.gitignore
@@ -17,3 +17,5 @@ src/content/docs/tutorials/agent/
 src/content/docs/tutorials/intro/
 src/content/docs/tutorials/sft/
 src/content/docs/tutorials/misc/
+src/content/docs/guides/index.md
+src/content/docs/guides/tools/


### PR DESCRIPTION
Fixes omission made in #393.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->