### PR TITLE
Make the dashboard's metric links configurable

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -11,3 +11,27 @@ modal deploy dashboards/app.py
 ```
 
 Modal prints the URL where the dashboard is served.
+
+## Pointing the metric links at another tracker
+
+Each run links out to its metric curves on wandb.ai. If your training
+containers log somewhere else — a self-hosted W&B server, or a wandb-compatible
+shim in front of another backend — create an optional `training-gym-tracker`
+Secret and redeploy:
+
+```bash
+modal secret create training-gym-tracker \
+  TRAINING_GYM_TRACKER_LABEL=metrics \
+  TRAINING_GYM_TRACKER_RUN_URL_TEMPLATE='https://metrics.example.com/?project={project}&run={run_id}' \
+  TRAINING_GYM_TRACKER_PROJECT_URL_TEMPLATE='https://metrics.example.com/?project={project}'
+```
+
+Templates substitute `{entity}`, `{project}`, `{group}` and `{run_id}` from the
+run record, percent-encoded, and render only when every field they reference is
+non-empty — so the project template is the fallback for a run whose id isn't
+known yet, and a backend with no notion of an entity can just leave `{entity}`
+out. Setting either template switches both away from the wandb.ai defaults.
+
+Links are derived when the dashboard reads a run, not when it writes one, so
+this also relabels and relinks runs that were recorded before you set it. See
+`modal_training_gym/common/tracker.py`.

--- a/dashboards/frontend/src/components/RunSummary.svelte
+++ b/dashboards/frontend/src/components/RunSummary.svelte
@@ -250,7 +250,7 @@
 
     {#if wandbLinks.length}
       <section class="summary-section">
-        <h3 class="summary-section-title">W&B</h3>
+        <h3 class="summary-section-title">Metrics</h3>
         <div class="flex flex-wrap gap-[6px]">
           {#each wandbLinks as link (link.url)}
             <a

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -111,20 +111,11 @@
   // the auto-refresh hands us a new `run` object with the same status (which
   // would otherwise tear down and rebuild the log stream, flashing the tail).
   let runStatus = $derived(String(run?.status || "").toLowerCase());
-  let wandbUrl = $derived.by(() => {
-    const directUrl = run?.train_result?.wandb_url || run?.config_summary?.wandb_url || "";
-    if (directUrl) return directUrl;
-
-    const project = run?.config_summary?.wandb_project || "";
-    return project ? `https://wandb.ai/home?search=${encodeURIComponent(project)}` : "";
-  });
-  let wandbLinks = $derived.by(() =>
-    run?.wandb_links?.length
-      ? run.wandb_links
-      : wandbUrl
-        ? [{ label: "Open in W&B", url: wandbUrl }]
-        : [],
-  );
+  // Metric links come from the server already rendered and labelled, so that a
+  // deployment logging somewhere other than wandb.ai gets links that work. A
+  // run the server couldn't build a link for gets none, rather than a guessed
+  // wandb.ai search that would be wrong for those deployments.
+  let wandbLinks = $derived(run?.wandb_links || []);
 
   $effect(() => {
     const id = runId;

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -131,6 +131,12 @@ MODAL_CREDS_SECRET_NAME = "_training-gym-modal-creds"
 # Set a real value via ``training-gym set-password``.
 DASHBOARD_PASSWORD_SECRET_NAME = "_training-gym-dashboard-password"
 
+# Optional, operator-created (hence no underscore prefix: nothing auto-manages
+# it). Holds TRAINING_GYM_TRACKER_LABEL / _RUN_URL_TEMPLATE /
+# _PROJECT_URL_TEMPLATE, which point each run's metric link at a tracker other
+# than wandb.ai — see modal_training_gym.common.tracker and dashboards/README.md.
+TRACKER_SECRET_NAME = "training-gym-tracker"
+
 # Routes that must bypass Basic Auth. Write endpoints authenticate with their
 # own per-run bearer token; the proxy-auth status route must report only the
 # Modal-layer setting, independent of dashboard password protection.
@@ -279,14 +285,14 @@ def ensure_creds_secret(interactive: bool = False) -> bool:
         return False
 
 
-def _password_secret_exists() -> bool:
-    """True if the operator has configured a dashboard password Secret.
+def _secret_exists(name: str) -> bool:
+    """True if a Secret by this name is configured in the environment.
 
-    Checked at deploy time (local) to decide whether to mount the Secret on
-    the ASGI function — if it was never created, the dashboard stays open.
+    Checked at deploy time (local) to decide whether to mount an optional
+    Secret on the ASGI function.
     """
     try:
-        modal.Secret.from_name(DASHBOARD_PASSWORD_SECRET_NAME).hydrate()
+        modal.Secret.from_name(name).hydrate()
         return True
     except Exception:
         return False
@@ -295,12 +301,14 @@ def _password_secret_exists() -> bool:
 def _function_secrets() -> list[modal.Secret]:
     """Secrets mounted on the ASGI function.
 
-    The password Secret is optional and mounted only when it exists; absent
-    it, ``DASHBOARD_PASSWORD`` is never injected and the dashboard is open.
+    Both optional Secrets are mounted only when they exist: absent the
+    password one, ``DASHBOARD_PASSWORD`` is never injected and the dashboard
+    is open; absent the tracker one, metric links point at wandb.ai.
     """
     secrets = [modal.Secret.from_name(MODAL_CREDS_SECRET_NAME)]
-    if _password_secret_exists():
-        secrets.append(modal.Secret.from_name(DASHBOARD_PASSWORD_SECRET_NAME))
+    for optional in (DASHBOARD_PASSWORD_SECRET_NAME, TRACKER_SECRET_NAME):
+        if _secret_exists(optional):
+            secrets.append(modal.Secret.from_name(optional))
     return secrets
 
 

--- a/modal_training_gym/common/run_summary.py
+++ b/modal_training_gym/common/run_summary.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import datetime as dt
 import math
 from typing import Any, cast
-from urllib.parse import quote
 
 from pydantic import BaseModel, Field, ValidationError
 from pydantic.fields import FieldInfo
 
 from modal_training_gym.common.modal_urls import modal_app_dashboard_url
+from modal_training_gym.common.tracker import tracker_config
 
 
 JsonDict = dict[str, object]
@@ -220,6 +220,20 @@ def _text(value: object) -> str:
     return "" if value is None else str(value)
 
 
+def _identifier(value: object) -> str:
+    """A tracker identifier — entity, project, group or run id — or "".
+
+    ``_text`` stringifies whatever it is handed, which is what display fields
+    want but not this: a link built out of ``"0"`` or ``"{'value': ''}"`` points
+    nowhere, and it would let a malformed record pass for a configured tracker.
+    These fields are declared as strings, so anything else here means the record
+    is broken; ``""`` says so and suppresses the link. That covers a wrapper
+    nested more than once too — the inner wrapper isn't a string.
+    """
+    value = _unwrap(value)
+    return value.strip() if isinstance(value, str) else ""
+
+
 def _mapping(value: object) -> JsonDict:
     value = _unwrap(value)
     return dict(value) if isinstance(value, dict) else {}
@@ -286,22 +300,29 @@ def _modal_app_url(modal_app_id: str) -> str | None:
     return modal_app_dashboard_url(app_id)
 
 
-def _wandb_url(entity: object, project: object, run_id: object) -> str | None:
-    clean_entity = _text(entity).strip()
-    clean_project = _text(project).strip()
-    clean_run_id = _text(run_id).strip()
-    if not clean_entity or not clean_project:
-        return None
-    base = f"https://wandb.ai/{quote(clean_entity, safe='')}/{quote(clean_project, safe='')}"
-    return f"{base}/runs/{quote(clean_run_id, safe='')}" if clean_run_id else base
+def _wandb_url(
+    entity: object, project: object, run_id: object, group: object = ""
+) -> str | None:
+    """Link to this run in whichever tracker the dashboard points at.
+
+    wandb.ai by default; see :mod:`modal_training_gym.common.tracker`.
+    """
+    return tracker_config().url(
+        entity=_identifier(entity),
+        project=_identifier(project),
+        group=_identifier(group),
+        run_id=_identifier(run_id),
+    )
 
 
 def _wandb_summary(
     *, entity: object, project: object, group: object = "", run_id: object = ""
 ) -> dict[str, Any]:
-    url = _wandb_url(entity, project, run_id)
+    url = _wandb_url(entity, project, run_id, group)
     link = (
-        [WandbLink(label="W&B", url=url, run_id=_text(run_id).strip())] if url else []
+        [WandbLink(label=tracker_config().label, url=url, run_id=_identifier(run_id))]
+        if url
+        else []
     )
     return {
         "wandb_project": _text(project),
@@ -313,7 +334,7 @@ def _wandb_summary(
     }
 
 
-def _config_summary(config: object, training_run_id: str) -> ConfigSummary | JsonDict:
+def _config_summary(config: object) -> ConfigSummary | JsonDict:
     if not isinstance(config, dict):
         return {}
     model = _mapping(config.get("model"))
@@ -325,7 +346,11 @@ def _config_summary(config: object, training_run_id: str) -> ConfigSummary | Jso
         or _text(dataset.get("prompt_data"))
         or _text(dataset.get("name"))
     )
-    wandb_run_id = _text(wandb.get("run_id")) or training_run_id[:8]
+    # Only a recorded run id, never one derived from the training run id: where
+    # no launcher recorded one, this side does not know what the tracker named
+    # the run, so a derived id links to a run that does not exist. Empty falls
+    # back to the project link, which resolves.
+    wandb_run_id = _identifier(wandb.get("run_id"))
     return ConfigSummary(
         model_name=_text(model.get("model_name")),
         dataset_name=dataset_name,
@@ -339,7 +364,7 @@ def _config_summary(config: object, training_run_id: str) -> ConfigSummary | Jso
             entity=wandb.get("entity"),
             project=wandb.get("project"),
             group=wandb.get("group"),
-            run_id=wandb_run_id if wandb.get("project") and wandb.get("entity") else "",
+            run_id=wandb_run_id,
         ),
     )
 
@@ -457,18 +482,22 @@ def _wandb_attempt_links(metadata: JsonDict) -> list[WandbLink]:
     attempts = metadata.get("wandb_attempts")
     if not isinstance(attempts, list):
         return []
+    label = tracker_config().label
     links: list[WandbLink] = []
     for raw_attempt in attempts:
         attempt = _mapping(raw_attempt)
         attempt_number = _integer(attempt.get("attempt"))
-        run_id = _text(attempt.get("run_id"))
+        run_id = _identifier(attempt.get("run_id"))
         url = _wandb_url(
-            attempt.get("entity"), attempt.get("project"), attempt.get("run_id")
+            attempt.get("entity"),
+            attempt.get("project"),
+            attempt.get("run_id"),
+            attempt.get("group"),
         )
         if url:
             links.append(
                 WandbLink(
-                    label=f"W&B a{attempt_number}" if attempt_number > 1 else "W&B",
+                    label=f"{label} a{attempt_number}" if attempt_number > 1 else label,
                     url=url,
                     run_id=run_id,
                     attempt=attempt_number or None,
@@ -502,7 +531,7 @@ def build_run_summary(
     metadata = _mapping(run.get("metadata"))
     raw_config = run.get("config")
     config = _mapping(raw_config)
-    config_summary = _config_summary(raw_config, training_run_id)
+    config_summary = _config_summary(raw_config)
     result_summary = _train_result_summary(result) if result else None
     group_id = (
         _text(run.get("group_id"))

--- a/modal_training_gym/common/tracker.py
+++ b/modal_training_gym/common/tracker.py
@@ -1,0 +1,200 @@
+"""Where the dashboard's per-run metric links point, and what they're called.
+
+Training frameworks reach Weights & Biases through the ``wandb`` package, so a
+deployment can put a wandb-compatible backend behind that import — a
+self-hosted W&B server, or a shim that forwards to another tracker. The runs
+are then logged somewhere other than wandb.ai, and the dashboard's links are
+dead ends.
+
+The dashboard never stores those URLs: it derives them at read time from the
+``(entity, project, group, run_id)`` tuple the launcher already records per
+attempt. That makes the link target a rendering choice, set by env vars on the
+dashboard app:
+
+    TRAINING_GYM_TRACKER_LABEL                 # "W&B"
+    TRAINING_GYM_TRACKER_RUN_URL_TEMPLATE      # a single run
+    TRAINING_GYM_TRACKER_PROJECT_URL_TEMPLATE  # fallback when the run is unknown
+
+Unset, the defaults reproduce wandb.ai links exactly. Because nothing is baked
+into the stored records, pointing an existing dashboard at another backend also
+relabels and relinks the runs recorded before the switch.
+
+Setting *either* URL template switches off both W&B defaults: whichever one you
+don't set produces no link rather than silently falling back to wandb.ai, so a
+half-finished or mistyped set of templates can't mix the two backends.
+
+``TRACKER_LABEL`` is independent of that, and on its own only renames the
+links — it does not move them. Relabelling wandb.ai (an internal name for it,
+say) is the point; if you meant to move the links too, set a template.
+
+Templates are ``str.format`` strings over :data:`TEMPLATE_FIELDS`, and a
+template renders only when every field it references is non-empty — which is
+what makes ``PROJECT_URL_TEMPLATE`` a fallback for a run whose id isn't known
+yet, and what lets a backend that has no notion of an entity leave ``{entity}``
+out. The fields a template names are therefore also the evidence it needs: a
+``{group}``-only template links any run with a recorded group, which is the
+point of writing one. Values are percent-encoded, so a backend that keys runs off a query
+parameter works as well as one that uses path segments::
+
+    TRAINING_GYM_TRACKER_LABEL=metrics
+    TRAINING_GYM_TRACKER_RUN_URL_TEMPLATE=https://metrics.example.com/?project={project}&run={run_id}
+    TRAINING_GYM_TRACKER_PROJECT_URL_TEMPLATE=https://metrics.example.com/?project={project}
+
+This is one tracker per dashboard, not per run: it describes where *this*
+deployment's training containers log.
+"""
+
+from __future__ import annotations
+
+import os
+import string
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from urllib.parse import quote, urlparse
+
+LABEL_ENV = "TRAINING_GYM_TRACKER_LABEL"
+RUN_URL_TEMPLATE_ENV = "TRAINING_GYM_TRACKER_RUN_URL_TEMPLATE"
+PROJECT_URL_TEMPLATE_ENV = "TRAINING_GYM_TRACKER_PROJECT_URL_TEMPLATE"
+
+DEFAULT_LABEL = "W&B"
+DEFAULT_RUN_URL_TEMPLATE = "https://wandb.ai/{entity}/{project}/runs/{run_id}"
+DEFAULT_PROJECT_URL_TEMPLATE = "https://wandb.ai/{entity}/{project}"
+
+# Substitutable fields — what the launcher records per attempt. Keep in sync
+# with the keyword arguments of TrackerConfig.url().
+TEMPLATE_FIELDS = frozenset({"entity", "project", "group", "run_id"})
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_FORMATTER = string.Formatter()
+
+
+def _warn(message: str) -> None:
+    print(f"[tracker] {message}", file=sys.stderr, flush=True)
+
+
+def _fields(template: str) -> set[str]:
+    """Fields ``template`` references, or ``ValueError`` if it isn't renderable.
+
+    Deliberately narrow: only bare ``{field}`` references to known names. A
+    conversion (``{project!r}``), a format spec (``{project:>8}``), a nested
+    spec (``{project:{group}}``) or a positional field all parse fine here but
+    blow up — or resolve a name we never supply — at format time, so they are
+    rejected up front rather than at render time.
+    """
+    found: set[str] = set()
+    for _, name, spec, conversion in _FORMATTER.parse(template):
+        if name is None:
+            continue
+        if conversion is not None:
+            raise ValueError(f"conversion {'!' + conversion!r} is not supported")
+        if spec:
+            raise ValueError(f"format spec {spec!r} is not supported")
+        if name not in TEMPLATE_FIELDS:
+            raise ValueError(
+                f"unknown field {name!r}; supported: {sorted(TEMPLATE_FIELDS)}"
+            )
+        found.add(name)
+    if not found:
+        raise ValueError("template references no fields, so it can't identify a run")
+    return found
+
+
+def _accept(template: str, env_name: str) -> str | None:
+    """Return ``template`` if it is safe to render, else warn and return None.
+
+    A bad template is a config mistake, not a reason to take the dashboard
+    down, so the affected link is dropped and everything else keeps working.
+    The scheme and host checks matter because the result goes straight into an
+    ``href``: an operator-supplied ``javascript:`` template would otherwise be
+    a self-XSS foothold on a dashboard that holds workspace credentials, and
+    ``https://`` alone renders a link that goes nowhere.
+    """
+    try:
+        fields = _fields(template)
+        parsed = urlparse(template)
+        if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+            raise ValueError(f"scheme must be http or https, got {parsed.scheme!r}")
+        # hostname, not netloc: "https://:/x" and "https://user@/x" have a
+        # netloc but no actual host, and render links that go nowhere.
+        if not parsed.hostname:
+            raise ValueError("no host")
+        if "{" in parsed.netloc:
+            # The operator fixes the host; run metadata only fills the path and
+            # query. Otherwise a run's project name chooses where the link goes.
+            raise ValueError("host must be a literal, not a template field")
+        # Prove it formats before any run summary depends on it.
+        template.format(**dict.fromkeys(fields, "x"))
+    except (ValueError, KeyError, IndexError) as exc:
+        _warn(f"ignoring {env_name}: {exc}")
+        return None
+    return template
+
+
+def _render(template: str | None, values: dict[str, str]) -> str | None:
+    """Percent-encode ``values`` into ``template``; None if any is empty."""
+    if not template:
+        return None
+    try:
+        fields = _fields(template)
+        if any(not values.get(field, "") for field in fields):
+            return None
+        return template.format(
+            **{field: quote(values[field], safe="") for field in fields}
+        )
+    except Exception:  # never let a link break run-summary construction
+        return None
+
+
+@dataclass(frozen=True)
+class TrackerConfig:
+    # Both templates are required, with no default: defaulting one to wandb.ai
+    # would let a caller configure a custom run URL and silently keep W&B's
+    # project URL, which is the backend mixing tracker_config() rules out.
+    run_url_template: str | None
+    project_url_template: str | None
+    label: str = DEFAULT_LABEL
+
+    def url(
+        self,
+        *,
+        entity: str = "",
+        project: str = "",
+        group: str = "",
+        run_id: str = "",
+    ) -> str | None:
+        """Link to this run, falling back to its project, else None."""
+        values = {
+            "entity": entity.strip(),
+            "project": project.strip(),
+            "group": group.strip(),
+            "run_id": run_id.strip(),
+        }
+        return _render(self.run_url_template, values) or _render(
+            self.project_url_template, values
+        )
+
+
+@lru_cache(maxsize=1)
+def tracker_config() -> TrackerConfig:
+    """Tracker config for this process, read from the environment once.
+
+    Tests that patch the environment should call ``tracker_config.cache_clear()``.
+    """
+    run_template = os.environ.get(RUN_URL_TEMPLATE_ENV, "").strip()
+    project_template = os.environ.get(PROJECT_URL_TEMPLATE_ENV, "").strip()
+    if run_template or project_template:
+        # Custom backend: never mix in a wandb.ai default for the other one.
+        run_url = _accept(run_template, RUN_URL_TEMPLATE_ENV) if run_template else None
+        project_url = (
+            _accept(project_template, PROJECT_URL_TEMPLATE_ENV)
+            if project_template
+            else None
+        )
+    else:
+        run_url, project_url = DEFAULT_RUN_URL_TEMPLATE, DEFAULT_PROJECT_URL_TEMPLATE
+    return TrackerConfig(
+        label=os.environ.get(LABEL_ENV, "").strip() or DEFAULT_LABEL,
+        run_url_template=run_url,
+        project_url_template=project_url,
+    )

--- a/tests/test_dashboard_runs_route.py
+++ b/tests/test_dashboard_runs_route.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from modal_training_gym import _dashboard
+from modal_training_gym.common import tracker
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.run import TrainingRun
 from modal_training_gym.common.train_result import TrainResult
@@ -28,7 +29,7 @@ def _client(monkeypatch, tmp_path) -> TestClient:
     return TestClient(_dashboard.fastapi_app.local())
 
 
-def _save_records() -> None:
+def _save_records(wandb: dict | None = None) -> None:
     TrainingRun(
         training_run_id="run-route-1",
         modal_app_id="ap-route",
@@ -37,6 +38,7 @@ def _save_records() -> None:
             "model": {"model_name": "Qwen/Qwen3-4B"},
             "dataset": {"hf_repo": "openai/gsm8k"},
             "recipe": {"gpu_type": "H100"},
+            **({"wandb": wandb} if wandb else {}),
         },
         created_at=100,
         started_at=100,
@@ -295,3 +297,32 @@ def test_run_logs_rejects_invalid_time_bound(bound, fake_volume, monkeypatch, tm
     assert response.json()["detail"].startswith(
         f"{bound} must be epoch seconds, ISO 8601, or a relative time"
     )
+
+
+@pytest.mark.parametrize("path", ["/api/runs", "/api/runs/run-route-1"])
+def test_a_malformed_tracker_template_cannot_break_the_run_routes(
+    path, fake_volume, monkeypatch, tmp_path
+):
+    """Both routes turn an exception during summary construction into an error
+    or an empty list, so a typo in one env var could otherwise blank the whole
+    dashboard. The bad template must cost only its own link.
+
+    The record carries tracker metadata a working template would link, so an
+    empty ``wandb_links`` here is the bad template being suppressed rather than
+    there having been nothing to link in the first place."""
+    monkeypatch.setenv(
+        tracker.RUN_URL_TEMPLATE_ENV, "https://metrics.example.com/{project!r}"
+    )
+    tracker.tracker_config.cache_clear()
+    _save_records(wandb={"project": "training", "run_id": "recorded-id"})
+
+    try:
+        with _client(monkeypatch, tmp_path) as client:
+            response = client.get(path)
+    finally:
+        tracker.tracker_config.cache_clear()
+
+    assert response.status_code == 200
+    summary = response.json()[0] if path == "/api/runs" else response.json()
+    assert summary["training_run_id"] == "run-route-1"
+    assert summary["wandb_links"] == []

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -3,10 +3,27 @@ from __future__ import annotations
 import pytest
 
 from modal_training_gym.common import run_summary as run_summary_module
+from modal_training_gym.common import tracker as tracker_module
 from modal_training_gym.common.run_summary import (
     build_run_summaries,
     build_run_summary,
 )
+
+CUSTOM_PROJECT_URL = "https://metrics.example.com/?project={project}"
+
+
+@pytest.fixture(autouse=True)
+def default_tracker(monkeypatch):
+    """These assert wandb.ai links, so the developer's own tracker env must not leak in."""
+    for name in (
+        tracker_module.LABEL_ENV,
+        tracker_module.RUN_URL_TEMPLATE_ENV,
+        tracker_module.PROJECT_URL_TEMPLATE_ENV,
+    ):
+        monkeypatch.delenv(name, raising=False)
+    tracker_module.tracker_config.cache_clear()
+    yield
+    tracker_module.tracker_config.cache_clear()
 
 
 def _run(**overrides):
@@ -171,9 +188,9 @@ def test_config_summary_fallbacks_and_wandb_defaults():
                 "entity": "entity",
                 "project": "project",
                 "group": "group",
+                "run_id": "abcdefgh",
             },
-        },
-        "abcdefghijk",
+        }
     )
 
     assert summary.model_name == "model"
@@ -184,7 +201,7 @@ def test_config_summary_fallbacks_and_wandb_defaults():
     assert summary.global_batch_size == 0
     assert summary.wandb_training_run_id == "abcdefgh"
     assert summary.wandb_url == "https://wandb.ai/entity/project/runs/abcdefgh"
-    assert run_summary_module._config_summary(None, "run-id") == {}
+    assert run_summary_module._config_summary(None) == {}
 
 
 def test_progress_rollout_and_resume_helpers_handle_missing_and_invalid_values():
@@ -341,6 +358,135 @@ def test_build_current_summary_joins_result_and_derives_public_fields():
     assert [link.label for link in summary.wandb_links] == ["W&B a2", "W&B"]
 
 
+def test_a_custom_tracker_relabels_and_relinks_recorded_runs(monkeypatch):
+    """Links are derived at read time, so switching backends also repairs the
+    runs recorded before the switch."""
+    monkeypatch.setenv(tracker_module.LABEL_ENV, "metrics")
+    monkeypatch.setenv(
+        tracker_module.RUN_URL_TEMPLATE_ENV,
+        "https://metrics.example.com/?project={project}&run={run_id}",
+    )
+    monkeypatch.setenv(
+        tracker_module.PROJECT_URL_TEMPLATE_ENV,
+        "https://metrics.example.com/?project={project}",
+    )
+    tracker_module.tracker_config.cache_clear()
+
+    run = _run(framework_status="generate_rollouts")
+    run["config"]["wandb"]["run_id"] = "run-1"
+
+    summary = build_run_summary(run, _result())
+
+    assert [link.label for link in summary.wandb_links] == ["metrics a2", "metrics"]
+    assert summary.wandb_links[0].url == (
+        "https://metrics.example.com/?project=training&run=run-1-a2"
+    )
+    assert summary.config_summary.wandb_url == (
+        "https://metrics.example.com/?project=training&run=run-1"
+    )
+
+
+def test_a_tracker_without_entities_still_links(monkeypatch):
+    """An entity is required only by templates that name one. A backend whose
+    URLs have no notion of an entity must still link a run that never recorded
+    one."""
+    monkeypatch.setenv(
+        tracker_module.RUN_URL_TEMPLATE_ENV,
+        "https://metrics.example.com/?project={project}&run={run_id}",
+    )
+    tracker_module.tracker_config.cache_clear()
+
+    run = _run()
+    run["config"]["wandb"] = {  # no entity
+        "project": "training",
+        "group": "g",
+        "run_id": "recorded-id",
+    }
+    run["metadata"].pop("wandb_attempts")
+
+    summary = build_run_summary(run, None)
+
+    assert summary.config_summary.wandb_url == (
+        "https://metrics.example.com/?project=training&run=recorded-id"
+    )
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "https://metrics.example.com/?project={project}&run={run_id}",
+        # A template needing only the run id must not turn the training run id
+        # into a link for a run that never logged metrics.
+        "https://metrics.example.com/runs/{run_id}",
+    ],
+)
+@pytest.mark.parametrize(
+    "wandb_config",
+    # One per rejection reason; the full set of shapes `_identifier` has to cope
+    # with is enumerated against `_identifier` itself, below.
+    [{}, {"project": "   "}, {"project": 0}],
+)
+def test_a_run_with_no_tracker_metadata_gets_no_link(
+    monkeypatch, template, wandb_config
+):
+    monkeypatch.setenv(tracker_module.RUN_URL_TEMPLATE_ENV, template)
+    tracker_module.tracker_config.cache_clear()
+
+    run = _run()
+    run["config"]["wandb"] = wandb_config
+    run["metadata"].pop("wandb_attempts")
+
+    summary = build_run_summary(run, None)
+
+    assert summary.config_summary.wandb_training_run_id == ""
+    assert summary.config_summary.wandb_url is None
+    assert summary.wandb_links == []
+
+
+def test_a_recorded_run_id_links_even_without_a_project(monkeypatch):
+    """`WandbConfig.project` defaults to "", but a recorded run id is the run's
+    real identity: it must be linked, not discarded along with the project."""
+    monkeypatch.setenv(
+        tracker_module.RUN_URL_TEMPLATE_ENV, "https://metrics.example.com/runs/{run_id}"
+    )
+    tracker_module.tracker_config.cache_clear()
+
+    run = _run()
+    run["config"]["wandb"] = {"project": "", "run_id": "real-id"}
+    run["metadata"].pop("wandb_attempts")
+
+    summary = build_run_summary(run, None)
+
+    assert summary.config_summary.wandb_training_run_id == "real-id"
+    assert (
+        summary.config_summary.wandb_url == "https://metrics.example.com/runs/real-id"
+    )
+
+
+def test_tracker_identifiers_unwrap_historical_shapes_and_reject_non_strings():
+    """These feed URLs, so `_text`'s "stringify anything" is wrong for them: it
+    would put a Python repr in an href and let a broken record pass for a run."""
+    cyclic: dict[str, object] = {}
+    cyclic["value"] = cyclic
+
+    assert run_summary_module._identifier("  spaced  ") == "spaced"
+    assert run_summary_module._identifier({"value": "wrapped"}) == "wrapped"
+    for rejected in (
+        None,
+        0,
+        1,
+        False,
+        True,
+        [],
+        ["id"],
+        {},
+        {"source": "legacy"},
+        {"value": {"value": "nested"}},  # unwrapped once; the rest isn't a string
+        cyclic,  # unwrapping until a string would never return
+    ):
+        assert run_summary_module._identifier(rejected) == ""
+
+
 def test_build_historical_summary_accepts_aliases_wrappers_and_iso_timestamps():
     historical = {
         "run_id": "legacy-1",
@@ -476,3 +622,42 @@ def test_malformed_records_do_not_hide_valid_runs():
     )
 
     assert [summary.training_run_id for summary in summaries] == ["valid-run"]
+
+
+@pytest.mark.parametrize(
+    ("recorded", "expected"),
+    [({"value": "wrapped-id"}, "wrapped-id"), (0, "")],
+)
+def test_an_attempt_link_carries_a_normalized_run_id(monkeypatch, recorded, expected):
+    """The link payload carries run_id for the UI, so a broken attempt record must
+    not surface as "0" or "{'value': 'x'}" on an otherwise working project link."""
+    monkeypatch.setenv(tracker_module.PROJECT_URL_TEMPLATE_ENV, CUSTOM_PROJECT_URL)
+    tracker_module.tracker_config.cache_clear()
+
+    run = _run()
+    run["config"]["wandb"] = {}
+    run["metadata"]["wandb_attempts"] = [
+        {"attempt": 1, "project": "training", "run_id": recorded}
+    ]
+
+    links = build_run_summary(run, None).wandb_links
+
+    assert [link.url for link in links] == [
+        "https://metrics.example.com/?project=training"
+    ]
+    assert links[0].run_id == expected
+
+
+def test_a_record_with_no_recorded_run_id_links_to_the_project_not_a_guess():
+    """Every launcher records the id it passed to the tracker, so a config
+    without one predates that — and such runs started with no WANDB_RUN_ID, so
+    the tracker minted an id this side never saw. Deriving one from the training
+    run id would link to a run that does not exist."""
+    run = _run(training_run_id="electric-batter-6362579afd91")
+    run["config"]["wandb"] = {"entity": "e", "project": "p"}
+    run["metadata"].pop("wandb_attempts")
+
+    summary = build_run_summary(run, None)
+
+    assert summary.config_summary.wandb_training_run_id == ""
+    assert summary.config_summary.wandb_url == "https://wandb.ai/e/p"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import pytest
+
+from modal_training_gym.common import tracker as tracker_module
+from modal_training_gym.common.tracker import TrackerConfig
+
+CUSTOM_RUN = "https://metrics.example.com/?project={project}&run={run_id}"
+CUSTOM_PROJECT = "https://metrics.example.com/?project={project}"
+
+
+@pytest.fixture(autouse=True)
+def clean_tracker_env(monkeypatch):
+    """Defaults must be tested against an empty environment, not the developer's."""
+    for name in (
+        tracker_module.LABEL_ENV,
+        tracker_module.RUN_URL_TEMPLATE_ENV,
+        tracker_module.PROJECT_URL_TEMPLATE_ENV,
+    ):
+        monkeypatch.delenv(name, raising=False)
+    tracker_module.tracker_config.cache_clear()
+    yield
+    tracker_module.tracker_config.cache_clear()
+
+
+# ── Defaults reproduce the wandb.ai links ───────────────────────────────────
+
+
+def test_defaults_match_the_wandb_urls_they_replaced():
+    config = tracker_module.tracker_config()
+
+    assert config.label == "W&B"
+    assert (
+        config.url(entity="entity", project="project", run_id="run")
+        == "https://wandb.ai/entity/project/runs/run"
+    )
+    # No run id yet -> project-level fallback.
+    assert (
+        config.url(entity="entity", project="project")
+        == "https://wandb.ai/entity/project"
+    )
+    # Neither default template can render without an entity.
+    assert config.url(project="project", run_id="run") is None
+    assert config.url() is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    # One per character class that percent-encoding has to survive: a path
+    # separator, query/fragment delimiters, a literal percent, non-ASCII, and a
+    # value that is empty once stripped.
+    ["project/name", "a?b#c", "100%", "ünïcode", "  "],
+)
+def test_default_urls_encode_identifiers_wherever_they_appear(value):
+    """The wandb.ai URLs are spelled out here rather than derived from the
+    templates, so a change to the substitution machinery cannot quietly move
+    them. Every identifier is fully encoded: no value can add a path segment or
+    a query of its own."""
+    from urllib.parse import quote
+
+    def expected(entity: str, project: str, run_id: str) -> str | None:
+        entity, project, run_id = entity.strip(), project.strip(), run_id.strip()
+        if not entity or not project:
+            return None
+        base = f"https://wandb.ai/{quote(entity, safe='')}/{quote(project, safe='')}"
+        return f"{base}/runs/{quote(run_id, safe='')}" if run_id else base
+
+    config = tracker_module.tracker_config()
+    for entity, project, run_id in (
+        (value, "project", "run"),
+        ("entity", value, "run"),
+        ("entity", "project", value),
+    ):
+        assert config.url(entity=entity, project=project, run_id=run_id) == expected(
+            entity, project, run_id
+        )
+
+
+# ── Custom backends ─────────────────────────────────────────────────────────
+
+
+def test_custom_templates_need_only_the_fields_they_reference(monkeypatch):
+    monkeypatch.setenv(tracker_module.LABEL_ENV, "metrics")
+    monkeypatch.setenv(tracker_module.RUN_URL_TEMPLATE_ENV, CUSTOM_RUN)
+    monkeypatch.setenv(tracker_module.PROJECT_URL_TEMPLATE_ENV, CUSTOM_PROJECT)
+    tracker_module.tracker_config.cache_clear()
+
+    config = tracker_module.tracker_config()
+
+    assert config.label == "metrics"
+    # No entity anywhere, which the wandb.ai templates would have required.
+    assert (
+        config.url(project="proj", run_id="abcdefgh")
+        == "https://metrics.example.com/?project=proj&run=abcdefgh"
+    )
+    assert config.url(project="proj") == "https://metrics.example.com/?project=proj"
+    assert config.url() is None
+
+
+def test_values_cannot_inject_extra_query_parameters():
+    config = TrackerConfig(run_url_template=CUSTOM_RUN, project_url_template=None)
+
+    assert (
+        config.url(project="a&b=c", run_id="d e")
+        == "https://metrics.example.com/?project=a%26b%3Dc&run=d%20e"
+    )
+
+
+def test_group_is_substitutable():
+    config = TrackerConfig(
+        run_url_template="https://metrics.example.com/{group}/{run_id}",
+        project_url_template=None,
+    )
+
+    assert (
+        config.url(group="sweep", run_id="r") == "https://metrics.example.com/sweep/r"
+    )
+    assert config.url(run_id="r") is None  # missing group, no fallback configured
+
+
+# ── Partial configuration must not mix backends ─────────────────────────────
+
+
+def test_setting_one_template_disables_the_other_default(monkeypatch):
+    """Configuring one URL template must not leave the other pointing at wandb.ai:
+    a half-finished set of templates produces no link, never a mixed backend."""
+    monkeypatch.setenv(tracker_module.LABEL_ENV, "metrics")
+    monkeypatch.setenv(tracker_module.RUN_URL_TEMPLATE_ENV, CUSTOM_RUN)
+    tracker_module.tracker_config.cache_clear()
+
+    config = tracker_module.tracker_config()
+
+    assert config.project_url_template is None
+    assert config.url(entity="e", project="p", run_id="r").startswith(
+        "https://metrics.example.com/"
+    )
+    # Run id unknown: no project fallback rather than a wandb.ai link.
+    assert config.url(entity="e", project="p") is None
+
+
+def test_an_invalid_custom_template_disables_that_link_not_falls_back(monkeypatch):
+    monkeypatch.setenv(tracker_module.RUN_URL_TEMPLATE_ENV, "https://x.example/{oops}")
+    monkeypatch.setenv(tracker_module.PROJECT_URL_TEMPLATE_ENV, CUSTOM_PROJECT)
+    tracker_module.tracker_config.cache_clear()
+
+    config = tracker_module.tracker_config()
+
+    assert config.run_url_template is None
+    assert (
+        config.url(project="p", run_id="r") == "https://metrics.example.com/?project=p"
+    )
+
+
+def test_label_alone_renames_without_moving_the_links(monkeypatch):
+    monkeypatch.setenv(tracker_module.LABEL_ENV, "Internal W&B")
+    tracker_module.tracker_config.cache_clear()
+
+    config = tracker_module.tracker_config()
+
+    assert config.label == "Internal W&B"
+    assert config.run_url_template == tracker_module.DEFAULT_RUN_URL_TEMPLATE
+
+
+# ── Rejected templates ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("template", "why"),
+    [
+        ("https://x.example/{nope}", "unknown field"),
+        ("https://x.example/{project!r}", "conversion"),
+        ("https://x.example/{project:>8}", "format spec"),
+        ("https://x.example/{project:{group}}", "nested format spec"),
+        ("https://x.example/{}", "positional field"),
+        ("https://x.example/{unbalanced", "malformed"),
+        ("https://x.example/fixed", "no fields, so it can't identify a run"),
+        ("javascript:alert({project})", "non-http scheme"),
+        ("/relative/{project}", "no scheme"),
+        ("https://user@/{project}", "netloc but no host"),
+        # Run metadata must not be able to choose the link's host.
+        ("https://{project}/x", "templated host"),
+    ],
+)
+def test_unrenderable_templates_are_rejected_with_a_warning(
+    monkeypatch, capsys, template, why
+):
+    monkeypatch.setenv(tracker_module.RUN_URL_TEMPLATE_ENV, template)
+    tracker_module.tracker_config.cache_clear()
+
+    config = tracker_module.tracker_config()
+
+    assert config.run_url_template is None, why
+    assert "[tracker]" in capsys.readouterr().err
+
+
+def test_render_never_raises_even_if_a_template_slips_through():
+    """`url()` is called while building every run summary; the /api/runs route
+    turns any exception there into an empty run list."""
+    config = TrackerConfig(
+        run_url_template="https://x.example/{project!r}",
+        project_url_template="https://x.example/{project}",
+    )
+
+    assert config.url(entity="e", project="p", run_id="r") == "https://x.example/p"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"run_url_template": "https://metrics.example.com/runs/{run_id}"},
+        {"project_url_template": "https://metrics.example.com/{project}"},
+    ],
+)
+def test_both_templates_must_be_given_explicitly(kwargs):
+    """Neither template may default to wandb.ai: that would let a caller set one
+    and silently keep W&B's other half, which is the mixing tracker_config()
+    exists to prevent."""
+    with pytest.raises(TypeError):
+        TrackerConfig(**kwargs)


### PR DESCRIPTION
Run links are hardcoded to `wandb.ai`, so a stack logging through a
wandb-compatible client to trackio, MLflow or a self-hosted W&B gets working
metrics and dead links.

Links are already derived at read time from the `(entity, project, group,
run_id)` recorded per attempt, so this exposes the target as three env vars,
read from an optional `training-gym-tracker` Secret:

```
TRAINING_GYM_TRACKER_LABEL
TRAINING_GYM_TRACKER_RUN_URL_TEMPLATE
TRAINING_GYM_TRACKER_PROJECT_URL_TEMPLATE
```

Unset, the defaults reproduce today's wandb.ai URLs byte for byte (tested
against independently built URLs). Nothing is stored, so setting them relinks
runs recorded earlier too.

Templates are `str.format` over `{entity}`/`{project}`/`{group}`/`{run_id}`,
percent-encoded, rendering only when every field they name is non-empty — so the
project template is the fallback for a run with no id, and a backend without
entities just omits `{entity}`. Setting either template drops both wandb.ai
defaults rather than mixing backends; an unrenderable one warns and disables
only its own link. Rejected at parse: conversions, format specs,
positional/unknown fields, non-http(s) schemes, missing host, and `{}` in the
netloc — run metadata must not choose the link's host.

Also: `_config_summary` no longer derives a run id when the record has none.
Every launcher records the id it used, so a record without one predates that and
logged under an id wandb minted; the derived link 404s, the project link
resolves. Dead `training_run_id` parameter removed.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->