### PR TITLE
Render legacy-derived timings in the run timeline

### DIFF
--- a/dashboards/frontend/src/lib/timing.test.js
+++ b/dashboards/frontend/src/lib/timing.test.js
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { clipIdleSpans, nestedHitTargetsForRow, runTimeline } from "./timing.js";
+import {
+  clipIdleSpans,
+  nestedHitTargetsForRow,
+  runTimeline,
+  shouldShowTimingSection,
+} from "./timing.js";
 
 test("nested hit targets cover drawn bars without entering siblings", () => {
   const bars = [
@@ -156,4 +161,27 @@ test("empty packed rollout groups do not produce labelled rows", () => {
   assert.equal(rolloutRows.length, 1);
   assert.equal(rolloutRows[0].key, "rollout-0");
   assert.ok(rolloutRows[0].spans.some((span) => span.name === "generate_samples"));
+});
+
+test("legacy-derived timing lanes show the timing section", () => {
+  const timings = {
+    0: {
+      roles: {
+        driver: {
+          lane_start_unix_s: 100,
+          phases: {
+            train_models: {
+              count: 1,
+              busy_duration_s: 4,
+              first_start_s: 0,
+              last_end_s: 4,
+            },
+          },
+        },
+      },
+    },
+    metadata: { legacy_derived: true },
+  };
+
+  assert.equal(shouldShowTimingSection(timings), true);
 });

--- a/dashboards/frontend/src/lib/timing.test.js
+++ b/dashboards/frontend/src/lib/timing.test.js
@@ -1,12 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  clipIdleSpans,
-  nestedHitTargetsForRow,
-  runTimeline,
-  shouldShowTimingSection,
-} from "./timing.js";
+import { clipIdleSpans, nestedHitTargetsForRow, runTimeline } from "./timing.js";
 
 test("nested hit targets cover drawn bars without entering siblings", () => {
   const bars = [
@@ -161,27 +156,4 @@ test("empty packed rollout groups do not produce labelled rows", () => {
   assert.equal(rolloutRows.length, 1);
   assert.equal(rolloutRows[0].key, "rollout-0");
   assert.ok(rolloutRows[0].spans.some((span) => span.name === "generate_samples"));
-});
-
-test("legacy-derived timing lanes show the timing section", () => {
-  const timings = {
-    0: {
-      roles: {
-        driver: {
-          lane_start_unix_s: 100,
-          phases: {
-            train_models: {
-              count: 1,
-              busy_duration_s: 4,
-              first_start_s: 0,
-              last_end_s: 4,
-            },
-          },
-        },
-      },
-    },
-    metadata: { legacy_derived: true },
-  };
-
-  assert.equal(shouldShowTimingSection(timings), true);
 });

--- a/dashboards/frontend/src/lib/timing_vocabulary.js
+++ b/dashboards/frontend/src/lib/timing_vocabulary.js
@@ -204,7 +204,6 @@ export function rolloutIdForTimingKey(id) {
 }
 
 export function shouldShowTimingSection(timings) {
-  if (isLegacyTiming(timings)) return false;
   return (
     timings?.metadata?.timing_stale === true ||
     Object.entries(timings || {}).some(([id, value]) => {


### PR DESCRIPTION
## Summary

Runs whose only timing data lives in the legacy `step_times`/`substep_times` fields showed no Substep Timing section at all, even though the backend already converts them (`legacy_run_to_records`) and returns real per-phase lanes with `metadata.legacy_derived: true`. Cause was a one-line gate in `shouldShowTimingSection`:
 
Requested by: @cskitty