### PR TITLE
Repair summary drift incrementally instead of rebuilding the whole store

### DIFF
--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -158,6 +158,14 @@ def _store_path(store: MetadataStore | str) -> str:
     return store
 
 
+def _is_top_level_json_path(store: MetadataStore | str, path: str) -> bool:
+    prefix = f"{_store_path(store).rstrip('/')}/"
+    if not path.startswith(prefix):
+        return False
+    relative_path = path[len(prefix) :]
+    return relative_path.endswith(".json") and "/" not in relative_path
+
+
 async def bounded_gather_with_retries(
     readers: Iterable[Callable[[], Awaitable[T]]],
 ) -> list[T | BaseException]:
@@ -409,7 +417,7 @@ def _list_metadata_entries(
                     entries = [
                         _metadata_entry(entry)
                         async for entry in vol.iterdir.aio(_store_path(store))
-                        if entry.path.endswith(".json")
+                        if _is_top_level_json_path(store, entry.path)
                     ]
                     return entries, None
                 except (FileNotFoundError, NotFoundError):
@@ -428,7 +436,7 @@ def _list_metadata_entries(
             return [
                 _metadata_entry(entry)
                 for entry in vol.iterdir(_store_path(store))
-                if entry.path.endswith(".json")
+                if _is_top_level_json_path(store, entry.path)
             ], None
         except (FileNotFoundError, NotFoundError):
             return [], None
@@ -648,23 +656,17 @@ def vol_remove_keys_with_prefix(store: MetadataStore | str, prefix: str) -> int:
     return removed
 
 
+def vol_list_item_keys(store: MetadataStore | str) -> set[str] | None:
+    """List top-level canonical item keys without reading their payloads."""
+    entries, failure = _list_metadata_entries(store)
+    if failure is not None:
+        return None
+    return {entry["path"].rsplit("/", 1)[-1][: -len(".json")] for entry in entries}
+
+
 def vol_count_items(store: MetadataStore | str) -> int:
-    """Count canonical ``.json`` files in a store without reading them.
-
-    A single directory listing, used to cheaply detect a collapsed summary
-    (summary item count < canonical file count) before paying for a full
-    rebuild via ``vol_list``.
-    """
-    from modal.exception import NotFoundError
-
-    vol = _metadata_volume()
-    _safe_reload(vol)
-    try:
-        return sum(
-            1 for e in vol.iterdir(_store_path(store)) if e.path.endswith(".json")
-        )
-    except (FileNotFoundError, NotFoundError):
-        return 0
+    """Count canonical ``.json`` files in a store without reading them."""
+    return len(vol_list_item_keys(store) or ())
 
 
 def compact_summary_store(summary_store: MetadataStore) -> list[dict[str, Any]]:
@@ -680,20 +682,49 @@ def compact_summary_store(summary_store: MetadataStore) -> list[dict[str, Any]]:
 
 
 def vol_get_summary_items_healed(summary_store: MetadataStore) -> list[dict[str, Any]]:
-    """Read a summary, rebuilding from canonical files if it looks collapsed.
-
-    Self-heals the read path: if a racing writer clobbered the summary down to
-    fewer items than there are canonical files, rebuild from canonical instead
-    of surfacing the truncated list. The canonical count is a cheap one-op
-    directory listing, so the expensive rebuild only runs when actually needed.
-    """
+    """Read a summary and repair only its drift from canonical files."""
     items = vol_get_summary_items(summary_store) or []
     cfg = _SUMMARY_COMPACTION.get(summary_store)
     if cfg is None:
         return items
-    if vol_count_items(cfg.item_store) > len(items):
+
+    canonical_keys = vol_list_item_keys(cfg.item_store)
+    if not canonical_keys:
+        return items
+
+    summary_ids = {
+        item_id for item in items if (item_id := item.get(cfg.item_id_key)) is not None
+    }
+    missing_keys = canonical_keys - summary_ids
+    stale_ids = summary_ids - canonical_keys
+    if not missing_keys and not stale_ids:
+        return items
+
+    try:
+        entries = [
+            {"path": f"{_store_path(cfg.item_store)}/{key}.json"}
+            for key in missing_keys
+        ]
+        canonical_items, failure = _read_metadata_records(entries)
+        if failure is not None:
+            raise failure
+
+        items_by_id = {
+            item[cfg.item_id_key]: item
+            for item in items
+            if item.get(cfg.item_id_key) in canonical_keys
+        }
+        for item in canonical_items:
+            item_id = item.get(cfg.item_id_key)
+            if item_id in canonical_keys:
+                items_by_id[item_id] = {**items_by_id.get(item_id, {}), **item}
+
+        repaired_items = list(items_by_id.values())
+        repaired_items.sort(key=cfg.sort_key, reverse=cfg.reverse)
+        vol_put_summary_items(summary_store, repaired_items)
+        return repaired_items
+    except Exception:
         return compact_summary_store(summary_store)
-    return items
 
 
 def summary_items_from_payload(
@@ -904,6 +935,7 @@ __all__ = [
     "vol_get",
     "vol_list",
     "vol_list_prefix",
+    "vol_list_item_keys",
     "vol_count_items",
     "compact_summary_store",
     "vol_get_summary_items_healed",

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -20,6 +20,7 @@ from modal_training_gym.common import run as run_mod
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.train_result import TrainResult
 from modal_training_gym.common.training_rollout import TrainingRolloutResult
+from modal_training_gym.utils import metadata
 from modal_training_gym.utils.metadata import MetadataStore
 
 
@@ -69,6 +70,169 @@ def test_rollout_async_save_survives_unmounted_volume(fake_volume):
 def test_train_result_payload_is_json_serializable(fw):
     payload = TrainResult(app_name="a", framework=fw, training_run_id="t")._to_dict()
     assert json.loads(json.dumps(payload))["framework"] == fw.value
+
+
+def _put_json(fake_volume, path: str, payload: object) -> None:
+    fake_volume.files[path] = (json.dumps(payload) + "\n").encode()
+
+
+def test_summary_heal_reads_only_missing_canonical_items(fake_volume, monkeypatch):
+    canonical_store = MetadataStore.TRAINING_RUNS.value
+    summary_store = MetadataStore.TRAINING_RUNS_SUMMARY.value
+    for run_id in ("run-1", "run-2", "run-3"):
+        _put_json(
+            fake_volume,
+            f"{canonical_store}/{run_id}.json",
+            {"training_run_id": run_id, "created_at": 1},
+        )
+    _put_json(
+        fake_volume,
+        f"{summary_store}/summary.json",
+        {
+            "items": [
+                {"training_run_id": "run-1", "created_at": 1},
+                {"training_run_id": "run-2", "created_at": 1},
+            ]
+        },
+    )
+
+    read_paths: list[str] = []
+    original_read_file = fake_volume.read_file
+
+    def read_file(path: str):
+        read_paths.append(path)
+        return original_read_file(path)
+
+    monkeypatch.setattr(fake_volume, "read_file", read_file)
+    repaired = metadata.vol_get_summary_items_healed(
+        MetadataStore.TRAINING_RUNS_SUMMARY
+    )
+
+    assert {item["training_run_id"] for item in repaired} == {
+        "run-1",
+        "run-2",
+        "run-3",
+    }
+    assert [path for path in read_paths if path.startswith(f"{canonical_store}/")] == [
+        f"{canonical_store}/run-3.json"
+    ]
+
+
+def test_summary_heal_without_drift_reads_no_canonical_items(fake_volume, monkeypatch):
+    canonical_store = MetadataStore.TRAINING_RUNS.value
+    summary_store = MetadataStore.TRAINING_RUNS_SUMMARY.value
+    for run_id in ("run-1", "run-2"):
+        _put_json(
+            fake_volume,
+            f"{canonical_store}/{run_id}.json",
+            {"training_run_id": run_id, "created_at": 1},
+        )
+    _put_json(
+        fake_volume,
+        f"{summary_store}/summary.json",
+        {
+            "items": [
+                {"training_run_id": "run-1", "created_at": 1},
+                {"training_run_id": "run-2", "created_at": 1},
+            ]
+        },
+    )
+
+    read_paths: list[str] = []
+    original_read_file = fake_volume.read_file
+
+    def read_file(path: str):
+        read_paths.append(path)
+        return original_read_file(path)
+
+    monkeypatch.setattr(fake_volume, "read_file", read_file)
+    metadata.vol_get_summary_items_healed(MetadataStore.TRAINING_RUNS_SUMMARY)
+
+    assert not [path for path in read_paths if path.startswith(f"{canonical_store}/")]
+
+
+def test_summary_heal_drops_stale_summary_items(fake_volume):
+    canonical_store = MetadataStore.TRAINING_RUNS.value
+    summary_store = MetadataStore.TRAINING_RUNS_SUMMARY.value
+    _put_json(
+        fake_volume,
+        f"{canonical_store}/run-1.json",
+        {"training_run_id": "run-1", "created_at": 1},
+    )
+    _put_json(
+        fake_volume,
+        f"{summary_store}/summary.json",
+        {
+            "items": [
+                {"training_run_id": "run-1", "created_at": 1},
+                {"training_run_id": "gone", "created_at": 2},
+            ]
+        },
+    )
+
+    repaired = metadata.vol_get_summary_items_healed(
+        MetadataStore.TRAINING_RUNS_SUMMARY
+    )
+
+    assert repaired == [{"training_run_id": "run-1", "created_at": 1}]
+    stored = json.loads(fake_volume.files[f"{summary_store}/summary.json"])
+    assert stored["items"] == repaired
+
+
+@pytest.mark.parametrize("canonical_keys", [set(), None])
+def test_summary_heal_ignores_empty_or_failed_canonical_listing(
+    fake_volume, monkeypatch, canonical_keys
+):
+    summary_store = MetadataStore.TRAINING_RUNS_SUMMARY.value
+    original_summary = {"items": [{"training_run_id": "run-1", "created_at": 1}]}
+    _put_json(fake_volume, f"{summary_store}/summary.json", original_summary)
+    monkeypatch.setattr(metadata, "vol_list_item_keys", lambda _store: canonical_keys)
+    monkeypatch.setattr(
+        metadata,
+        "vol_put_summary_items",
+        lambda *_args, **_kwargs: pytest.fail("summary should not be rewritten"),
+    )
+
+    assert (
+        metadata.vol_get_summary_items_healed(MetadataStore.TRAINING_RUNS_SUMMARY)
+        == original_summary["items"]
+    )
+    assert (
+        json.loads(fake_volume.files[f"{summary_store}/summary.json"])
+        == original_summary
+    )
+
+
+def test_summary_heal_falls_back_to_compaction_on_incremental_failure(
+    fake_volume, monkeypatch
+):
+    canonical_store = MetadataStore.TRAINING_RUNS.value
+    summary_store = MetadataStore.TRAINING_RUNS_SUMMARY.value
+    for run_id in ("run-1", "run-2"):
+        _put_json(
+            fake_volume,
+            f"{canonical_store}/{run_id}.json",
+            {"training_run_id": run_id, "created_at": 1},
+        )
+    _put_json(
+        fake_volume,
+        f"{summary_store}/summary.json",
+        {"items": [{"training_run_id": "run-1", "created_at": 1}]},
+    )
+    fallback = [{"training_run_id": "from-compaction"}]
+    monkeypatch.setattr(
+        metadata,
+        "_read_metadata_records",
+        lambda _entries: ([], RuntimeError("read failed")),
+    )
+    monkeypatch.setattr(
+        metadata, "compact_summary_store", lambda _summary_store: fallback
+    )
+
+    assert (
+        metadata.vol_get_summary_items_healed(MetadataStore.TRAINING_RUNS_SUMMARY)
+        == fallback
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

`/api/runs` on the `melody-dev` dashboard returned HTTP 500 after 60s (`modal-http: internal error: Server has lost track of input`), which the UI renders as "0 runs". Cause: `vol_get_summary_items_healed` treated *any* canonical-vs-summary count mismatch as a collapsed summary and paid for a full rebuild:

```py
if vol_count_items(cfg.item_store) > len(items):
    return compact_summary_store(summary_store)   # reads EVERY canonical file
```

In that environment the summary is permanently a handful of items behind canonical (~1900 run files, 8.5MB `summary.json`, new runs written continuously so summary appends race and lose entries), so every request re-read ~1900 volume files — >600s when measured locally.

Now the heal diffs the canonical *key set* (same single `iterdir`, no payload reads — `vol_list_item_keys`, which `vol_count_items` is now built on) against the ids in the summary and only reads the files that are actually missing, drops summary entries whose canonical file is gone, re-sorts, and writes the repaired summary back. Cost is O(drift), not O(store). A genuinely collapsed summary degrades to the old cost, since every key is then missing. `compact_summary_store` is unchanged and still backs the 30-min cron plus the fallback if incremental repair raises.

Two safety properties, both covered by tests: an empty or failed canonical listing leaves the summary untouched (never interpreted as "everything was deleted"), and directory listings only count top-level `.json` entries, so stray subdirectories under a store (e.g. `training-runs/Qwen/`) are ignored as before.

`uv run pytest tests/test_metadata_persistence.py tests/test_dashboard_runs_route.py tests/test_run_summary.py tests/test_run_reconciler.py tests/test_reconcile.py` → 82 passed, 1 skipped; ruff check/format and `compileall` clean.

## Checklist

Not an example change — the example checklist below does not apply.


Link to Devin session: https://modal.devinenterprise.com/sessions/a673c0b937be444b9579a19360e4c314
Requested by: @cskitty