### PR TITLE
miles libibverbs install

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -68,7 +68,7 @@ from modal_training_gym.frameworks.miles.modal_helpers.utils import (
 MILES_ROOT = "/root/miles"
 SYSTEM_LIB_DIR = "/usr/lib/x86_64-linux-gnu"
 # libibverbs and the libmlx5 provider come from incompatible rdma package versions for miles multi-node training
-# reinstalling fixes this issue, mooncake transferengine imports successfully 
+# reinstalling fixes this issue, mooncake transferengine imports successfully
 RDMA_RUNTIME_INSTALL_COMMAND = (
     "apt-get update && apt-get install -y --no-install-recommends "
     "--reinstall libibverbs1 ibverbs-providers && "

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -67,6 +67,11 @@ from modal_training_gym.frameworks.miles.modal_helpers.utils import (
 
 MILES_ROOT = "/root/miles"
 SYSTEM_LIB_DIR = "/usr/lib/x86_64-linux-gnu"
+RDMA_RUNTIME_INSTALL_COMMAND = (
+    "apt-get update && apt-get install -y --no-install-recommends "
+    "--reinstall libibverbs1 ibverbs-providers && "
+    "rm -rf /var/lib/apt/lists/*"
+)
 # v0.8.0+ makes per-task CPU/memory requests configurable via enforcement
 # policies ("limit"/"ignore"), letting sandboxes burst on Modal and bill by
 # actual CPU-/RAM-second usage instead of over-provisioning a static reservation.
@@ -95,6 +100,8 @@ def _build_miles_base_image(miles: MilesRecipe) -> Image:
             *_REPORTING_PATCH_COMMANDS,
         )
     )
+    if miles.total_nodes > 1:
+        image = image.run_commands(RDMA_RUNTIME_INSTALL_COMMAND)
     if miles.image_env:
         image = image.env(miles.image_env)
     return image

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -67,6 +67,8 @@ from modal_training_gym.frameworks.miles.modal_helpers.utils import (
 
 MILES_ROOT = "/root/miles"
 SYSTEM_LIB_DIR = "/usr/lib/x86_64-linux-gnu"
+# libibverbs and the libmlx5 provider come from incompatible rdma package versions for miles multi-node training
+# reinstalling fixes this issue, mooncake transferengine imports successfully 
 RDMA_RUNTIME_INSTALL_COMMAND = (
     "apt-get update && apt-get install -y --no-install-recommends "
     "--reinstall libibverbs1 ibverbs-providers && "

--- a/tests/test_miles_runtime_env.py
+++ b/tests/test_miles_runtime_env.py
@@ -2,7 +2,45 @@
 
 from __future__ import annotations
 
+from modal_training_gym.frameworks.miles import launcher
 from modal_training_gym.frameworks.miles.launcher import build_ray_runtime_env
+from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+
+
+class _FakeImage:
+    def __init__(self):
+        self.commands: list[str] = []
+
+    @classmethod
+    def from_registry(cls, _docker_image: str) -> "_FakeImage":
+        return cls()
+
+    def entrypoint(self, _entrypoint: list[str]) -> "_FakeImage":
+        return self
+
+    def run_commands(self, *commands: str) -> "_FakeImage":
+        self.commands.extend(commands)
+        return self
+
+    def env(self, _environment: dict[str, str]) -> "_FakeImage":
+        return self
+
+
+def test_multinode_image_reinstalls_matching_rdma_runtime(monkeypatch):
+    monkeypatch.setattr(launcher, "Image", _FakeImage)
+    recipe = MilesRecipe(colocate=False, rollout_num_gpus=8)
+
+    image = launcher._build_miles_base_image(recipe)
+
+    assert launcher.RDMA_RUNTIME_INSTALL_COMMAND in image.commands
+
+
+def test_single_node_image_keeps_base_rdma_runtime(monkeypatch):
+    monkeypatch.setattr(launcher, "Image", _FakeImage)
+
+    image = launcher._build_miles_base_image(MilesRecipe())
+
+    assert launcher.RDMA_RUNTIME_INSTALL_COMMAND not in image.commands
 
 
 def test_ld_library_path_comes_from_the_container(monkeypatch):


### PR DESCRIPTION
Miles multi-node runs under base radixark image runs into a rdma library mismatch error during mooncake transferengine import
```
ImportError: /usr/lib/x86_64-linux-gnu/libibverbs.so.1:
version `IBVERBS_PRIVATE_34' not found
(required by /usr/lib/x86_64-linux-gnu/libmlx5.so.1)
```

fix: reinstall matching RDMA runtime packages for multi-node miles runs, validated with 2-node run using MilesRecipe
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->