### PR TITLE
Reject launch() from inside a container before writing run metadata

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -627,6 +627,16 @@ class TrainConfig:
         """Start training in a detached Modal app and return immediately."""
         import modal
 
+        if not modal.is_local():
+            raise modal.exception.InvalidError(
+                "TrainConfig.launch() and train() must be called from a local "
+                "process because they open a detached Modal app, which cannot "
+                "be done from inside a container. Run the script locally and "
+                "guard module-scope launch code with "
+                '`if __name__ == "__main__":` so it does not execute when '
+                "imported inside a container."
+            )
+
         from modal_training_gym.common.config import (
             CONFIG_PATH,
             get_framework_status_url,

--- a/tests/test_train_checkpoint.py
+++ b/tests/test_train_checkpoint.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import inspect
+from unittest.mock import Mock
 
+import modal
 import pytest
 
 from modal_training_gym.common.checkpoint import Checkpoint, CheckpointType
@@ -110,3 +112,22 @@ def test_launchers_do_not_replace_model_path_with_checkpoint() -> None:
     assert "model.model_path = checkpoint.path" not in inspect.getsource(
         build_miles_app
     )
+
+
+def test_launch_rejects_container_before_persisting_run(monkeypatch) -> None:
+    config = _config(SlimeRecipe(**_RECIPE_KW), CheckpointType.megatron)
+    save = Mock()
+    vol_put = Mock()
+
+    monkeypatch.setattr(modal, "is_local", lambda: False)
+    monkeypatch.setattr("modal_training_gym.common.train.TrainingRun.save", save)
+    monkeypatch.setattr("modal_training_gym.common.train.vol_put", vol_put)
+
+    with pytest.raises(
+        modal.exception.InvalidError,
+        match="must be called from a local process",
+    ):
+        config.launch(show_output=False)
+
+    save.assert_not_called()
+    vol_put.assert_not_called()


### PR DESCRIPTION
`launch()` persists the `training-runs` record before it opens the app:

```python
run_record.save()                     # phantom record lands here
vol_put(MetadataStore.FRAMEWORK_STATUS_TOKENS, ...)
...
with app.run(detach=True):            # InvalidError: Can not run an app in
                                      # global scope within a container
```

So a `TrainConfig(...).train()` at module scope inside a container writes a run record, then dies on `app.run()`. Modal restarts the container, and the cycle repeats — this happened today in `melody-dev` from a `resume_from_checkpoint_run_override.py` running in-container: **1321 phantom runs** over 10h, each with an empty `modal_app_id`, stuck at "Initializing" until the 2h auto-cancel, drowning the dashboard run list.

This adds a `modal.is_local()` check as the first statement of `launch()`, so the failure happens before any id generation, dashboard bootstrap, metadata write or status token, and the error names the fix (run locally; guard module-scope launch code with `if __name__ == "__main__":`) instead of surfacing as a deserialization error deep in Modal's container entrypoint. `train()` goes through `launch()`, so one guard covers both.

## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
</body>
</invoke>


Link to Devin session: https://modal.devinenterprise.com/sessions/cfb9a04c825141d39ae7ab16ecc68462
Requested by: @cskitty