### PR TITLE
dashboard: collapse thinking blocks by default in rollouts and evals

### DIFF
--- a/dashboards/frontend/src/components/ConversationView.svelte
+++ b/dashboards/frontend/src/components/ConversationView.svelte
@@ -248,6 +248,8 @@
     thinkingOpen = { ...thinkingOpen, [idx]: !thinkingOpen[idx] };
   }
 
+  let topThinkingOpen = $state(false);
+
   let checks = $derived.by(() => {
     if (!evalReport || typeof evalReport !== "object") return null;
     const c = evalReport.checks;
@@ -268,10 +270,13 @@
 <div class="flex flex-col gap-[2px]">
   {#if thinking}
     <div class="turn turn-thinking">
-      <div class="turn-header">
-        <span class="text-[10px] font-[600] uppercase tracking-[0.05em] p-[2px_6px] rounded-[3px] bg-[rgba(168,139,250,0.12)] text-[#a78bfa]">Thinking</span>
-      </div>
-      <pre class="thinking-block">{thinking}</pre>
+      <button class="inline-flex items-center gap-[4px] [background:none] [border:1px_solid_var(--border,#2f2f2f)] rounded-[4px] text-(--muted) text-[11px] p-[2px_8px] cursor-pointer hover:text-(--text) hover:[border-color:var(--border-strong,#4a4a4a)]" onclick={() => (topThinkingOpen = !topThinkingOpen)}>
+        <ChevronDown size={12} style={topThinkingOpen ? "transform:rotate(180deg)" : ""} />
+        <span>Thinking</span>
+      </button>
+      {#if topThinkingOpen}
+        <pre class="thinking-block mt-[6px]">{thinking}</pre>
+      {/if}
     </div>
   {/if}
 

--- a/dashboards/frontend/src/pages/EvalsPage.svelte
+++ b/dashboards/frontend/src/pages/EvalsPage.svelte
@@ -235,6 +235,7 @@
   let exampleSearch = $state("");
 
   let expandedExamples = $state(new Set());
+  let expandedThinking = $state(new Set());
 
   function scoreColor(score) {
     if (score >= 0.8) return "var(--color-c-green-80)";
@@ -253,6 +254,7 @@
     exampleSearch = "";
 
     expandedExamples = new Set();
+    expandedThinking = new Set();
     const evalId = run.eval.eval_id;
     if (evalId && fetchEvalDetail) {
       try {
@@ -274,6 +276,10 @@
 
   function toggleExample(index) {
     expandedExamples = toggleInSet(expandedExamples, index);
+  }
+
+  function toggleThinking(index) {
+    expandedThinking = toggleInSet(expandedThinking, index);
   }
 
   let drawerRows = $derived.by(() => {
@@ -729,8 +735,17 @@
                     {:else if row.parsed_response}
                       {#if row.parsed_response.thinking}
                         <div class="example-section">
-                          <span class="example-section-label">Thinking</span>
-                          <pre class="example-section-text text-(--muted)! [border:1px_solid_var(--color-c-gray-10,#2f2f2f)] [border-left:3px_solid_var(--color-c-orange-80,#f0a040)] bg-[rgba(240,160,64,0.06)]!">{row.parsed_response.thinking}</pre>
+                          <button class="inline-flex items-center gap-[4px] self-start [background:none] [border:1px_solid_var(--color-c-gray-10)] rounded-[4px] text-(--muted) text-[11px] p-[2px_8px] cursor-pointer [font:inherit] hover:text-(--text)" onclick={() => toggleThinking(row._index)}>
+                            {#if expandedThinking.has(row._index)}
+                              <ChevronDown size={12} />
+                            {:else}
+                              <ChevronRight size={12} />
+                            {/if}
+                            <span>Thinking</span>
+                          </button>
+                          {#if expandedThinking.has(row._index)}
+                            <pre class="example-section-text text-(--muted)! [border:1px_solid_var(--color-c-gray-10,#2f2f2f)] [border-left:3px_solid_var(--color-c-orange-80,#f0a040)] bg-[rgba(240,160,64,0.06)]!">{row.parsed_response.thinking}</pre>
+                          {/if}
                         </div>
                       {/if}
                       {#if row.parsed_response.content}


### PR DESCRIPTION
Thinking text no longer floods the conversation views. Two spots were rendering it always-expanded:

- `ConversationView.svelte`: the top-level `thinking` prop (rollout sample drawer in `TrainingRunDetailPage`) rendered as a bare `<pre>`. Now behind the same collapsed-by-default "Thinking" chevron toggle already used for per-message `msg.thinking`.
- `EvalsPage.svelte`: `row.parsed_response.thinking` in the examples drawer now uses a per-row chevron toggle (`expandedThinking` set, reset when a drawer opens), collapsed by default.

Per-message thinking inside `ConversationView` was already collapsed by default — unchanged.

Verified with `npm run build` in `dashboards/frontend`.

## Checklist

Not applicable — frontend dashboard change, no example added or modified.


Link to Devin session: https://modal.devinenterprise.com/sessions/610cf4217d134c3baafb4a1ae2266103
Requested by: @joyliu-q