### PR TITLE
Honor TRAINING_GYM_FRAMEWORK_STATUS_URL in get_framework_status_url

### DIFF
--- a/modal_training_gym/common/config.py
+++ b/modal_training_gym/common/config.py
@@ -182,7 +182,15 @@ def modal_proxy_auth_headers() -> dict[str, str]:
 
 
 def get_framework_status_url() -> str | None:
-    """Return the saved framework-status endpoint URL, or ``None``."""
+    """Resolve the framework-status endpoint URL, or ``None``.
+
+    The ``TRAINING_GYM_FRAMEWORK_STATUS_URL`` env var takes precedence when set,
+    so callers on the driver and inside remote containers resolve the same
+    endpoint; otherwise the URL is derived from the saved dashboard URL.
+    """
+    override = os.environ.get("TRAINING_GYM_FRAMEWORK_STATUS_URL", "").strip()
+    if override:
+        return override
     base = get_dashboard_url()
     if not base:
         return None

--- a/modal_training_gym/common/status_reporter.py
+++ b/modal_training_gym/common/status_reporter.py
@@ -38,9 +38,6 @@ _STATUS_TOKEN_ENV = "TRAINING_GYM_FRAMEWORK_STATUS_TOKEN"
 
 
 def _resolve_url() -> str:
-    url = os.environ.get("TRAINING_GYM_FRAMEWORK_STATUS_URL", "").strip()
-    if url:
-        return url
     try:
         from modal_training_gym.common.config import get_framework_status_url
 


### PR DESCRIPTION
`status_reporter._resolve_url()` already honors `TRAINING_GYM_FRAMEWORK_STATUS_URL`, but `get_framework_status_url()` does not. `train.py` resolves the status URL through `get_framework_status_url()` on the driver and passes it into the workers, so when the env var is set the driver and the reporters disagree on the endpoint.

This moves the override into `get_framework_status_url()` and has `_resolve_url()` delegate to it, so the precedence lives in one place.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->