### PR TITLE
skip redundant megatron->hf conversions

### DIFF
--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-import json
 import os
 import time
 
@@ -20,6 +19,7 @@ from modal_training_gym.deploy_recipes import SglangRecipe, VllmRecipe
 
 
 _CHECKPOINTS_MOUNT_FALLBACK = "/checkpoints"
+_CONVERT_COMPLETE_MARKER = ".training_gym_convert_complete"
 
 
 class CheckpointType(Enum):
@@ -193,43 +193,7 @@ def convert_megatron_checkpoint_to_hf(
         if name:
             names.add(name)
 
-    if "config.json" in names:
-        shards = None
-        for index_name in (
-            "model.safetensors.index.json",
-            "pytorch_model.bin.index.json",
-        ):
-            if index_name in names:
-                index_path = f"{rel}/{index_name}" if rel else index_name
-                try:
-                    payload = json.loads(b"".join(volume.read_file(index_path)))
-                except (
-                    FileNotFoundError,
-                    NotFoundError,
-                    OSError,
-                    TypeError,
-                    UnicodeDecodeError,
-                    ValueError,
-                    json.JSONDecodeError,
-                ):
-                    payload = None
-                weight_map = (
-                    payload.get("weight_map") if isinstance(payload, dict) else None
-                )
-                shards = (
-                    {str(filename) for filename in weight_map.values()}
-                    if isinstance(weight_map, dict) and weight_map
-                    else set()
-                )
-                break
-        if shards is None:
-            ready = "model.safetensors" in names or "pytorch_model.bin" in names
-        else:
-            ready = bool(shards) and shards <= names
-    else:
-        ready = False
-
-    if ready:
+    if _CONVERT_COMPLETE_MARKER in names:
         return Checkpoint(
             checkpoint_type=CheckpointType.hf,
             name=os.path.basename(output_path.rstrip("/")),
@@ -312,6 +276,8 @@ def convert_megatron_checkpoint_to_hf(
         )
         print(f"Converting checkpoint for serving: {cmd}")
         subprocess.run(["bash", "-c", cmd], check=True)
+        with open(os.path.join(output_dir, _CONVERT_COMPLETE_MARKER), "w"):
+            pass
         checkpoints_volume.commit()
         return output_dir
 

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -7,6 +7,7 @@ from enum import Enum
 import os
 import time
 
+import modal
 from modal import Volume
 from modal.exception import NotFoundError
 
@@ -205,9 +206,6 @@ def convert_megatron_checkpoint_to_hf(
             checkpoints_mount_path=checkpoints_mount_path,
         )
 
-    import modal
-    from modal import App
-
     model_ref = model.model_name or model.model_path
     if model_ref in (None, ""):
         raise TrainingGymConfigError(
@@ -225,7 +223,7 @@ def convert_megatron_checkpoint_to_hf(
     image = _build_slime_base_image().add_local_python_source(
         "modal_training_gym", copy=True
     )
-    conversion_app = App("training-gym-checkpoint-convert")
+    conversion_app = modal.App("training-gym-checkpoint-convert")
     gpu_spec = _conversion_gpu_spec(checkpoint, recipe)
 
     @conversion_app.function(

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+import json
 import os
 import time
 
@@ -76,7 +77,7 @@ def _to_volume_path(checkpoint_dir: str, checkpoints_mount_path: str) -> str:
 
 def _list_checkpoints(train_result: "TrainResult") -> list[Checkpoint]:
     checkpoint_dir = train_result.checkpoint_dir.rstrip("/")
-    if not checkpoint_dir:
+    if checkpoint_dir == "":
         return []
 
     def _entry_name(entry: object) -> str:
@@ -121,21 +122,19 @@ def _list_checkpoints(train_result: "TrainResult") -> list[Checkpoint]:
         key=lambda entry: _entry_name(entry),
     ):
         name = _entry_name(entry)
-        if not name.startswith(prefix):
-            continue
-
-        checkpoints.append(
-            Checkpoint(
-                checkpoint_type=_checkpoint_type(name),
-                name=name,
-                path=os.path.join(checkpoint_dir, name),
-                timestamp=float(getattr(entry, "mtime", 0.0)),
-                training_run_id=train_result.training_run_id,
-                app_name=train_result.app_name,
-                checkpoints_volume_name=checkpoints_volume_name,
-                checkpoints_mount_path=checkpoints_mount_path,
+        if name.startswith(prefix):
+            checkpoints.append(
+                Checkpoint(
+                    checkpoint_type=_checkpoint_type(name),
+                    name=name,
+                    path=os.path.join(checkpoint_dir, name),
+                    timestamp=float(getattr(entry, "mtime", 0.0)),
+                    training_run_id=train_result.training_run_id,
+                    app_name=train_result.app_name,
+                    checkpoints_volume_name=checkpoints_volume_name,
+                    checkpoints_mount_path=checkpoints_mount_path,
+                )
             )
-        )
     return checkpoints
 
 
@@ -148,7 +147,7 @@ def _conversion_gpu_spec(
             training_run = TrainingRun.from_id(run_id)
         except KeyError:
             training_run = None
-        if training_run is not None:
+        if training_run:
             recipe_config = training_run.config.get("recipe", {})
             gpu_type = recipe_config.get("gpu_type")
             n_gpu = recipe_config.get("actor_num_gpus_per_node")
@@ -173,20 +172,80 @@ def convert_megatron_checkpoint_to_hf(
     if checkpoint.checkpoint_type == CheckpointType.hf:
         return checkpoint
 
-    import modal
-    from modal import App, Volume
-
     checkpoints_volume_name = checkpoint.checkpoints_volume_name
-    if not checkpoints_volume_name:
+    if checkpoints_volume_name in (None, ""):
         raise TrainingGymConfigError(
             "Cannot convert checkpoint without checkpoints volume metadata."
         )
     checkpoints_mount_path = (
         checkpoint.checkpoints_mount_path or _CHECKPOINTS_MOUNT_FALLBACK
     )
+    output_path = f"{checkpoint.path}_hf"
+    volume = Volume.from_name(checkpoints_volume_name, create_if_missing=True)
+    rel = _to_volume_path(output_path, checkpoints_mount_path)
+    try:
+        entries = list(volume.iterdir(rel or "/", recursive=False))
+    except (FileNotFoundError, NotFoundError):
+        entries = []
+    names: set[str] = set()
+    for entry in entries:
+        name = getattr(entry, "path", "").rstrip("/").rsplit("/", 1)[-1]
+        if name:
+            names.add(name)
+
+    if "config.json" in names:
+        shards = None
+        for index_name in (
+            "model.safetensors.index.json",
+            "pytorch_model.bin.index.json",
+        ):
+            if index_name in names:
+                index_path = f"{rel}/{index_name}" if rel else index_name
+                try:
+                    payload = json.loads(b"".join(volume.read_file(index_path)))
+                except (
+                    FileNotFoundError,
+                    NotFoundError,
+                    OSError,
+                    TypeError,
+                    UnicodeDecodeError,
+                    ValueError,
+                    json.JSONDecodeError,
+                ):
+                    payload = None
+                weight_map = (
+                    payload.get("weight_map") if isinstance(payload, dict) else None
+                )
+                shards = (
+                    {str(filename) for filename in weight_map.values()}
+                    if isinstance(weight_map, dict) and weight_map
+                    else set()
+                )
+                break
+        if shards is None:
+            ready = "model.safetensors" in names or "pytorch_model.bin" in names
+        else:
+            ready = bool(shards) and shards <= names
+    else:
+        ready = False
+
+    if ready:
+        return Checkpoint(
+            checkpoint_type=CheckpointType.hf,
+            name=os.path.basename(output_path.rstrip("/")),
+            path=output_path,
+            timestamp=checkpoint.timestamp,
+            training_run_id=checkpoint.training_run_id,
+            app_name=checkpoint.app_name,
+            checkpoints_volume_name=checkpoints_volume_name,
+            checkpoints_mount_path=checkpoints_mount_path,
+        )
+
+    import modal
+    from modal import App
 
     model_ref = model.model_name or model.model_path
-    if not model_ref:
+    if model_ref in (None, ""):
         raise TrainingGymConfigError(
             "Cannot convert a megatron checkpoint without model_name or model_path."
         )
@@ -239,10 +298,10 @@ def convert_megatron_checkpoint_to_hf(
         spec = importlib.util.find_spec(
             "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf"
         )
-        convert_script = spec.origin if spec is not None else None
-        if not convert_script:
+        convert_script = spec.origin if spec else None
+        if convert_script in (None, ""):
             raise RuntimeError(
-                "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf not found"
+                "modal_training_gym.frameworks.slime.modal_helpers.convert_torch_dist_to_hf is missing"
             )
         cmd = (
             f"python {convert_script} "
@@ -256,7 +315,6 @@ def convert_megatron_checkpoint_to_hf(
         checkpoints_volume.commit()
         return output_dir
 
-    output_path = f"{checkpoint.path}_hf"
     with modal.enable_output():
         with conversion_app.run():
             output_path = convert_megatron_to_hf.remote(

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -184,17 +184,14 @@ def convert_megatron_checkpoint_to_hf(
     output_path = f"{checkpoint.path}_hf"
     volume = Volume.from_name(checkpoints_volume_name, create_if_missing=True)
     rel = _to_volume_path(output_path, checkpoints_mount_path)
+    marker_rel = (
+        f"{rel}/{_CONVERT_COMPLETE_MARKER}" if rel else _CONVERT_COMPLETE_MARKER
+    )
     try:
-        entries = list(volume.iterdir(rel or "/", recursive=False))
+        b"".join(volume.read_file(marker_rel))
     except (FileNotFoundError, NotFoundError):
-        entries = []
-    names: set[str] = set()
-    for entry in entries:
-        name = getattr(entry, "path", "").rstrip("/").rsplit("/", 1)[-1]
-        if name:
-            names.add(name)
-
-    if _CONVERT_COMPLETE_MARKER in names:
+        pass
+    else:
         return Checkpoint(
             checkpoint_type=CheckpointType.hf,
             name=os.path.basename(output_path.rstrip("/")),

--- a/modal_training_gym/common/endpoint.py
+++ b/modal_training_gym/common/endpoint.py
@@ -165,12 +165,13 @@ class Endpoint:
         before creating. The default is ``False`` so existing callers keep a
         live endpoint.
 
+        Megatron training checkpoints are converted to Hugging Face format
+        before create. The conversion can take hours on large models, so we
+        skip if HF checkpoints are present.
+
         Returns once the endpoint has a URL, which may occur before it can serve
         traffic; call ``wait_until_ready()`` to wait for the model to become ready.
         Raises ``TimeoutError`` if no URL is published within ``wait_timeout_sec``.
-
-        Megatron training checkpoints are converted to Hugging Face format
-        before create.
         """
         if checkpoint:
             model_config = (

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -55,10 +55,12 @@ def test_convert_megatron_checkpoint_to_hf_returns_hf_checkpoints_unchanged() ->
     assert result is checkpoint
 
 
-def test_convert_reuses_a_complete_hf_sibling(monkeypatch) -> None:
+def test_convert_reuses_when_marker_present(monkeypatch) -> None:
     _patch_volume(
         monkeypatch,
-        _CheckpointVolume(["config.json", "model.safetensors"]),
+        _CheckpointVolume(
+            ["config.json", "model.safetensors", ".training_gym_convert_complete"]
+        ),
     )
 
     result = convert_megatron_checkpoint_to_hf(
@@ -70,8 +72,16 @@ def test_convert_reuses_a_complete_hf_sibling(monkeypatch) -> None:
     assert result.name == "iter_10_hf"
 
 
-def test_convert_runs_when_the_hf_sibling_is_incomplete(monkeypatch) -> None:
-    _patch_volume(monkeypatch, _CheckpointVolume(["config.json"]))
+@pytest.mark.parametrize(
+    "names",
+    [
+        [],
+        ["config.json", "model.safetensors"],
+    ],
+    ids=["missing", "unmarked"],
+)
+def test_convert_runs_without_marker(monkeypatch, names: list[str]) -> None:
+    _patch_volume(monkeypatch, _CheckpointVolume(names))
     monkeypatch.setattr(
         modal,
         "App",

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,9 +1,42 @@
+from types import SimpleNamespace
+
+import modal
+import pytest
+
+from modal_training_gym.common import checkpoint as checkpoint_mod
 from modal_training_gym.common.checkpoint import (
     Checkpoint,
     CheckpointType,
     convert_megatron_checkpoint_to_hf,
 )
 from modal_training_gym.common.models import ModelConfig
+
+
+class _CheckpointVolume:
+    def __init__(self, names: list[str]):
+        self.names = names
+
+    def iterdir(self, path: str, recursive: bool = False):
+        return [SimpleNamespace(path=name) for name in self.names]
+
+
+def _megatron_checkpoint() -> Checkpoint:
+    return Checkpoint(
+        checkpoint_type=CheckpointType.megatron,
+        name="iter_10",
+        path="/checkpoints/run/iter_10",
+        timestamp=1.0,
+        training_run_id="run",
+        app_name="app",
+        checkpoints_volume_name="gym-checkpoints",
+        checkpoints_mount_path="/checkpoints",
+    )
+
+
+def _patch_volume(monkeypatch, volume: _CheckpointVolume) -> None:
+    monkeypatch.setattr(
+        checkpoint_mod.Volume, "from_name", lambda *args, **kwargs: volume
+    )
 
 
 def test_convert_megatron_checkpoint_to_hf_returns_hf_checkpoints_unchanged() -> None:
@@ -20,3 +53,32 @@ def test_convert_megatron_checkpoint_to_hf_returns_hf_checkpoints_unchanged() ->
     )
 
     assert result is checkpoint
+
+
+def test_convert_reuses_a_complete_hf_sibling(monkeypatch) -> None:
+    _patch_volume(
+        monkeypatch,
+        _CheckpointVolume(["config.json", "model.safetensors"]),
+    )
+
+    result = convert_megatron_checkpoint_to_hf(
+        _megatron_checkpoint(), ModelConfig(model_name="Qwen/Qwen3-4B")
+    )
+
+    assert result.checkpoint_type is CheckpointType.hf
+    assert result.path == "/checkpoints/run/iter_10_hf"
+    assert result.name == "iter_10_hf"
+
+
+def test_convert_runs_when_the_hf_sibling_is_incomplete(monkeypatch) -> None:
+    _patch_volume(monkeypatch, _CheckpointVolume(["config.json"]))
+    monkeypatch.setattr(
+        modal,
+        "App",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("convert")),
+    )
+
+    with pytest.raises(RuntimeError, match="convert"):
+        convert_megatron_checkpoint_to_hf(
+            _megatron_checkpoint(), ModelConfig(model_name="Qwen/Qwen3-4B")
+        )

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import modal
 import pytest
 
@@ -16,8 +14,11 @@ class _CheckpointVolume:
     def __init__(self, names: list[str]):
         self.names = names
 
-    def iterdir(self, path: str, recursive: bool = False):
-        return [SimpleNamespace(path=name) for name in self.names]
+    def read_file(self, path: str):
+        name = path.rstrip("/").rsplit("/", 1)[-1]
+        if name not in self.names:
+            raise FileNotFoundError(path)
+        return []
 
 
 def _megatron_checkpoint() -> Checkpoint:


### PR DESCRIPTION
Skip `convert_megatron_checkpoint_to_hf` when HF dir already present.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->