### PR TITLE
Name tracker runs after the training run

### DIFF
--- a/docs-next/src/content/docs/guides/tools/wandb-integration.md
+++ b/docs-next/src/content/docs/guides/tools/wandb-integration.md
@@ -78,14 +78,14 @@ fix — or to drop `wandb=` if you didn't want logging at all.
 
 ## How runs map to W&B runs
 
-Each training run gets an id like `tender-ranch-2275c004a3bf`; its W&B
-run id is the first 8 characters of that id, so runs are easy to
-correlate across the dashboard, W&B, and your terminal:
+Each training run gets an id like `tender-ranch-2275c004a3bf`, and that id
+is its W&B run id, so runs are easy to correlate across the dashboard,
+W&B, and your terminal:
 
-- First attempt → W&B run id `<first 8 chars of the run id>`.
+- First attempt → W&B run id `tender-ranch-2275c004a3bf`.
 - If a run is **preempted and retried**, attempt *N* logs to
-  `<first-8>-aN` with resume enabled, so each attempt's curves stay
-  separate but linked.
+  `tender-ranch-2275c004a3bf-aN` with resume enabled, so each attempt's
+  curves stay separate but linked.
 
 The dashboard records the entity, project, group, and run id for every
 attempt — the **W&B** button on a run's detail page (see the

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -438,8 +438,9 @@ def record_resume_checkpoint(
 
 
 def wandb_run_id_for_attempt(training_run_id: str, attempt_count: int) -> str:
-    base_run_id = training_run_id[:8]
-    return base_run_id if attempt_count <= 1 else f"{base_run_id}-a{attempt_count}"
+    return (
+        training_run_id if attempt_count <= 1 else f"{training_run_id}-a{attempt_count}"
+    )
 
 
 def record_wandb_attempt(

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -16,7 +16,7 @@ from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.ids import create_hash
 from modal_training_gym.common.models import ModelConfig
-from modal_training_gym.common.run import TrainingRun
+from modal_training_gym.common.run import TrainingRun, wandb_run_id_for_attempt
 from modal_training_gym.common.status import (
     FrameworkStatus,
     MilesStatus,
@@ -513,7 +513,7 @@ class TrainConfig:
                     "project": wandb.project,
                     "entity": getattr(wandb, "entity", ""),
                     "group": wandb.group,
-                    "run_id": training_run_id[:8],
+                    "run_id": wandb_run_id_for_attempt(training_run_id, 1),
                 }
                 if wandb
                 else {}

--- a/tests/test_readable_ids.py
+++ b/tests/test_readable_ids.py
@@ -103,3 +103,38 @@ def test_train_config_can_skip_model_recipe_merge() -> None:
     )._build_config_summary("brisk-river-deadbeef")
     assert unmerged["recipe"]["n_samples_per_prompt"] == 2
     assert unmerged["recipe"]["lr"] == 1e-6
+
+
+def test_the_wandb_run_id_is_the_whole_training_run_id() -> None:
+    """The same id is exported as WANDB_RUN_ID and recorded for the dashboard's
+    deep link, so the producer and the record have to agree on it, and it has to
+    stay distinguishing: WANDB_RESUME=allow turns a repeat into a resume of the
+    earlier run rather than a new one."""
+    from modal_training_gym.common.run import wandb_run_id_for_attempt
+    from modal_training_gym.common.wandb import WandbConfig
+
+    run_id = "electric-batter-6362579afd91"
+    assert wandb_run_id_for_attempt(run_id, 1) == run_id
+    assert wandb_run_id_for_attempt(run_id, 3) == f"{run_id}-a3"
+
+    summary = TrainConfig(
+        dataset=HuggingFaceDataset(
+            hf_repo="some/dataset", input_column="prompt", output_column="answer"
+        ),
+        model=Qwen3_4B(),
+        recipe=SlimeRecipe(
+            gpu_type="H100",
+            colocate=True,
+            tensor_model_parallel_size=1,
+            sequence_parallel=False,
+            rollout_num_gpus_per_engine=1,
+            num_rollout=1,
+            rollout_batch_size=16,
+            rollout_max_response_len=4096,
+            rollout_temperature=1.0,
+            save_interval=10,
+            wandb=WandbConfig(project="p", entity="e"),
+        ),
+    )._build_config_summary(run_id)
+
+    assert summary["wandb"]["run_id"] == run_id


### PR DESCRIPTION
`wandb_run_id_for_attempt()` returns `training_run_id[:8]`. W&B validates run
ids for charset only (`/\#?%:`) with no length cap, and these are `[a-z0-9-]`,
so pass the whole thing.

The full id travels better across wandb-compatible backends: W&B keeps a display
name separate from the id, so truncation only ever shows in its URLs, but
trackio and friends use the id *as* the run name.

It also removes a collision. A training run id is a random slug plus a 12-hex
digest (`create_hash`), so 8 characters is mostly slug and drops what
distinguishes two runs:

```
electric-batter-6362579afd91      -> electric
electrical-solution-5b54ee2f4ca8  -> electric
```

Over `randomname`'s vocabulary, 5000 ids give 4993 distinct slugs but only 2814
distinct 8-char prefixes — median 51 runs to a project's first collision. The
launchers export this as `WANDB_RUN_ID` with `WANDB_RESUME=allow`, so a
collision reads as a request to resume the earlier run.

Retries keep `-aN`. Ids are stored on the record at launch, so only new launches
change. Updates `docs-next/src/content/docs/guides/tools/wandb-integration.md`.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->