### PR TITLE
give docs page action buttons room under the fixed header

### DIFF
--- a/docs-next/src/styles/custom.css
+++ b/docs-next/src/styles/custom.css
@@ -76,12 +76,6 @@ body::before {
 }
 
 .header {
-  position: sticky;
-  top: 0;
-  z-index: var(--sl-z-index-navbar);
-}
-
-.header {
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
   border-bottom: 1px solid #2f2f2f;
@@ -678,7 +672,6 @@ body::before {
 
 @media (min-width: 72rem) {
   .tg-page-head__actions {
-    margin-top: -1.5rem;
     margin-bottom: 1.5rem;
   }
 }

--- a/docs-next/src/styles/custom.css
+++ b/docs-next/src/styles/custom.css
@@ -76,6 +76,12 @@ body::before {
 }
 
 .header {
+  position: sticky;
+  top: 0;
+  z-index: var(--sl-z-index-navbar);
+}
+
+.header {
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
   border-bottom: 1px solid #2f2f2f;


### PR DESCRIPTION
`.tg-page-head__actions` had `margin-top: -1.5rem` at ≥72rem, which cancelled the content panel's `1.5rem` top padding and left "Copy page" / "Open in Modal Notebook" / "View on GitHub" flush against the fixed header. Dropping the negative margin puts the buttons `24px` below the navbar — the same offset as the "On this page" heading in the right sidebar (`right-sidebar-panel` `1.25rem` + `sl-container` `0.25rem`), so the two now align exactly.

Starlight's fixed header is kept as-is (the earlier sticky-positioning experiment is not part of this PR anymore).

Verified at 1440px and 900px viewports; measured `actions.top - header.bottom == toc.top - header.bottom == 24px`.

![docs page with spacing above Copy page](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJjbGVyay1vcmdfMmZDNldVdEx4OWxOV1BWY1ZPdEVrWkVFVnF5IiwidXNlcl9pZCI6bnVsbCwiYnVja2V0X25hbWUiOiJkZXZpbmF0dGFjaG1lbnRzIiwiYnVja2V0X2tleSI6ImF0dGFjaG1lbnRzX3ByaXZhdGUvY2xlcmstb3JnXzJmQzZXVXRMeDlsTldQVmNWT3RFa1pFRVZxeS84ZjJiNmRkMi0yNTc1LTRlZDQtYTU5Yi02OTdmODNkMDI0YzEiLCJpYXQiOjE3ODcxNzE3OTYsImV4cCI6MTc4Nzc3NjU5NiwiZmlsZW5hbWUiOiJhZnRlci13aWRlLnBuZyJ9.rxH5OsXlyJQXKIJep1xbUCVcoCbSqV0Bmb7uy2ia0ys)

## Checklist

Not an example change (docs CSS only), so the example checklist does not apply.


Link to Devin session: https://modal.devinenterprise.com/sessions/47e35bd5716f46ec872baff797e19109
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->