### PR TITLE
Show legacy-derived timings in the per-rollout view

### DIFF
--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -33,7 +33,6 @@
     updateTimingFailureState,
   } from "../lib/timing_retry.js";
   import {
-    isLegacyTiming,
     rolloutIdForTimingKey,
     shouldShowTimingSection,
     timingIsAsync,
@@ -681,7 +680,6 @@
 
   let runTimings = $state({});
   let runTimingsSerialized = $state("{}");
-  let legacyTiming = $derived(isLegacyTiming(runTimings));
   let showTimingSection = $derived(shouldShowTimingSection(runTimings));
   let timelineAsync = $derived(timingIsAsync(runTimings));
   let timelineRunOrigin = $derived(timingRunStart(runTimings));
@@ -1740,7 +1738,7 @@
                     {:else if !expandedRollout || !sampleDist}
                       <div class="detail-empty">No rollouts recorded.</div>
                     {:else}
-                      {#if runTimings[r.rollout_id] && !legacyTiming}
+                      {#if runTimings[r.rollout_id]}
                         <div class="rollout-chart">
                           <div class="rollout-chart-title">Substep timing</div>
                           <RunTimeline


### PR DESCRIPTION
Follow-up to #423, which ungated the top-level Substep Timing section for legacy-derived timings but left the per-rollout drill-in gated:

```svelte
{#if runTimings[r.rollout_id] && !legacyTiming}
```

Dropping `&& !legacyTiming` so expanding a rollout on an old run shows its timeline too. `legacyTiming` and the `isLegacyTiming` import are now unused in the page, so they go with it.

Note the legacy adapter (`legacy_run_to_records`) only emits a `driver` lane per step, so a legacy run's per-rollout timeline shows driver bars only — no rollout-worker lanes.


Link to Devin session: https://modal.devinenterprise.com/sessions/cfb9a04c825141d39ae7ab16ecc68462
Requested by: @cskitty