### PR TITLE
Projector-only GLM-5.2 training on miles (frozen base, no LoRA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Models with a built-in training recipe, with the `ModelConfig` and recipe classe
 
 | Model | Framework | ModelConfig | Recipe |
 |---|---|---|---|
+| `Pinaster/GLM-5.2_5layer` | `miles` | `GLM_5_2_5Layer` | `GLM_5_2_5Layer_Projector_Recipe` |
 | `Qwen/Qwen3-0.6B` | `slime` | `Qwen3_0_6B` | `Qwen3_0_6b_Recipe` |
 | `Qwen/Qwen3-1.7B` | `slime` | `Qwen3_1_7B` | `Qwen3_1_7b_Recipe` |
 | `Qwen/Qwen3-4B` | `slime` | `Qwen3_4B` | `Qwen3_4b_Recipe` |
@@ -128,6 +129,7 @@ Models with a built-in training recipe, with the `ModelConfig` and recipe classe
 | `google/gemma-4-26B-A4B-it` | `miles` | `Gemma4_26B_A4B` | `Gemma4_26B_A4B_Recipe` |
 | `moonshotai/Moonlight-16B-A3B-Instruct` | `miles` | `Moonlight_16B_A3B_Instruct` | `Moonlight_16B_A3B_Recipe` |
 | `zai-org/GLM-4.7` | `slime` | `GLM_4_7` | `GLM_4_7_Recipe` |
+| `zai-org/GLM-5.2` | `miles` | `GLM_5_2` | `GLM_5_2_Projector_Recipe` |
 <!-- END MODELS TABLE -->
 
 ## Tutorials

--- a/docs-next/public/llms.txt
+++ b/docs-next/public/llms.txt
@@ -57,6 +57,7 @@ Repo: https://github.com/modal-projects/training-gym
 - [HuggingFaceDataset](https://gym.modal.dev/reference/core/huggingfacedataset/): `HuggingFaceDataset`
 - [HarborDataset](https://gym.modal.dev/reference/core/harbordataset/): `HarborDataset`
 - [EmbeddingProjectorDataset](https://gym.modal.dev/reference/core/embeddingprojectordataset/): `EmbeddingProjectorDataset`
+- [ProteinLocalizationDataset](https://gym.modal.dev/reference/core/proteinlocalizationdataset/): `ProteinLocalizationDataset`
 - [WandbConfig](https://gym.modal.dev/reference/core/wandbconfig/): `WandbConfig`
 - [ModalRayCluster](https://gym.modal.dev/reference/core/modalraycluster/): `ModalRayCluster`
 - [TrainResult](https://gym.modal.dev/reference/core/trainresult/): `TrainResult`
@@ -96,6 +97,7 @@ Repo: https://github.com/modal-projects/training-gym
 - [GLM_5_2_Projector_Recipe](https://gym.modal.dev/reference/training/glm_5_2_projector_recipe/): `GLM_5_2_Projector_Recipe`
 - [GLM_5_2_5Layer_Projector_Recipe](https://gym.modal.dev/reference/training/glm_5_2_5layer_projector_recipe/): `GLM_5_2_5Layer_Projector_Recipe`
 - [ProjectorSpec](https://gym.modal.dev/reference/training/projectorspec/): `ProjectorSpec`
+- [ProjectorEval](https://gym.modal.dev/reference/training/projectoreval/): `ProjectorEval`
 - [Qwen3_6_35b_Recipe](https://gym.modal.dev/reference/training/qwen3_6_35b_recipe/): `Qwen3_6_35b_Recipe`
 - [Qwen3_6_27b_Recipe](https://gym.modal.dev/reference/training/qwen3_6_27b_recipe/): `Qwen3_6_27b_Recipe`
 - [Qwen3_8_27b_Recipe](https://gym.modal.dev/reference/training/qwen3_8_27b_recipe/): `Qwen3_8_27b_Recipe`

--- a/docs-next/public/llms.txt
+++ b/docs-next/public/llms.txt
@@ -56,6 +56,7 @@ Repo: https://github.com/modal-projects/training-gym
 - [DatasetConfig](https://gym.modal.dev/reference/core/datasetconfig/): `DatasetConfig`
 - [HuggingFaceDataset](https://gym.modal.dev/reference/core/huggingfacedataset/): `HuggingFaceDataset`
 - [HarborDataset](https://gym.modal.dev/reference/core/harbordataset/): `HarborDataset`
+- [EmbeddingProjectorDataset](https://gym.modal.dev/reference/core/embeddingprojectordataset/): `EmbeddingProjectorDataset`
 - [WandbConfig](https://gym.modal.dev/reference/core/wandbconfig/): `WandbConfig`
 - [ModalRayCluster](https://gym.modal.dev/reference/core/modalraycluster/): `ModalRayCluster`
 - [TrainResult](https://gym.modal.dev/reference/core/trainresult/): `TrainResult`
@@ -76,6 +77,8 @@ Repo: https://github.com/modal-projects/training-gym
 - [Qwen3-30B-A3B](https://gym.modal.dev/reference/models/qwen3_30b/): `Qwen3_30B`
 - [Moonlight-16B-A3B-Instruct](https://gym.modal.dev/reference/models/moonlight_16b_a3b_instruct/): `Moonlight_16B_A3B_Instruct`
 - [Gemma-4-26B-A4B-it](https://gym.modal.dev/reference/models/gemma4_26b_a4b/): `Gemma4_26B_A4B`
+- [GLM-5.2](https://gym.modal.dev/reference/models/glm_5_2/): `GLM_5_2`
+- [GLM-5.2-5layer](https://gym.modal.dev/reference/models/glm_5_2_5layer/): `GLM_5_2_5Layer`
 - [Qwen3.6-35B-A3B](https://gym.modal.dev/reference/models/qwen3_6_35b/): `Qwen3_6_35B`
 - [Qwen3.6-27B](https://gym.modal.dev/reference/models/qwen3_6_27b/): `Qwen3_6_27B`
 - [Qwen3.8-27B](https://gym.modal.dev/reference/models/qwen3_8_27b/): `Qwen3_8_27B`
@@ -90,6 +93,9 @@ Repo: https://github.com/modal-projects/training-gym
 - [Qwen3_5_4b_Miles_Recipe](https://gym.modal.dev/reference/training/qwen3_5_4b_miles_recipe/): `Qwen3_5_4b_Miles_Recipe`
 - [Moonlight_16B_A3B_Recipe](https://gym.modal.dev/reference/training/moonlight_16b_a3b_recipe/): `Moonlight_16B_A3B_Recipe`
 - [Gemma4_26B_A4B_Recipe](https://gym.modal.dev/reference/training/gemma4_26b_a4b_recipe/): `Gemma4_26B_A4B_Recipe`
+- [GLM_5_2_Projector_Recipe](https://gym.modal.dev/reference/training/glm_5_2_projector_recipe/): `GLM_5_2_Projector_Recipe`
+- [GLM_5_2_5Layer_Projector_Recipe](https://gym.modal.dev/reference/training/glm_5_2_5layer_projector_recipe/): `GLM_5_2_5Layer_Projector_Recipe`
+- [ProjectorSpec](https://gym.modal.dev/reference/training/projectorspec/): `ProjectorSpec`
 - [Qwen3_6_35b_Recipe](https://gym.modal.dev/reference/training/qwen3_6_35b_recipe/): `Qwen3_6_35b_Recipe`
 - [Qwen3_6_27b_Recipe](https://gym.modal.dev/reference/training/qwen3_6_27b_recipe/): `Qwen3_6_27b_Recipe`
 - [Qwen3_8_27b_Recipe](https://gym.modal.dev/reference/training/qwen3_8_27b_recipe/): `Qwen3_8_27b_Recipe`

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -50,6 +50,14 @@ _EXPORTS = {
         "modal_training_gym.common.dataset",
         "EmbeddingProjectorDataset",
     ),
+    "ProteinLocalizationDataset": (
+        "modal_training_gym.common.dataset",
+        "ProteinLocalizationDataset",
+    ),
+    "ProjectorEval": (
+        "modal_training_gym.frameworks.miles.projector_eval",
+        "ProjectorEval",
+    ),
     "HFModelConfiguration": (
         "modal_training_gym.common.models",
         "HFModelConfiguration",
@@ -166,7 +174,9 @@ __all__ = [
     "GLM_5_2_Projector_Recipe",
     "GLM_5_2_5Layer_Projector_Recipe",
     "ProjectorSpec",
+    "ProjectorEval",
     "EmbeddingProjectorDataset",
+    "ProteinLocalizationDataset",
     "HarborDataset",
     "EvalConfig",
     "EvalConfigDurable",

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -32,6 +32,24 @@ _EXPORTS = {
         "Gemma4_26B_A4B_Recipe",
     ),
     "GLM_4_7": ("modal_training_gym.common.models", "GLM_4_7"),
+    "GLM_5_2": ("modal_training_gym.common.models", "GLM_5_2"),
+    "GLM_5_2_5Layer": ("modal_training_gym.common.models", "GLM_5_2_5Layer"),
+    "GLM_5_2_Projector_Recipe": (
+        "modal_training_gym.train_recipes.miles_recipe",
+        "GLM_5_2_Projector_Recipe",
+    ),
+    "GLM_5_2_5Layer_Projector_Recipe": (
+        "modal_training_gym.train_recipes.miles_recipe",
+        "GLM_5_2_5Layer_Projector_Recipe",
+    ),
+    "ProjectorSpec": (
+        "modal_training_gym.frameworks.miles.projector_config",
+        "ProjectorSpec",
+    ),
+    "EmbeddingProjectorDataset": (
+        "modal_training_gym.common.dataset",
+        "EmbeddingProjectorDataset",
+    ),
     "HFModelConfiguration": (
         "modal_training_gym.common.models",
         "HFModelConfiguration",
@@ -143,6 +161,12 @@ __all__ = [
     "Gemma4_26B_A4B",
     "Gemma4_26B_A4B_Recipe",
     "GLM_4_7",
+    "GLM_5_2",
+    "GLM_5_2_5Layer",
+    "GLM_5_2_Projector_Recipe",
+    "GLM_5_2_5Layer_Projector_Recipe",
+    "ProjectorSpec",
+    "EmbeddingProjectorDataset",
     "HarborDataset",
     "EvalConfig",
     "EvalConfigDurable",

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -714,9 +714,16 @@ class EmbeddingProjectorDataset(DatasetConfig):
         The rows are generated at prepare time from the seed rather than held in
         the instance: the dataset is cloudpickled into the container, and a
         thousand 1536-wide vectors do not belong in that payload.
+
+        ``always_prepare`` is on: the on-volume path is derived from the class
+        name, so without it a later run with a different row count or embedding
+        width would silently train on the file an earlier run left behind.
         """
         return cls(
-            synthetic_rows=n_rows, synthetic_input_dim=input_dim, synthetic_seed=seed
+            synthetic_rows=n_rows,
+            synthetic_input_dim=input_dim,
+            synthetic_seed=seed,
+            always_prepare=True,
         )
 
     def _synthetic_rows(self) -> list[dict[str, Any]]:

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -879,3 +879,173 @@ class EmbeddingProjectorDataset(DatasetConfig):
             with open(target, "w") as f:
                 for row in rows:
                     f.write(json.dumps(row) + "\n")
+
+
+#: DeepLocBinary annotates membrane vs soluble with single letters; spelled out
+#: so the target is a word the base model has a prior over.
+_DEEPLOC_BINARY_WORDS = {"M": "membrane", "S": "soluble"}
+
+
+class ProteinLocalizationDataset(EmbeddingProjectorDataset):
+    """Projector data from a real protein encoder: ESM-2 over DeepLoc.
+
+    The synthetic modes above answer "does anything reach the projector"; this
+    one is the task a projector-only run exists for. Each row is one protein:
+    the embedding is an ESM-2 encoding of its amino-acid sequence, the prompt
+    asks where the protein localizes, and the assistant turn is the compartment
+    DeepLoc annotates it with. Nothing about the answer is in the prompt — every
+    row's prompt is identical — so held-out accuracy is a statement about the
+    projector, in the same shape as the synthetic control but on data whose
+    structure the projector did not get handed.
+
+    The train and eval files come from DeepLoc's own disjoint splits, so the
+    eval set is held out by construction rather than by sampling; the encoder
+    runs at ``prepare()`` time on the CPU container that materializes the data,
+    which is why the default encoder is one of the small ESM-2 checkpoints.
+    Embedding width is the encoder's hidden size, and it has to match
+    ``ProjectorSpec.input_dim`` — ``prepare()`` fails loudly when it doesn't,
+    rather than leaving the rollout to raise once a cluster is already up.
+
+    Sequences are mean-pooled over residues into one vector per protein, which
+    is the standard way these encoders are consumed for whole-sequence
+    prediction and what makes a protein cost exactly one token here.
+    """
+
+    hf_repo: str = "AI4Protein/DeepLocMulti"
+    hf_config: str | None = None
+    train_split: str = "train"
+    eval_split: str = "test"
+    sequence_key: str = "aa_seq"
+    location_key: str = "location"
+    encoder_model: str = "facebook/esm2_t30_150M_UR50D"
+    # Width the projector is configured for; checked against the encoder's
+    # actual output at prepare() time.
+    input_dim: int = 640
+    prompt: str = (
+        "<protein> Which subcellular compartment does this protein localize to?"
+    )
+    train_rows: int = 512
+    eval_rows: int = 128
+    # Residues per protein handed to the encoder. DeepLoc sequences run to
+    # thousands; ESM-2's attention is quadratic and localization signal is
+    # concentrated in the terminal targeting peptides, so truncation is the
+    # normal treatment.
+    max_residues: int = 512
+    encoder_batch_size: int = 8
+    seed: int = 0
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("always_prepare", True)
+        super().__init__(**kwargs)
+
+    @property
+    def name(self) -> str:
+        return self.hf_repo
+
+    def _class_word(self, location: str) -> str:
+        """DeepLoc's location string as the words the model has to produce.
+
+        Multi-class labels arrive as ``"Endoplasmic.reticulum,M"`` (compartment,
+        then the membrane/soluble annotation); binary ones as bare ``"M"`` /
+        ``"S"``. Only the compartment is the target here.
+        """
+        head = str(location).split(",")[0].strip()
+        if head in _DEEPLOC_BINARY_WORDS:
+            return _DEEPLOC_BINARY_WORDS[head]
+        return head.replace(".", " ").replace("/", " or ").lower()
+
+    def _encode(self, sequences: list[str]) -> list[list[float]]:
+        import torch
+        from transformers import AutoModel, AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(self.encoder_model)
+        encoder = AutoModel.from_pretrained(self.encoder_model)
+        encoder.eval()
+
+        vectors: list[list[float]] = []
+        for start in range(0, len(sequences), self.encoder_batch_size):
+            batch = [
+                seq[: self.max_residues]
+                for seq in sequences[start : start + self.encoder_batch_size]
+            ]
+            tokens = tokenizer(
+                batch,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=self.max_residues + 2,
+            )
+            with torch.no_grad():
+                hidden = encoder(**tokens).last_hidden_state
+            mask = tokens["attention_mask"].unsqueeze(-1).to(hidden.dtype)
+            pooled = (hidden * mask).sum(dim=1) / mask.sum(dim=1)
+            vectors.extend(pooled.float().tolist())
+            print(
+                f"[{type(self).__name__}] encoded "
+                f"{min(start + self.encoder_batch_size, len(sequences))}"
+                f"/{len(sequences)} sequences",
+                flush=True,
+            )
+        return vectors
+
+    def _split_rows(self, split: str, n_rows: int) -> list[dict[str, Any]]:
+        from datasets import load_dataset
+
+        ds = load_dataset(self.hf_repo, self.hf_config, split=split)
+        # Shuffled before truncation: DeepLoc's files are grouped by
+        # compartment, so the first N rows of a split are one or two classes.
+        ds = ds.shuffle(seed=self.seed)
+        if n_rows:
+            ds = ds.select(range(min(n_rows, len(ds))))
+        records = [dict(row) for row in ds]
+        embeddings = self._encode([str(r[self.sequence_key]) for r in records])
+        width = len(embeddings[0]) if embeddings else 0
+        if width != self.input_dim:
+            raise TrainingGymConfigError(
+                f"{self.encoder_model} produces {width}-wide embeddings but "
+                f"{type(self).__name__}.input_dim is {self.input_dim}. Set both "
+                "this and the recipe's ProjectorSpec.input_dim to the encoder's "
+                "hidden size; the projector's first Linear is built from it."
+            )
+        return [
+            {
+                "messages": [
+                    {"role": "user", "content": self.prompt},
+                    {
+                        "role": "assistant",
+                        "content": self._class_word(record[self.location_key]),
+                    },
+                ],
+                "embeddings": [vector],
+                # Position 1 of the row's own tokens, as with the synthetic
+                # modes: the merge overwrites that token's embedding with the
+                # projected protein, and the prompt carries no answer either
+                # way.
+                "positions": [1],
+                "label": self._class_word(record[self.location_key]),
+            }
+            for record, vector in zip(records, embeddings)
+        ]
+
+    def prepare(self, path: str, eval_paths: dict[str, str] | None = None) -> None:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._write_split(path, self._split_rows(self.train_split, self.train_rows))
+        for eval_path in (eval_paths or {}).values():
+            Path(eval_path).parent.mkdir(parents=True, exist_ok=True)
+            self._write_split(
+                eval_path, self._split_rows(self.eval_split, self.eval_rows)
+            )
+
+    def _write_split(self, target: str, rows: list[dict[str, Any]]) -> None:
+        counts: dict[str, int] = {}
+        with open(target, "w") as f:
+            for row in rows:
+                counts[row["label"]] = counts.get(row["label"], 0) + 1
+                f.write(json.dumps(self._to_row(row)) + "\n")
+        majority = max(counts.values()) / len(rows) if rows else 0.0
+        print(
+            f"[{type(self).__name__}] wrote {len(rows)} rows to {target}; "
+            f"class counts {dict(sorted(counts.items()))}; "
+            f"majority-class share {majority:.3f}",
+            flush=True,
+        )

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -631,3 +631,131 @@ class MultimodalDataset(DatasetConfig):
         if eval_paths:
             for eval_path in eval_paths.values():
                 self._write_jsonl(rows, eval_path)
+
+
+class EmbeddingProjectorDataset(DatasetConfig):
+    """Supervised dataset for projector training: messages plus token embeddings.
+
+    Each row is a chat conversation together with the embeddings an external
+    encoder produced and the token positions they occupy::
+
+        EmbeddingProjectorDataset(
+            rows=[
+                {
+                    "messages": [
+                        {"role": "user", "content": "<emb> what does this bind?"},
+                        {"role": "assistant", "content": "..."},
+                    ],
+                    "embeddings": [[0.1, ...], [0.2, ...]],  # [n_tokens, input_dim]
+                    "positions": [3, 4],                     # positions in the token ids
+                },
+            ]
+        )
+
+    The embeddings ride in the ``metadata`` column, which miles carries onto
+    ``Sample.metadata`` untouched, and the projector rollout function turns them
+    into the tensors the model's forward takes. Positions index the row's own
+    token sequence; miles offsets them when it packs samples together.
+
+    Targets come from the conversation itself, so ``label_key`` holds nothing a
+    reward function would read — supervised training has no reward — but the
+    column exists because the loaders index it.
+    """
+
+    input_key: str = "messages"
+    label_key: str = "label"
+    embeddings_key: str = "projector_embeddings"
+    positions_key: str = "projector_positions"
+    output_format: str = "jsonl"
+    # The conversation reaches miles as a list of messages, which the loss-mask
+    # generator needs; a rendered string would leave it nothing to split on.
+    apply_chat_template: bool = False
+    # Synthetic rows are described, not stored: see ``synthetic()``.
+    synthetic_rows: int = 0
+    synthetic_input_dim: int = 0
+    synthetic_seed: int = 0
+
+    def __init__(self, rows: list[dict[str, Any]] | None = None, **kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        self._rows = list(rows or [])
+        if not self.dataset_id:
+            self.dataset_id = f"projector-{uuid.uuid4()}"
+        self._validate()
+        for row in self._rows:
+            self._check_row(row)
+
+    @staticmethod
+    def _check_row(row: dict[str, Any]) -> None:
+        embeddings, positions = row.get("embeddings"), row.get("positions")
+        if embeddings is None or positions is None:
+            raise TrainingGymConfigError(
+                "each EmbeddingProjectorDataset row needs 'embeddings' and "
+                f"'positions'; got keys {sorted(row)}"
+            )
+        if len(embeddings) != len(positions):
+            raise TrainingGymConfigError(
+                f"{len(embeddings)} embedding row(s) for {len(positions)} "
+                "position(s): every embedding occupies exactly one token"
+            )
+
+    @classmethod
+    def synthetic(
+        cls, n_rows: int, input_dim: int, seed: int = 0
+    ) -> "EmbeddingProjectorDataset":
+        """Random embeddings on a fixed conversation, for wiring validation.
+
+        A projector-only run needs an encoder's embeddings, and no public dataset
+        ships them, so a smoke test that only has to prove the plumbing (data →
+        rollout → forward → loss → projector gradient) generates them. Loss goes
+        down on noise no more than it should — read this as a wiring check, not a
+        learning curve.
+
+        The rows are generated at prepare time from the seed rather than held in
+        the instance: the dataset is cloudpickled into the container, and a
+        thousand 1536-wide vectors do not belong in that payload.
+        """
+        return cls(
+            synthetic_rows=n_rows, synthetic_input_dim=input_dim, synthetic_seed=seed
+        )
+
+    def _synthetic_rows(self) -> list[dict[str, Any]]:
+        rng = random.Random(self.synthetic_seed)
+        return [
+            {
+                "messages": [
+                    {"role": "user", "content": f"<emb> describe sample {i}."},
+                    {"role": "assistant", "content": f"Sample {i} is a placeholder."},
+                ],
+                "embeddings": [
+                    [rng.gauss(0.0, 1.0) for _ in range(self.synthetic_input_dim)]
+                ],
+                "positions": [1],
+            }
+            for i in range(self.synthetic_rows)
+        ]
+
+    @property
+    def rows(self) -> list[DatasetRow]:
+        return self._rows or self._synthetic_rows()
+
+    def _to_row(self, r: dict[str, Any]) -> DatasetRow:
+        return {
+            self.input_key: r["messages"],
+            self.label_key: r.get("label", ""),
+            "metadata": {
+                self.embeddings_key: [list(e) for e in r["embeddings"]],
+                self.positions_key: [int(p) for p in r["positions"]],
+            },
+        }
+
+    def load(self) -> list[DatasetRow]:
+        return [self._to_row(r) for r in self.rows]
+
+    def prepare(self, path: str, eval_paths: dict[str, str] | None = None) -> None:
+        rows = self.load()
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        for target in [path, *(eval_paths or {}).values()]:
+            with open(target, "w") as f:
+                for row in rows:
+                    f.write(json.dumps(row) + "\n")

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -674,7 +674,7 @@ class EmbeddingProjectorDataset(DatasetConfig):
     synthetic_rows: int = 0
     synthetic_input_dim: int = 0
     synthetic_seed: int = 0
-    synthetic_tokens: int = 1600
+    synthetic_tokens: int = 512
 
     def __init__(self, rows: list[dict[str, Any]] | None = None, **kwargs: Any) -> None:
         for k, v in kwargs.items():
@@ -702,7 +702,7 @@ class EmbeddingProjectorDataset(DatasetConfig):
 
     @classmethod
     def synthetic(
-        cls, n_rows: int, input_dim: int, seed: int = 0, tokens: int = 1600
+        cls, n_rows: int, input_dim: int, seed: int = 0, tokens: int = 512
     ) -> "EmbeddingProjectorDataset":
         """Random embeddings on a fixed conversation, for wiring validation.
 
@@ -720,10 +720,15 @@ class EmbeddingProjectorDataset(DatasetConfig):
         name, so without it a later run with a different row count or embedding
         width would silently train on the file an earlier run left behind.
 
-        ``tokens`` is a rough per-sample length, long by default so a
-        validation step exercises a sequence a real projector run would see —
-        a two-sentence conversation is a few dozen tokens, well under the
-        sparse-attention regime a DSA model like GLM-5.2 trains in.
+        ``tokens`` is a *word* budget, not a token count, and the filler words
+        are worth ~2.7 GLM tokens each: measured on the pinned image,
+        ``tokens=1600`` produced 4298-token samples, past the GLM-5.2 recipe's
+        4096 ``seq_length`` and ``max_position_embeddings``. It is long enough
+        to exercise a real sequence (a two-sentence conversation is a few dozen
+        tokens, nothing like what a projector run sees) and, at the default,
+        short enough to stay inside that window with room for the chat
+        template. Raising it is a request to check the model's ``seq_length``
+        first.
         """
         return cls(
             synthetic_rows=n_rows,
@@ -735,8 +740,8 @@ class EmbeddingProjectorDataset(DatasetConfig):
 
     def _synthetic_rows(self) -> list[dict[str, Any]]:
         rng = random.Random(self.synthetic_seed)
-        # ~1 token per word, split so both the prompt and the response the loss
-        # is taken over are long.
+        # Split so both the prompt and the response the loss is taken over are
+        # long. See ``synthetic()`` for what a word costs in tokens.
         filler = " ".join(
             f"token{n}" for n in range(max(self.synthetic_tokens, 8) // 2)
         )

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -675,6 +675,9 @@ class EmbeddingProjectorDataset(DatasetConfig):
     synthetic_input_dim: int = 0
     synthetic_seed: int = 0
     synthetic_tokens: int = 512
+    # Labelled synthetic mode: see ``synthetic_classification()``.
+    synthetic_classes: int = 0
+    synthetic_zero_embeddings: bool = False
 
     def __init__(self, rows: list[dict[str, Any]] | None = None, **kwargs: Any) -> None:
         for k, v in kwargs.items():
@@ -738,7 +741,91 @@ class EmbeddingProjectorDataset(DatasetConfig):
             always_prepare=True,
         )
 
+    @classmethod
+    def synthetic_classification(
+        cls,
+        n_rows: int,
+        input_dim: int,
+        n_classes: int = 4,
+        zero_embeddings: bool = False,
+        seed: int = 0,
+    ) -> "EmbeddingProjectorDataset":
+        """A task whose answer is *only* in the embedding, to measure learning.
+
+        ``synthetic()`` proves the wiring; its targets are predictable from the
+        prompt, so a falling loss there says nothing about the projector. Here
+        every row carries the same prompt and one of ``n_classes`` fixed random
+        vectors, and the assistant turn is that class's word: the only path from
+        input to target runs through the projector, so loss falling below the
+        entropy of the class prior is the projector carrying information through
+        the frozen base.
+
+        ``zero_embeddings=True`` is the control — the same run with the
+        information deleted. Its curve is what "no learning" looks like on this
+        task, and a trained curve that does not separate from it means the
+        projector is not being used, however healthy the gradients look.
+
+        Rows are generated at prepare time from the seed, like ``synthetic()``:
+        ``n_classes`` vectors of a few thousand floats do not fit in the
+        cloudpickled closure Modal accepts (64 KiB).
+        """
+        return cls(
+            synthetic_rows=n_rows,
+            synthetic_input_dim=input_dim,
+            synthetic_classes=n_classes,
+            synthetic_zero_embeddings=zero_embeddings,
+            synthetic_seed=seed,
+            always_prepare=True,
+        )
+
+    # Short, single-token-ish words so the loss concentrates on the one
+    # decision the embedding determines.
+    _CLASS_WORDS = (
+        "alpha",
+        "bravo",
+        "charlie",
+        "delta",
+        "echo",
+        "foxtrot",
+        "golf",
+        "hotel",
+    )
+
+    def _classification_rows(self) -> list[dict[str, Any]]:
+        n_classes = self.synthetic_classes
+        if n_classes > len(self._CLASS_WORDS):
+            raise TrainingGymConfigError(
+                f"synthetic_classes={n_classes} exceeds the "
+                f"{len(self._CLASS_WORDS)} class words available"
+            )
+        rng = random.Random(self.synthetic_seed)
+        vectors = [
+            [rng.gauss(0.0, 1.0) for _ in range(self.synthetic_input_dim)]
+            for _ in range(n_classes)
+        ]
+        zero = [0.0] * self.synthetic_input_dim
+        rows = []
+        for i in range(self.synthetic_rows):
+            label = i % n_classes
+            rows.append(
+                {
+                    "messages": [
+                        # Identical for every row on purpose: the prompt holds
+                        # no information about the answer.
+                        {"role": "user", "content": "<emb> name it."},
+                        {"role": "assistant", "content": self._CLASS_WORDS[label]},
+                    ],
+                    "embeddings": [
+                        zero if self.synthetic_zero_embeddings else vectors[label]
+                    ],
+                    "positions": [1],
+                }
+            )
+        return rows
+
     def _synthetic_rows(self) -> list[dict[str, Any]]:
+        if self.synthetic_classes:
+            return self._classification_rows()
         rng = random.Random(self.synthetic_seed)
         # Split so both the prompt and the response the loss is taken over are
         # long. See ``synthetic()`` for what a word costs in tokens.

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -674,6 +674,7 @@ class EmbeddingProjectorDataset(DatasetConfig):
     synthetic_rows: int = 0
     synthetic_input_dim: int = 0
     synthetic_seed: int = 0
+    synthetic_tokens: int = 1600
 
     def __init__(self, rows: list[dict[str, Any]] | None = None, **kwargs: Any) -> None:
         for k, v in kwargs.items():
@@ -701,7 +702,7 @@ class EmbeddingProjectorDataset(DatasetConfig):
 
     @classmethod
     def synthetic(
-        cls, n_rows: int, input_dim: int, seed: int = 0
+        cls, n_rows: int, input_dim: int, seed: int = 0, tokens: int = 1600
     ) -> "EmbeddingProjectorDataset":
         """Random embeddings on a fixed conversation, for wiring validation.
 
@@ -718,21 +719,38 @@ class EmbeddingProjectorDataset(DatasetConfig):
         ``always_prepare`` is on: the on-volume path is derived from the class
         name, so without it a later run with a different row count or embedding
         width would silently train on the file an earlier run left behind.
+
+        ``tokens`` is a rough per-sample length, long by default so a
+        validation step exercises a sequence a real projector run would see —
+        a two-sentence conversation is a few dozen tokens, well under the
+        sparse-attention regime a DSA model like GLM-5.2 trains in.
         """
         return cls(
             synthetic_rows=n_rows,
             synthetic_input_dim=input_dim,
             synthetic_seed=seed,
+            synthetic_tokens=tokens,
             always_prepare=True,
         )
 
     def _synthetic_rows(self) -> list[dict[str, Any]]:
         rng = random.Random(self.synthetic_seed)
+        # ~1 token per word, split so both the prompt and the response the loss
+        # is taken over are long.
+        filler = " ".join(
+            f"token{n}" for n in range(max(self.synthetic_tokens, 8) // 2)
+        )
         return [
             {
                 "messages": [
-                    {"role": "user", "content": f"<emb> describe sample {i}."},
-                    {"role": "assistant", "content": f"Sample {i} is a placeholder."},
+                    {
+                        "role": "user",
+                        "content": f"<emb> describe sample {i}. {filler}",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": f"Sample {i} is a placeholder. {filler}",
+                    },
                 ],
                 "embeddings": [
                     [rng.gauss(0.0, 1.0) for _ in range(self.synthetic_input_dim)]
@@ -751,7 +769,10 @@ class EmbeddingProjectorDataset(DatasetConfig):
             self.input_key: r["messages"],
             self.label_key: r.get("label", ""),
             "metadata": {
-                self.embeddings_key: [list(e) for e in r["embeddings"]],
+                # Normalized element-wise: encoder output arrives as a numpy
+                # array or a torch tensor as often as a list, and neither's
+                # scalars are JSON-serializable.
+                self.embeddings_key: [[float(v) for v in e] for e in r["embeddings"]],
                 self.positions_key: [int(p) for p in r["positions"]],
             },
         }

--- a/modal_training_gym/common/models/__init__.py
+++ b/modal_training_gym/common/models/__init__.py
@@ -11,6 +11,7 @@ from .base import (
 )
 from .gemma4_26b_a4b import Gemma4_26B_A4B
 from .glm_4_7 import GLM_4_7
+from .glm_5_2 import GLM_5_2, GLM_5_2_5Layer
 from .moonlight_16b_a3b_instruct import Moonlight_16B_A3B_Instruct
 from .qwen3_0_6b import Qwen3_0_6B
 from .qwen3_1_7b import Qwen3_1_7B
@@ -34,6 +35,8 @@ __all__ = [
     "ParsedResponse",
     "Gemma4_26B_A4B",
     "GLM_4_7",
+    "GLM_5_2",
+    "GLM_5_2_5Layer",
     "Qwen3_0_6B",
     "Qwen3_1_7B",
     "Qwen3_4B",

--- a/modal_training_gym/common/models/glm_5_2.py
+++ b/modal_training_gym/common/models/glm_5_2.py
@@ -1,0 +1,32 @@
+"""GLM-5.2 (744B-A40B MoE, DSA attention) model specs."""
+
+from .base import HFModelConfiguration, parse_glm_response
+
+
+class GLM_5_2(HFModelConfiguration):
+    """GLM-5.2 (744B total, ~40B active) MoE model from Z.ai.
+
+    256 routed experts + 1 shared expert, 8 active per token, the first 3
+    layers dense, and DeepSeek-style sparse attention (``glm_moe_dsa``) with
+    a cross-layer index. ``architecture`` is left unset: the Megatron args
+    live in miles' own ``scripts/models/glm5.2-744B-A40B.py`` (selected by
+    ``miles_model_name`` on the recipe), because the DSA spec, the indexer
+    and the MoE routing are not representable in ``ModelArchitecture``.
+    """
+
+    response_parser = staticmethod(parse_glm_response)
+
+    model_name = "zai-org/GLM-5.2"
+
+
+class GLM_5_2_5Layer(HFModelConfiguration):
+    """5-layer pruned GLM-5.2, upstream's single-node smoke-test checkpoint.
+
+    Same config family as :class:`GLM_5_2` (``glm_moe_dsa``, 256 experts) with
+    the decoder truncated to 5 layers, so a full train step fits on one node.
+    Outputs are meaningless — it exists to exercise plumbing, not quality.
+    """
+
+    response_parser = staticmethod(parse_glm_response)
+
+    model_name = "Pinaster/GLM-5.2_5layer"

--- a/modal_training_gym/common/models/validation.py
+++ b/modal_training_gym/common/models/validation.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from ..framework import Framework
 from .base import ModelConfig
 from .gemma4_26b_a4b import Gemma4_26B_A4B
+from .glm_5_2 import GLM_5_2, GLM_5_2_5Layer
 from .moonlight_16b_a3b_instruct import Moonlight_16B_A3B_Instruct
 from .qwen3_0_6b import Qwen3_0_6B
 from .qwen3_1_7b import Qwen3_1_7B
@@ -107,4 +108,14 @@ VALIDATION_CONFIGS: set[_ValidationConfig] = {
     _ValidationConfig(
         "Gemma-4-26B-A4B-it", Gemma4_26B_A4B, Framework.MILES, run_on_pr=False
     ),
+    # Projector-only GLM-5.2: the 5-layer checkpoint is the single-node shape
+    # upstream smoke-tests on, the full model is 8 nodes. Neither fans out on a
+    # PR — dispatch them by name.
+    _ValidationConfig(
+        "GLM-5.2-5layer-Projector",
+        GLM_5_2_5Layer,
+        Framework.MILES,
+        run_on_pr=False,
+    ),
+    _ValidationConfig("GLM-5.2-Projector", GLM_5_2, Framework.MILES, run_on_pr=False),
 }

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -282,6 +282,39 @@ def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) ->
     return reduced
 
 
+_grads_logged: set[str] = set()
+
+
+def log_incoming_grad(tensor: torch.Tensor, name: str) -> torch.Tensor:
+    """Log the first gradient that reaches ``tensor``, once per ``name``.
+
+    A projector-only run detects nothing but the projector's own gradients:
+    Megatron's grad-norm check covers the DDP buckets, and with the base frozen
+    the only bucket is the projector's. So a base whose backward hands the
+    embedding stream an ``inf`` (bf16 overflow) or a NaN is reported as *the
+    projector's* NaN, with nothing to distinguish it from the projector itself
+    producing one. Logging what arrives at the merge separates the two, and one
+    line per tensor per process is not worth gating behind a flag.
+    """
+    if not tensor.requires_grad or name in _grads_logged:
+        return tensor
+    _grads_logged.add(name)
+
+    def _log(grad: torch.Tensor) -> None:
+        detached = grad.detach().float()
+        logger.info(
+            "projector backward: grad into %s rms=%.6g absmax=%.6g nan=%d inf=%d",
+            name,
+            float(detached.pow(2).mean().sqrt()),
+            float(detached.abs().max()),
+            int(detached.isnan().sum()),
+            int(detached.isinf().sum()),
+        )
+
+    tensor.register_hook(_log)
+    return tensor
+
+
 def _scatter_projected(
     sequence_parallel, embeddings_out, embeds, positions, projector=None
 ):
@@ -309,7 +342,10 @@ def _scatter_projected(
         """``embeddings_out``, with the projector still in the graph at zero weight."""
         if projector is None:
             return embeddings_out
-        return embeddings_out + projector_graph_tap(projector, embeddings_out.dtype)
+        return log_incoming_grad(
+            embeddings_out + projector_graph_tap(projector, embeddings_out.dtype),
+            "the embeddings of a rank with no projected positions",
+        )
 
     if positions.numel() == 0:
         return unmerged()
@@ -360,8 +396,9 @@ def _scatter_projected(
             float(kept.detach().float().pow(2).mean().sqrt()),
             float(kept.detach().float().abs().max()),
         )
+    log_incoming_grad(kept, "the projector's output")
     merged[local, 0] = kept
-    return merged
+    return log_incoming_grad(merged, "the merged embeddings (from the frozen base)")
 
 
 class _ProjectorMerge:

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -928,7 +928,22 @@ def save_projector_checkpoint(
 
     Idempotent — the hook fires before every train step and the saver is
     installed on the first one, once per optimizer.
+
+    The saver owns both the projector's gradient all-reduce and every checkpoint
+    write, so a hook call without an optimizer is not something to skip: it
+    would train unreduced, tensor-parallel-partial gradients and leave no
+    adapter behind, silently. The pinned image passes the optimizer from its
+    train step (and the GPU runs on this branch installed the saver and wrote
+    checkpoints), so this raises if that ever stops being true.
     """
-    if optimizer is None or getattr(optimizer, "_training_gym_projector_saver", None):
+    if optimizer is None:
+        raise RuntimeError(
+            "miles called the before-train-step hook without an optimizer, so "
+            "projector-only training cannot install the wrapper that reduces "
+            "projector gradients across the tensor-parallel group and writes "
+            "the projector checkpoints. Continuing would train partial "
+            "gradients and produce no adapter."
+        )
+    if getattr(optimizer, "_training_gym_projector_saver", None):
         return
     optimizer._training_gym_projector_saver = _ProjectorSaver(args, model, optimizer)

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -154,14 +154,33 @@ def projector_parameters(projector: nn.Module) -> list[tuple[str, torch.Tensor]]
     return sorted(projector.named_parameters(), key=lambda item: item[0])
 
 
-def all_reduce_projector_grads(projector: nn.Module) -> int:
+def projector_graph_tap(projector: nn.Module, dtype) -> torch.Tensor:
+    """A differentiable, exactly-zero scalar tying ``projector`` into the graph.
+
+    Needed on a rank whose sequence shard holds none of the projected positions:
+    the base is frozen, so the projector is the only thing in the forward that
+    requires grad, and dropping it there would leave the rank's loss without a
+    ``grad_fn`` — it would then skip the backward its peers are waiting on.
+
+    Built from the parameters rather than from the projector's output: parameters
+    are finite by construction, whereas multiplying an activation by zero is a
+    ``0 * inf`` trap that poisons the whole embedding tensor with NaN.
+    """
+    total = sum(param.sum() for _, param in projector_parameters(projector))
+    return (total * 0.0).to(dtype)
+
+
+def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) -> int:
     """Sum the replicated projector's gradients across the tensor-parallel group.
 
     Under sequence parallelism each tensor-parallel rank holds a disjoint slice
     of the packed sequence, so each computes the gradient of the same replicated
     weight with respect to a different subset of the projected positions. The
     whole-sequence gradient is their **sum**, not their average; the
-    data-parallel average is DDP's job and is left alone.
+    data-parallel average is DDP's job and is left alone. Without sequence
+    parallelism every tensor-parallel rank merges every position and so already
+    holds the whole gradient — summing there would scale it by the group size,
+    which is why the flag is honored rather than assumed.
 
     Every rank enters this unconditionally, once per optimizer step, with a
     tensor of the same shape for every parameter — materializing a zero gradient
@@ -174,7 +193,7 @@ def all_reduce_projector_grads(projector: nn.Module) -> int:
     """
     import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
 
-    if ps.get_tensor_model_parallel_world_size() <= 1:
+    if not sequence_parallel or ps.get_tensor_model_parallel_world_size() <= 1:
         return 0
     group = ps.get_tensor_model_parallel_group()
     reduced = 0
@@ -194,7 +213,9 @@ def all_reduce_projector_grads(projector: nn.Module) -> int:
     return reduced
 
 
-def _scatter_projected(sequence_parallel, embeddings_out, embeds, positions):
+def _scatter_projected(
+    sequence_parallel, embeddings_out, embeds, positions, projector=None
+):
     """Write ``embeds`` into ``embeddings_out`` at ``positions`` (sequence-first).
 
     ``LanguageModelEmbedding.forward`` returns ``[sequence, batch, hidden]``, and
@@ -207,8 +228,14 @@ def _scatter_projected(sequence_parallel, embeddings_out, embeds, positions):
     """
     import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
 
+    def unmerged():
+        """``embeddings_out``, with the projector still in the graph at zero weight."""
+        if projector is None:
+            return embeddings_out
+        return embeddings_out + projector_graph_tap(projector, embeddings_out.dtype)
+
     if positions.numel() == 0:
-        return embeddings_out
+        return unmerged()
     if embeddings_out.shape[1] != 1:
         raise ValueError(
             "projector training expects miles' packed layout, one sequence per "
@@ -221,14 +248,14 @@ def _scatter_projected(sequence_parallel, embeddings_out, embeds, positions):
         local, embeds = local[keep], embeds[keep]
     else:
         local = positions
+    logger.info(
+        "projector merge: %d of %d position(s) on this rank's %d-token shard",
+        int(local.numel()),
+        int(positions.numel()),
+        s_local,
+    )
     if not local.numel():
-        # None of the projected positions live on this rank's sequence shard, so
-        # the projector contributes nothing here and its gradient stays at the
-        # zero Megatron's grad buffers start the iteration at. Keeping it in the
-        # graph with a zero multiplier instead would be a ``0 * inf`` trap; the
-        # unconditional all-reduce in ``all_reduce_projector_grads`` is what
-        # keeps the collectives symmetric.
-        return embeddings_out
+        return unmerged()
     merged = embeddings_out.clone()
     merged[local, 0] = embeds.to(merged.dtype)
     return merged
@@ -298,6 +325,7 @@ class _ProjectorMerge:
             output,
             projected,
             positions.to(output.device),
+            self._projector,
         )
 
 
@@ -542,6 +570,7 @@ class _ProjectorSaver:
                 "found" if isinstance(direct, EmbeddingProjector) else "None",
                 "found" if get_projector(chunk) is not None else "NOT FOUND",
             )
+        self._sequence_parallel = bool(getattr(args, "sequence_parallel", False))
         self._total_steps = int(getattr(args, "train_iters", 0) or 0)
         self._steps = 0
         self._original_step = optimizer.step
@@ -549,7 +578,7 @@ class _ProjectorSaver:
 
     def _step(self, *fargs, **fkwargs):
         for projector in self._projectors:
-            all_reduce_projector_grads(projector)
+            all_reduce_projector_grads(projector, self._sequence_parallel)
         out = self._original_step(*fargs, **fkwargs)
         self._log_replica_state()
         # Megatron returns (success, grad_norm, num_zeros); a step that did not

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -284,6 +284,23 @@ def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) ->
 
 
 _grads_logged: set[str] = set()
+_merges_logged: set[str] = set()
+
+
+def _log_merge_once(key: str) -> bool:
+    """Whether to emit the merge diagnostic ``key`` in this process.
+
+    ``_scatter_projected`` runs from a forward hook on ``model.embedding``, so
+    once per micro-batch per rank, and again for every recomputation of the
+    embedding. The scale line reduces the whole embedding tensor and pulls the
+    result to Python, which drains the stream, so it is worth exactly once — like
+    every other diagnostic here. What these say (which ranks hold projected
+    positions, at what scale the projector writes) does not change between steps.
+    """
+    if key in _merges_logged:
+        return False
+    _merges_logged.add(key)
+    return True
 
 
 def log_incoming_grad(tensor: torch.Tensor, name: str) -> torch.Tensor:
@@ -375,28 +392,31 @@ def _scatter_projected(
         local, embeds = local[keep], embeds[keep]
     else:
         local = positions
-    logger.info(
-        "projector merge: %d of %d position(s) on this rank's %d-token shard",
-        int(local.numel()),
-        int(positions.numel()),
-        s_local,
-    )
+    if _log_merge_once("positions"):
+        logger.info(
+            "projector merge: %d of %d position(s) on this rank's %d-token shard",
+            int(local.numel()),
+            int(positions.numel()),
+            s_local,
+        )
     if not local.numel():
         return unmerged()
     merged = embeddings_out.clone()
     kept = embeds.to(merged.dtype)
-    with torch.no_grad():
-        # The scales have to be comparable: a projector row far above the base's
-        # embedding scale is out of the decoder's distribution and overflows the
-        # forward, which shows up as NaN gradients on exactly the merging ranks.
-        logger.info(
-            "projector merge scale: base rms=%.6g absmax=%.6g, projected "
-            "rms=%.6g absmax=%.6g",
-            float(embeddings_out.detach().float().pow(2).mean().sqrt()),
-            float(embeddings_out.detach().float().abs().max()),
-            float(kept.detach().float().pow(2).mean().sqrt()),
-            float(kept.detach().float().abs().max()),
-        )
+    if _log_merge_once("scale"):
+        with torch.no_grad():
+            # The scales have to be comparable: a projector row far above the
+            # base's embedding scale is out of the decoder's distribution and
+            # overflows the forward, which shows up as NaN gradients on exactly
+            # the merging ranks.
+            logger.info(
+                "projector merge scale: base rms=%.6g absmax=%.6g, projected "
+                "rms=%.6g absmax=%.6g",
+                float(embeddings_out.detach().float().pow(2).mean().sqrt()),
+                float(embeddings_out.detach().float().abs().max()),
+                float(kept.detach().float().pow(2).mean().sqrt()),
+                float(kept.detach().float().abs().max()),
+            )
     log_incoming_grad(kept, "the projector's output")
     merged[local, 0] = kept
     return log_incoming_grad(merged, "the merged embeddings (from the frozen base)")

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -494,7 +494,10 @@ class _ProjectorMerge:
             int(detached.isinf().sum()),
             int(detached.numel()),
         )
-        return output
+        # And what the loss hands back, which localizes a NaN: arriving here it
+        # came from the loss, arriving only at the embeddings it was produced
+        # inside the frozen base's backward.
+        return log_incoming_grad(output, "the frozen base's output (from the loss)")
 
     def _embedding_hook(self, module, inputs, output):
         if self._pending is None:

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -774,6 +774,12 @@ def write_projector_checkpoint(
             # the projector's output was sized from the model's hidden size — a
             # checkpoint has to describe its own shape.
             "output_dim": _projector_output_dim(projector),
+            # Not needed to rebuild the shape, but needed to rebuild the
+            # *starting point*: an eval's untrained baseline is only the state
+            # training began from if it inits from the same seed and scale this
+            # run used.
+            "init_seed": cfg.init_seed,
+            "output_scale": cfg.output_scale,
         },
     }
     latest = os.path.join(save_dir, _LATEST)

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -41,6 +41,7 @@ import torch.nn as nn  # pyright: ignore[reportMissingImports]
 from modal_training_gym.frameworks.miles.projector_config import (
     ProjectorSpec,
     from_miles_args,
+    require_projector_step_hook,
     should_save_projector,
 )
 
@@ -517,6 +518,7 @@ def projector_model_provider(
     from megatron.training import get_args  # pyright: ignore[reportMissingImports]
 
     args = get_args()
+    require_projector_step_hook(args)
     cfg = from_miles_args(args)
     model = _build_base_model(args, pre_process, post_process, vp_stage)
     frozen = freeze_base_model(model)

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -136,7 +136,13 @@ def freeze_base_model(model: nn.Module) -> int:
 
 
 def _build_base_model(args, pre_process: bool, post_process: bool, vp_stage):
-    """Build the model miles would have built without this provider."""
+    """Build the model miles would have built without this provider.
+
+    The build happens with ``custom_model_provider_path`` still cleared, not
+    just the lookup: whether miles resolves the choice when handing back the
+    provider or when the provider runs is its business, and re-entering this
+    function would recurse until the stack overflows.
+    """
     from miles.backends.megatron_utils.model_provider import (  # pyright: ignore[reportMissingImports]
         get_model_provider_func,
     )
@@ -145,11 +151,11 @@ def _build_base_model(args, pre_process: bool, post_process: bool, vp_stage):
     args.custom_model_provider_path = None
     try:
         provider = get_model_provider_func(args)
+        return provider(
+            pre_process=pre_process, post_process=post_process, vp_stage=vp_stage
+        )
     finally:
         args.custom_model_provider_path = saved
-    return provider(
-        pre_process=pre_process, post_process=post_process, vp_stage=vp_stage
-    )
 
 
 def projector_parameters(projector: nn.Module) -> list[tuple[str, torch.Tensor]]:
@@ -200,6 +206,11 @@ def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) ->
     that path is entered per-rank depending on what that rank's gradients look
     like, and a replicated module whose gradients are data-dependent cannot
     safely take part.
+
+    ``main_grad`` is read whole, so this assumes the non-distributed optimizer —
+    with ``use_distributed_optimizer`` it is a reduce-scattered shard of a
+    bucket and summing shards across the group means nothing. The recipe rejects
+    that flag rather than leaving the assumption implicit here.
     """
     import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
 

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -170,6 +170,47 @@ def projector_parameters(projector: nn.Module) -> list[tuple[str, torch.Tensor]]
     return sorted(projector.named_parameters(), key=lambda item: item[0])
 
 
+def check_projector_weights(projector: nn.Module) -> str:
+    """Describe the projector's weights, and refuse an all-zero one.
+
+    Called on the first forward rather than at build time, because what this
+    catches happens in between: Megatron allocates the DDP parameter buffer the
+    parameters are re-pointed into inside
+    ``torch_memory_saver.region(tag="param_buffer", enable_cpu_backup=False)``,
+    and a paused region without a backup comes back zeroed. With the base
+    frozen, that buffer holds only the projector, so offloading the train model
+    zeroes exactly the weights being trained. That is not a bad initialization
+    that trains slowly: an all-zero projector writes exactly-zero rows for every
+    embedding the encoder produced, so the run trains on no signal at all, and
+    on real hardware it surfaced as NaN gradients rather than as its cause. The
+    recipe rejects the flag that does it; this makes any other route to the same
+    state say so.
+    """
+    parts, all_zero = [], True
+    for name, param in projector_parameters(projector):
+        detached = param.detach().float()
+        rms = float(detached.pow(2).mean().sqrt())
+        all_zero = all_zero and rms == 0.0
+        finite = bool(torch.isfinite(detached).all())
+        parts.append(f"{name} rms={rms:.6g} absmax={float(detached.abs().max()):.6g}")
+        if not finite:
+            raise ValueError(
+                f"projector parameter '{name}' is not finite at the first "
+                "forward; the projector is initialized from a seed and cannot "
+                "reach this state by training."
+            )
+    if all_zero:
+        raise ValueError(
+            "every projector parameter is exactly zero at the first forward, "
+            "which the seeded initialization cannot produce. The train model "
+            "was most likely offloaded: Megatron's parameter buffer (holding only the "
+            "projector, since the base is frozen) lives in a torch_memory_saver "
+            "region with no backup, so pausing it zeroes the projector. Launch "
+            "with no_offload_train=True."
+        )
+    return ", ".join(parts)
+
+
 def projector_graph_tap(projector: nn.Module, dtype) -> torch.Tensor:
     """A differentiable, exactly-zero scalar tying ``projector`` into the graph.
 
@@ -343,6 +384,7 @@ class _ProjectorMerge:
         self._embeddings_key = cfg.embeddings_key
         self._positions_key = cfg.positions_key
         self._pending: tuple[torch.Tensor, torch.Tensor] | None = None
+        self._weights_checked = False
         self._original_forward = model.forward
         model.forward = self._forward
         if model.pre_process:
@@ -380,6 +422,15 @@ class _ProjectorMerge:
             # mixes in text-only samples rather than a path taken now.
             return output + projector_graph_tap(self._projector, output.dtype)
         embeddings, positions = self._pending
+        if not self._weights_checked:
+            # Once per process: the state this catches is set before the first
+            # forward and never changes back, and the check reads every
+            # parameter.
+            self._weights_checked = True
+            logger.info(
+                "projector weights at first forward: %s",
+                check_projector_weights(self._projector),
+            )
         projected = self._projector(
             embeddings.to(
                 device=output.device,

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -1,0 +1,411 @@
+"""Projector-only training on miles: a trainable adapter over a frozen base model.
+
+Runs inside the miles containers, not on the launching machine. Three entry
+points, all reached by dotted path:
+
+``projector_model_provider``
+    miles' ``--custom-model-provider-path``. Builds the model the model script
+    asks for (so GLM-5.2's DSA spec, MoE routing and indexer come from
+    upstream verbatim), freezes every base parameter, and attaches an
+    :class:`EmbeddingProjector` on the first pipeline stage. The projector maps
+    externally computed per-token embeddings — protein/DNA encoder outputs, for
+    instance — into the decoder's hidden space and writes them into the input
+    embeddings at the positions the data gives, following the merge that
+    ``miles_plugins.models.inkling.mm_towers`` does for its vision/audio towers.
+``save_projector_checkpoint``
+    miles' before-train-step hook. Writes the projector (a few hundred MB at
+    most) instead of the base model, which at 744B is terabytes of sharded
+    weights that never change during a projector-only run.
+``load_projector_checkpoint``
+    Called by the provider when ``load`` is set, and usable standalone for
+    inspection or export.
+
+The trainable-parameter set is what makes this cheap: freezing the base before
+Megatron builds the optimizer keeps optimizer state, gradient buffers and
+checkpoints proportional to the projector, not to the model — LoRA-free, and
+without the full-parameter memory bill.
+
+Configuration arrives as one dict under the ``training_gym_projector`` miles
+arg (the recipe writes it into ``extra_config``, whose keys miles sets on
+``args``), so no new miles CLI flags are needed.
+"""
+
+import logging
+import os
+
+import torch  # pyright: ignore[reportMissingImports]  # torch is installed only in training images
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+from modal_training_gym.frameworks.miles.projector_config import (
+    ProjectorSpec,
+    from_miles_args,
+)
+
+logger = logging.getLogger(__name__)
+
+_LATEST = "projector_latest.pt"
+
+
+class EmbeddingProjector(nn.Module):
+    """MLP mapping external embeddings into the decoder's hidden space.
+
+    Replicated on every rank rather than tensor-parallel: at a few hundred MB
+    it is not worth sharding, and replication keeps the checkpoint a single
+    plain state dict that loads anywhere.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int,
+        output_dim: int,
+        num_layers: int = 2,
+    ) -> None:
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError(f"projector num_layers must be >= 1, got {num_layers}")
+        dims = [input_dim] + [hidden_dim] * (num_layers - 1) + [output_dim]
+        layers: list[nn.Module] = []
+        for i in range(num_layers):
+            layers.append(nn.Linear(dims[i], dims[i + 1]))
+            if i < num_layers - 1:
+                layers.append(nn.GELU())
+        self.mlp = nn.Sequential(*layers)
+        self.norm = nn.LayerNorm(output_dim)
+
+    def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
+        return self.norm(self.mlp(embeddings))
+
+
+def freeze_base_model(model: nn.Module) -> int:
+    """Freeze every parameter of ``model``; returns how many were frozen.
+
+    Called before Megatron builds the optimizer, which skips parameters
+    without ``requires_grad`` — that is what keeps optimizer state and
+    gradient buffers proportional to the projector.
+    """
+    frozen = 0
+    for param in model.parameters():
+        if param.requires_grad:
+            param.requires_grad_(False)
+            frozen += 1
+    return frozen
+
+
+def _build_base_model(args, pre_process: bool, post_process: bool, vp_stage):
+    """Build the model miles would have built without this provider."""
+    from miles.backends.megatron_utils.model_provider import (  # pyright: ignore[reportMissingImports]
+        get_model_provider_func,
+    )
+
+    saved = args.custom_model_provider_path
+    args.custom_model_provider_path = None
+    try:
+        provider = get_model_provider_func(args)
+    finally:
+        args.custom_model_provider_path = saved
+    return provider(
+        pre_process=pre_process, post_process=post_process, vp_stage=vp_stage
+    )
+
+
+def _mark_sequence_parallel(module: nn.Module) -> None:
+    """Tag replicated parameters so Megatron all-reduces their grads over TP.
+
+    With sequence parallelism each tensor-parallel rank holds a different slice
+    of the sequence, so each sees a different subset of projected positions and
+    computes a different gradient for the same replicated weight. Megatron's
+    ``finalize_model_grads`` all-reduces exactly the parameters carrying this
+    attribute (the convention its LayerNorm weights use).
+    """
+    for param in module.parameters():
+        param.sequence_parallel = True
+
+
+def _scatter_projected(sequence_parallel, embeddings_out, embeds, positions):
+    """Write ``embeds`` into ``embeddings_out`` at ``positions`` (sequence-first).
+
+    ``LanguageModelEmbedding.forward`` returns ``[sequence, batch, hidden]``, and
+    under sequence parallelism the sequence dimension is already this rank's
+    shard (either reduce-scattered inside the vocab embedding or scattered right
+    after it), so positions are rebased onto the shard and the ones belonging to
+    other ranks dropped. miles packs a microbatch into one sequence, so the batch
+    dimension is 1.
+    """
+    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+    if positions.numel() == 0:
+        return embeddings_out
+    if embeddings_out.shape[1] != 1:
+        raise ValueError(
+            "projector training expects miles' packed layout, one sequence per "
+            f"microbatch, but the embedding output has batch {embeddings_out.shape[1]}"
+        )
+    s_local = embeddings_out.shape[0]
+    if sequence_parallel and ps.get_tensor_model_parallel_world_size() > 1:
+        local = positions - ps.get_tensor_model_parallel_rank() * s_local
+        keep = (local >= 0) & (local < s_local)
+        local, embeds = local[keep], embeds[keep]
+    else:
+        local = positions
+    if not local.numel():
+        return embeddings_out
+    merged = embeddings_out.clone()
+    merged[local, 0] = embeds.to(merged.dtype)
+    return merged
+
+
+class _ProjectorMerge:
+    """Moves the batch's embeddings from ``model.forward`` into the embedding layer.
+
+    miles splats ``multimodal_train_inputs`` straight into ``model(**kwargs)``
+    (``miles/backends/megatron_utils/model.py``), but ``GPTModel.forward`` takes
+    no such arguments, so they are stripped there and merged where the input
+    embeddings actually exist: a forward hook on ``model.embedding``, which is
+    the only place whose output layout and sequence-parallel sharding are already
+    settled. Recomputing the embedding here instead would duplicate the vocab
+    embedding's reduce-scatter and position-embedding branches.
+    """
+
+    def __init__(
+        self, model, projector: EmbeddingProjector, cfg: ProjectorSpec
+    ) -> None:
+        self._model = model
+        self._projector = projector
+        self._embeddings_key = cfg.embeddings_key
+        self._positions_key = cfg.positions_key
+        self._pending: tuple[torch.Tensor, torch.Tensor] | None = None
+        self._original_forward = model.forward
+        model.forward = self._forward
+        if model.pre_process:
+            model.embedding.register_forward_hook(self._embedding_hook)
+
+    def _forward(self, *fargs, **fkwargs):
+        embeddings = fkwargs.pop(self._embeddings_key, None)
+        positions = fkwargs.pop(self._positions_key, None)
+        if embeddings is None or not self._model.pre_process:
+            return self._original_forward(*fargs, **fkwargs)
+        if positions is None:
+            raise ValueError(
+                f"'{self._embeddings_key}' was passed without "
+                f"'{self._positions_key}'; the dataset must emit the token "
+                "positions the embeddings occupy."
+            )
+        if positions.numel() != embeddings.shape[0]:
+            raise ValueError(
+                f"{positions.numel()} projector position(s) for "
+                f"{embeddings.shape[0]} embedding row(s)"
+            )
+        self._pending = (embeddings, positions)
+        try:
+            return self._original_forward(*fargs, **fkwargs)
+        finally:
+            self._pending = None
+
+    def _embedding_hook(self, module, inputs, output):
+        if self._pending is None:
+            return output
+        embeddings, positions = self._pending
+        projected = self._projector(embeddings.to(device=output.device))
+        return _scatter_projected(
+            self._model.config.sequence_parallel,
+            output,
+            projected,
+            positions.to(output.device),
+        )
+
+
+def get_projector(model) -> EmbeddingProjector | None:
+    """The projector attached to ``model``, if this rank holds one."""
+    projector = model.__dict__.get("_training_gym_projector")
+    return projector if isinstance(projector, EmbeddingProjector) else None
+
+
+def projector_model_provider(
+    pre_process: bool = True, post_process: bool = True, vp_stage=None
+):
+    """miles ``--custom-model-provider-path``: frozen base + trainable projector."""
+    from megatron.training import get_args  # pyright: ignore[reportMissingImports]
+
+    args = get_args()
+    cfg = from_miles_args(args)
+    model = _build_base_model(args, pre_process, post_process, vp_stage)
+    frozen = freeze_base_model(model)
+
+    if pre_process:
+        projector = EmbeddingProjector(
+            input_dim=cfg.input_dim,
+            hidden_dim=cfg.hidden_dim,
+            output_dim=cfg.output_dim or model.config.hidden_size,
+            num_layers=cfg.num_layers,
+        )
+        projector.to(
+            device=torch.cuda.current_device(), dtype=model.config.params_dtype
+        )
+        projector.requires_grad_(True)
+        if model.config.sequence_parallel:
+            _mark_sequence_parallel(projector)
+        model.__dict__["_training_gym_projector"] = projector
+        # Registered so Megatron's DDP and the optimizer see the parameters.
+        model.add_module("embedding_projector", projector)
+        if cfg.load:
+            load_projector_checkpoint(cfg.load, projector)
+        model.__dict__["_training_gym_projector_merge"] = _ProjectorMerge(
+            model, projector, cfg
+        )
+        trainable = sum(p.numel() for p in projector.parameters())
+        logger.info(
+            "projector-only training: froze %d base parameter tensors, "
+            "%d trainable projector parameters",
+            frozen,
+            trainable,
+        )
+    else:
+        # Later pipeline stages get no projector, but miles still splats the
+        # batch's embedding tensors into every stage's forward, so they have to
+        # be stripped before they reach ``GPTModel.forward``.
+        model.__dict__["_training_gym_projector_merge"] = _ProjectorMerge(
+            model, EmbeddingProjector(1, 1, 1, 1), cfg
+        )
+
+    return model
+
+
+def projector_sft_rollout(args, rollout_id: int, data_buffer, evaluation: bool = False):
+    """miles ``--rollout-function-path``: supervised samples carrying embeddings.
+
+    miles' own ``sft_rollout.generate_rollout`` builds tokens and the loss mask
+    from each conversation, which is all a text SFT run needs. This does the
+    same and additionally lifts the dataset's embeddings out of
+    ``Sample.metadata`` into ``multimodal_train_inputs``, the per-sample tensor
+    dict miles concatenates across a packed batch — adding each sample's offset
+    to keys ending in ``_positions`` — and splats into ``model.forward``, where
+    the projector picks them up.
+    """
+    from miles.utils.mask_utils import (  # pyright: ignore[reportMissingImports]
+        MultiTurnLossMaskGenerator,
+    )
+    from miles.utils.processing_utils import (  # pyright: ignore[reportMissingImports]
+        load_tokenizer,
+    )
+
+    if evaluation:
+        raise ValueError("projector_sft_rollout does not generate, so cannot evaluate")
+    cfg = from_miles_args(args)
+    tokenizer = load_tokenizer(
+        args.hf_checkpoint,
+        chat_template_path=args.chat_template_path,
+        trust_remote_code=True,
+    )
+    mask_generator = MultiTurnLossMaskGenerator(
+        tokenizer, tokenizer_type=args.loss_mask_type
+    )
+
+    samples = data_buffer.get_samples(args.rollout_batch_size)
+    for sample in samples:
+        (sample,) = sample
+        messages = sample.prompt
+        token_ids, loss_mask = mask_generator.get_loss_mask(
+            messages, tools=sample.metadata.get("tools")
+        )
+        response_length = mask_generator.get_response_lengths([loss_mask])[0]
+        sample.tokens = token_ids
+        sample.response_length = response_length
+        sample.reward = 0
+        sample.loss_mask = loss_mask[-response_length:]
+
+        embeddings = sample.metadata.get(cfg.embeddings_key)
+        positions = sample.metadata.get(cfg.positions_key)
+        if embeddings is None or positions is None:
+            raise ValueError(
+                f"sample {sample.index} carries no '{cfg.embeddings_key}'/"
+                f"'{cfg.positions_key}' metadata; a projector-only run has "
+                "nothing to train without embeddings."
+            )
+        embeddings_t = torch.tensor(embeddings, dtype=torch.float32)
+        if embeddings_t.shape[-1] != cfg.input_dim:
+            raise ValueError(
+                f"sample {sample.index} has {embeddings_t.shape[-1]}-wide "
+                f"embeddings but the projector expects {cfg.input_dim}"
+            )
+        max_position = max(positions, default=-1)
+        if max_position >= len(token_ids):
+            raise ValueError(
+                f"sample {sample.index} places an embedding at token "
+                f"{max_position} of a {len(token_ids)}-token sequence"
+            )
+        sample.multimodal_train_inputs = {
+            cfg.embeddings_key: embeddings_t,
+            cfg.positions_key: torch.tensor(positions, dtype=torch.long),
+        }
+    return samples
+
+
+def load_projector_checkpoint(path: str, projector: EmbeddingProjector) -> int:
+    """Load a projector checkpoint (file or directory) into ``projector``.
+
+    Returns the iteration it was saved at. A directory resolves to the run's
+    ``projector_latest.pt``.
+    """
+    resolved = os.path.join(path, _LATEST) if os.path.isdir(path) else path
+    state = torch.load(resolved, map_location="cpu", weights_only=True)
+    projector.load_state_dict(state["state_dict"])
+    iteration = int(state.get("iteration", 0))
+    logger.info("loaded projector checkpoint %s (iteration %d)", resolved, iteration)
+    return iteration
+
+
+def _is_projector_writer() -> bool:
+    """True on exactly one rank per projector replica group."""
+    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+    return (
+        ps.get_tensor_model_parallel_rank() == 0
+        and ps.get_data_parallel_rank() == 0
+        and ps.get_expert_model_parallel_rank() == 0
+    )
+
+
+def save_projector_checkpoint(
+    args, rollout_id: int, step_id: int, model, optimizer=None, opt_param_scheduler=None
+) -> None:
+    """miles before-train-step hook: save the projector, not the base model.
+
+    Fires at the first micro step of a rollout and writes the state the
+    previous rollout produced, so the file lands outside the training step
+    itself. Optimizer state is not saved — the projector's Adam moments are
+    cheap to rebuild, and reading Megatron's distributed optimizer state for a
+    replicated module would need the base model's sharding machinery.
+    """
+    if step_id != 0 or rollout_id <= 0:
+        return
+    cfg = from_miles_args(args)
+    save_dir = cfg.save_dir or os.path.join(
+        str(args.save or "/checkpoints"), "projector"
+    )
+    if cfg.save_interval <= 0 or rollout_id % cfg.save_interval != 0:
+        return
+
+    chunks = model if isinstance(model, list) else [model]
+    for chunk in chunks:
+        projector = get_projector(chunk)
+        if projector is None or not _is_projector_writer():
+            continue
+        os.makedirs(save_dir, exist_ok=True)
+        state = {
+            "iteration": rollout_id,
+            "state_dict": {
+                k: v.detach().to("cpu") for k, v in projector.state_dict().items()
+            },
+            "config": {
+                "input_dim": cfg.input_dim,
+                "hidden_dim": cfg.hidden_dim,
+                "num_layers": cfg.num_layers,
+                "output_dim": cfg.output_dim,
+            },
+        }
+        path = os.path.join(save_dir, f"projector_iter_{rollout_id:07d}.pt")
+        torch.save(state, path)
+        torch.save(state, os.path.join(save_dir, _LATEST))
+        logger.info("saved projector checkpoint %s", path)
+        return

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -654,6 +654,17 @@ def projector_sft_rollout(args, rollout_id: int, data_buffer, evaluation: bool =
             messages, tools=sample.metadata.get("tools")
         )
         response_length = mask_generator.get_response_lengths([loss_mask])[0]
+        if not response_length:
+            # ``loss_mask[-0:]`` is the whole mask, so a conversation with no
+            # trained-on turn would hand miles a mask of the full sequence
+            # alongside ``response_length=0`` — nothing to learn from, reported
+            # as a mask/length mismatch deep in the loss instead.
+            raise ValueError(
+                f"sample {sample.index} has no tokens to train on: the loss "
+                "mask marks none of its turns as a response. Conversations for "
+                "supervised projector training have to end in an assistant "
+                "message."
+            )
         sample.tokens = token_ids
         sample.response_length = response_length
         sample.reward = 0

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -32,6 +32,7 @@ arg (the recipe writes it into ``extra_config``, whose keys miles sets on
 """
 
 import logging
+import math
 import os
 
 import torch  # pyright: ignore[reportMissingImports]  # torch is installed only in training images
@@ -77,6 +78,36 @@ class EmbeddingProjector(nn.Module):
 
     def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
         return self.norm(self.mlp(embeddings))
+
+
+def init_projector(projector: EmbeddingProjector, seed: int) -> None:
+    """Initialize from ``seed`` alone, so every replica agrees.
+
+    The projector is replicated and its gradients are all-reduced, so ranks that
+    start from different weights stay different forever — silently, since the
+    updates do agree. Torch's default init draws from the ambient RNG, whose
+    state depends on how the base model's build consumed it (TP/EP shards, MoE
+    expert counts, the DSA indexer), so it is not relied on here: a private
+    generator plus PyTorch's own ``nn.Linear`` bounds gives identical weights on
+    every rank without a collective, and without assuming the projector exists
+    on a rank that could take part in one.
+    """
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    with torch.no_grad():
+        for module in projector.modules():
+            if isinstance(module, nn.Linear):
+                bound = 1.0 / math.sqrt(module.weight.shape[1])
+                for param in (module.weight, module.bias):
+                    if param is None:
+                        continue
+                    param.copy_(
+                        torch.empty(param.shape, dtype=torch.float32).uniform_(
+                            -bound, bound, generator=gen
+                        )
+                    )
+            elif isinstance(module, nn.LayerNorm):
+                module.weight.fill_(1.0)
+                module.bias.zero_()
 
 
 def freeze_base_model(model: nn.Module) -> int:
@@ -132,7 +163,8 @@ def _scatter_projected(sequence_parallel, embeddings_out, embeds, positions):
     shard (either reduce-scattered inside the vocab embedding or scattered right
     after it), so positions are rebased onto the shard and the ones belonging to
     other ranks dropped. miles packs a microbatch into one sequence, so the batch
-    dimension is 1.
+    dimension is 1. Context parallelism would shard the sequence a second way,
+    with its own chunking, which is why the recipe rejects ``CP > 1``.
     """
     import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
 
@@ -208,7 +240,14 @@ class _ProjectorMerge:
         if self._pending is None:
             return output
         embeddings, positions = self._pending
-        projected = self._projector(embeddings.to(device=output.device))
+        projected = self._projector(
+            embeddings.to(
+                device=output.device,
+                # The rollout emits fp32; the projector carries the model's
+                # params_dtype, bf16 for these recipes.
+                dtype=next(self._projector.parameters()).dtype,
+            )
+        )
         return _scatter_projected(
             self._model.config.sequence_parallel,
             output,
@@ -241,6 +280,7 @@ def projector_model_provider(
             output_dim=cfg.output_dim or model.config.hidden_size,
             num_layers=cfg.num_layers,
         )
+        init_projector(projector, cfg.init_seed)
         projector.to(
             device=torch.cuda.current_device(), dtype=model.config.params_dtype
         )

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -423,6 +423,7 @@ class _ProjectorMerge:
         self._positions_key = cfg.positions_key
         self._pending: tuple[torch.Tensor, torch.Tensor] | None = None
         self._weights_checked = False
+        self._output_logged = False
         self._original_forward = model.forward
         model.forward = self._forward
         if model.pre_process:
@@ -446,9 +447,34 @@ class _ProjectorMerge:
             )
         self._pending = (embeddings, positions)
         try:
-            return self._original_forward(*fargs, **fkwargs)
+            return self._log_output(self._original_forward(*fargs, **fkwargs))
         finally:
             self._pending = None
+
+    def _log_output(self, output):
+        """Describe the frozen base's first forward output, once per process.
+
+        A projector-only run sees a non-finite loss only as a NaN in *the
+        projector's* gradient bucket, because with the base frozen that is the
+        only bucket Megatron checks. This says whether what the base returned
+        was already non-finite — a forward the merge fed out-of-distribution
+        rows, or a base that cannot run this shape — rather than something the
+        backward produced.
+        """
+        if self._output_logged or not isinstance(output, torch.Tensor):
+            return output
+        self._output_logged = True
+        detached = output.detach().float()
+        logger.info(
+            "projector: the frozen base's first forward output rms=%.6g "
+            "absmax=%.6g nan=%d inf=%d of %d",
+            float(detached.pow(2).mean().sqrt()),
+            float(detached.abs().max()),
+            int(detached.isnan().sum()),
+            int(detached.isinf().sum()),
+            int(detached.numel()),
+        )
+        return output
 
     def _embedding_hook(self, module, inputs, output):
         if self._pending is None:

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -13,9 +13,10 @@ points, all reached by dotted path:
     embeddings at the positions the data gives, following the merge that
     ``miles_plugins.models.inkling.mm_towers`` does for its vision/audio towers.
 ``save_projector_checkpoint``
-    miles' before-train-step hook. Writes the projector (a few hundred MB at
-    most) instead of the base model, which at 744B is terabytes of sharded
-    weights that never change during a projector-only run.
+    miles' before-train-step hook. Installs a wrapper around the optimizer's
+    ``step`` that writes the projector (a few hundred MB at most) instead of the
+    base model, which at 744B is terabytes of sharded weights that never change
+    during a projector-only run.
 ``load_projector_checkpoint``
     Called by the provider when ``load`` is set, and usable standalone for
     inspection or export.
@@ -39,6 +40,7 @@ import torch.nn as nn  # pyright: ignore[reportMissingImports]
 from modal_training_gym.frameworks.miles.projector_config import (
     ProjectorSpec,
     from_miles_args,
+    should_save_projector,
 )
 
 logger = logging.getLogger(__name__)
@@ -356,56 +358,103 @@ def load_projector_checkpoint(path: str, projector: EmbeddingProjector) -> int:
 
 
 def _is_projector_writer() -> bool:
-    """True on exactly one rank per projector replica group."""
+    """True on exactly one rank per projector replica group.
+
+    The projector is replicated, so every rank holds the same weights and one
+    writer is enough; the context-parallel rank is checked explicitly because
+    Megatron's ``get_data_parallel_rank`` defaults to ``with_context_parallel=False``
+    and would leave every ``cp_rank`` writing the same file.
+    """
     import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
 
     return (
         ps.get_tensor_model_parallel_rank() == 0
         and ps.get_data_parallel_rank() == 0
+        and ps.get_context_parallel_rank() == 0
         and ps.get_expert_model_parallel_rank() == 0
     )
+
+
+def write_projector_checkpoint(cfg: ProjectorSpec, save_dir: str, projector, step: int):
+    """Write ``projector``'s state dict plus enough config to rebuild it.
+
+    Optimizer state is not saved — the projector's Adam moments are cheap to
+    rebuild, and reading Megatron's distributed optimizer state for a replicated
+    module would need the base model's sharding machinery. The frozen base is not
+    saved either: it stays byte-identical to the run's ``hf_checkpoint``.
+    """
+    os.makedirs(save_dir, exist_ok=True)
+    state = {
+        "iteration": step,
+        "state_dict": {
+            k: v.detach().to("cpu") for k, v in projector.state_dict().items()
+        },
+        "config": {
+            "input_dim": cfg.input_dim,
+            "hidden_dim": cfg.hidden_dim,
+            "num_layers": cfg.num_layers,
+            "output_dim": cfg.output_dim,
+        },
+    }
+    path = os.path.join(save_dir, f"projector_iter_{step:07d}.pt")
+    torch.save(state, path)
+    torch.save(state, os.path.join(save_dir, _LATEST))
+    logger.info("saved projector checkpoint %s", path)
+
+
+class _ProjectorSaver:
+    """Writes the projector after optimizer steps, including the run's last one.
+
+    The before-train-step hook is the only hook miles offers on the training path
+    (``custom_megatron_post_save_hook`` fires off Megatron's own full-model save,
+    which a projector-only run never triggers). Saving *in* that hook would only
+    ever persist state one step stale and would miss the final step entirely, so
+    the hook is used just to get hold of the optimizer, and the write hangs off
+    ``optimizer.step``: counted in optimizer steps, so ``save_interval`` means
+    what it says, and the last step of the run always lands.
+    """
+
+    def __init__(self, args, model, optimizer) -> None:
+        self._cfg = from_miles_args(args)
+        self._save_dir = self._cfg.save_dir or os.path.join(
+            str(args.save or "/checkpoints"), "projector"
+        )
+        chunks = model if isinstance(model, list) else [model]
+        self._projectors = [p for c in chunks if (p := get_projector(c)) is not None]
+        self._total_steps = int(getattr(args, "train_iters", 0) or 0)
+        self._steps = 0
+        self._original_step = optimizer.step
+        optimizer.step = self._step
+
+    def _step(self, *fargs, **fkwargs):
+        out = self._original_step(*fargs, **fkwargs)
+        # Megatron returns (success, grad_norm, num_zeros); a step that did not
+        # apply (gradient overflow) left the projector unchanged.
+        if isinstance(out, tuple) and out and out[0] is False:
+            return out
+        self._steps += 1
+        if should_save_projector(
+            self._steps, self._total_steps, self._cfg.save_interval
+        ):
+            self._save()
+        return out
+
+    def _save(self) -> None:
+        if not self._projectors or not _is_projector_writer():
+            return
+        write_projector_checkpoint(
+            self._cfg, self._save_dir, self._projectors[0], self._steps
+        )
 
 
 def save_projector_checkpoint(
     args, rollout_id: int, step_id: int, model, optimizer=None, opt_param_scheduler=None
 ) -> None:
-    """miles before-train-step hook: save the projector, not the base model.
+    """miles before-train-step hook: arrange for projector-only checkpoints.
 
-    Fires at the first micro step of a rollout and writes the state the
-    previous rollout produced, so the file lands outside the training step
-    itself. Optimizer state is not saved — the projector's Adam moments are
-    cheap to rebuild, and reading Megatron's distributed optimizer state for a
-    replicated module would need the base model's sharding machinery.
+    Idempotent — the hook fires before every train step and the saver is
+    installed on the first one, once per optimizer.
     """
-    if step_id != 0 or rollout_id <= 0:
+    if optimizer is None or getattr(optimizer, "_training_gym_projector_saver", None):
         return
-    cfg = from_miles_args(args)
-    save_dir = cfg.save_dir or os.path.join(
-        str(args.save or "/checkpoints"), "projector"
-    )
-    if cfg.save_interval <= 0 or rollout_id % cfg.save_interval != 0:
-        return
-
-    chunks = model if isinstance(model, list) else [model]
-    for chunk in chunks:
-        projector = get_projector(chunk)
-        if projector is None or not _is_projector_writer():
-            continue
-        os.makedirs(save_dir, exist_ok=True)
-        state = {
-            "iteration": rollout_id,
-            "state_dict": {
-                k: v.detach().to("cpu") for k, v in projector.state_dict().items()
-            },
-            "config": {
-                "input_dim": cfg.input_dim,
-                "hidden_dim": cfg.hidden_dim,
-                "num_layers": cfg.num_layers,
-                "output_dim": cfg.output_dim,
-            },
-        }
-        path = os.path.join(save_dir, f"projector_iter_{rollout_id:07d}.pt")
-        torch.save(state, path)
-        torch.save(state, os.path.join(save_dir, _LATEST))
-        logger.info("saved projector checkpoint %s", path)
-        return
+    optimizer._training_gym_projector_saver = _ProjectorSaver(args, model, optimizer)

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -449,7 +449,13 @@ def projector_model_provider(
         # Registered so Megatron's DDP and the optimizer see the parameters.
         model.add_module("embedding_projector", projector)
         if cfg.load:
-            load_projector_checkpoint(cfg.load, projector)
+            # Stashed on the projector because the saver is built later, from a
+            # different hook, and only ever gets the model chunk: a resumed run
+            # continues the numbering rather than overwriting the checkpoints
+            # the previous one left in the same directory.
+            projector._training_gym_loaded_iteration = load_projector_checkpoint(
+                cfg.load, projector
+            )
         model.__dict__["_training_gym_projector_merge"] = _ProjectorMerge(
             model, projector, cfg
         )
@@ -679,6 +685,13 @@ class _ProjectorSaver:
         self._total_steps = int(getattr(args, "train_iters", 0) or 0)
         self._steps = 0
         self._attempts = 0
+        # Steps this run inherited from the checkpoint it resumed, so file names
+        # and the recorded ``iteration`` stay absolute. The counters above stay
+        # relative to this run: ``save_interval`` is this run's cadence, and
+        # ``train_iters`` counts this run's steps alone.
+        self._step_offset = int(
+            getattr(self._projectors[0], "_training_gym_loaded_iteration", 0) or 0
+        )
         self._original_step = optimizer.step
         optimizer.step = self._step
 
@@ -724,7 +737,7 @@ class _ProjectorSaver:
             logger.info(
                 "projector replica after step %d: tp_rank=%d dp_rank=%d %s "
                 "norm=%.8f abs_sum=%.8f",
-                self._steps + 1,
+                self._step_offset + self._steps + 1,
                 ps.get_tensor_model_parallel_rank(),
                 ps.get_data_parallel_rank(),
                 name,
@@ -739,7 +752,7 @@ class _ProjectorSaver:
             self._cfg,
             self._save_dir,
             self._projectors[0],
-            self._steps,
+            self._step_offset + self._steps,
             numbered=numbered,
         )
 

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -620,6 +620,7 @@ class _ProjectorSaver:
         self._sequence_parallel = bool(getattr(args, "sequence_parallel", False))
         self._total_steps = int(getattr(args, "train_iters", 0) or 0)
         self._steps = 0
+        self._attempts = 0
         self._original_step = optimizer.step
         optimizer.step = self._step
 
@@ -628,13 +629,15 @@ class _ProjectorSaver:
             all_reduce_projector_grads(projector, self._sequence_parallel)
         out = self._original_step(*fargs, **fkwargs)
         self._log_replica_state()
+        self._attempts += 1
         # Megatron returns (success, grad_norm, num_zeros); a step that did not
-        # apply (gradient overflow) left the projector unchanged.
-        if isinstance(out, tuple) and out and out[0] is False:
-            return out
-        self._steps += 1
+        # apply (gradient overflow) left the projector unchanged, so it does not
+        # advance the interval — but it still consumed one of the run's steps,
+        # which is what decides whether this was the last chance to write.
+        if not (isinstance(out, tuple) and out and out[0] is False):
+            self._steps += 1
         if should_save_projector(
-            self._steps, self._total_steps, self._cfg.save_interval
+            self._steps, self._attempts, self._total_steps, self._cfg.save_interval
         ):
             self._save()
         return out

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -199,8 +199,13 @@ def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) ->
     which is why the flag is honored rather than assumed.
 
     Every rank enters this unconditionally, once per optimizer step, with a
-    tensor of the same shape for every parameter — materializing a zero gradient
-    when one is missing rather than skipping the collective. Riding Megatron's
+    tensor of the same shape *and dtype* for every parameter — materializing a
+    zero gradient when one is missing rather than skipping the collective, and
+    reducing in fp32 so the collective's element size cannot depend on which
+    buffer a rank happened to have (Megatron's ``main_grad`` is fp32 under
+    ``accumulate_allreduce_grads_in_fp32``, a materialized ``param.grad``
+    carries ``params_dtype``, and a collective whose ranks disagree is
+    undefined). Riding Megatron's
     ``sequence_parallel`` attribute instead (which
     ``_allreduce_non_tensor_model_parallel_grads`` honors) is what deadlocked:
     that path is entered per-rank depending on what that rank's gradients look
@@ -227,9 +232,11 @@ def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) ->
                 # the optimizer will read it.
                 param.grad = torch.zeros_like(param)
             grad = param.grad
+        buffer = grad.float()
         torch.distributed.all_reduce(
-            grad, op=torch.distributed.ReduceOp.SUM, group=group
+            buffer, op=torch.distributed.ReduceOp.SUM, group=group
         )
+        grad.copy_(buffer)
         reduced += 1
     return reduced
 
@@ -344,7 +351,13 @@ class _ProjectorMerge:
 
     def _embedding_hook(self, module, inputs, output):
         if self._pending is None:
-            return output
+            # No embeddings in this microbatch, so nothing to merge — but the
+            # base is frozen, so returning the embeddings untouched would leave
+            # this rank's loss without a ``grad_fn`` and it would skip a
+            # backward its peers wait on. Today's rollout rejects a sample
+            # without embeddings, so this is the shape of a future rollout that
+            # mixes in text-only samples rather than a path taken now.
+            return output + projector_graph_tap(self._projector, output.dtype)
         embeddings, positions = self._pending
         projected = self._projector(
             embeddings.to(

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -253,6 +253,14 @@ def _scatter_projected(
     other ranks dropped. miles packs a microbatch into one sequence, so the batch
     dimension is 1. Context parallelism would shard the sequence a second way,
     with its own chunking, which is why the recipe rejects ``CP > 1``.
+
+    ``positions`` index the *micro*-batch that reached this forward: miles adds
+    each sample's offset inside ``get_batch``, from that micro-batch's own
+    ``unconcat_tokens`` (``miles/backends/training_utils/data.py``), and
+    ``get_batch`` runs per micro-batch from ``forward_step``. A position past the
+    packed sequence therefore means that contract changed, so it raises rather
+    than being dropped: under sequence parallelism it would otherwise fall off
+    every rank's shard and the run would train with no projector gradient at all.
     """
     import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
 
@@ -270,7 +278,20 @@ def _scatter_projected(
             f"microbatch, but the embedding output has batch {embeddings_out.shape[1]}"
         )
     s_local = embeddings_out.shape[0]
-    if sequence_parallel and ps.get_tensor_model_parallel_world_size() > 1:
+    tp_size = ps.get_tensor_model_parallel_world_size()
+    sharded = sequence_parallel and tp_size > 1
+    packed_len = s_local * tp_size if sharded else s_local
+    outside = int(((positions < 0) | (positions >= packed_len)).sum())
+    if outside:
+        raise ValueError(
+            f"{outside} of {int(positions.numel())} projector position(s) fall "
+            f"outside the micro-batch's {packed_len}-token packed sequence "
+            f"(min {int(positions.min())}, max {int(positions.max())}). "
+            "Positions have to be offsets into the packed micro-batch that "
+            "reaches forward, which is what miles' '_positions' offsetting "
+            "produces."
+        )
+    if sharded:
         local = positions - ps.get_tensor_model_parallel_rank() * s_local
         keep = (local >= 0) & (local < s_local)
         local, embeds = local[keep], embeds[keep]
@@ -552,13 +573,22 @@ def _is_projector_writer() -> bool:
     )
 
 
-def write_projector_checkpoint(cfg: ProjectorSpec, save_dir: str, projector, step: int):
+def write_projector_checkpoint(
+    cfg: ProjectorSpec, save_dir: str, projector, step: int, numbered: bool = True
+):
     """Write ``projector``'s state dict plus enough config to rebuild it.
 
     Optimizer state is not saved — the projector's Adam moments are cheap to
     rebuild, and reading Megatron's distributed optimizer state for a replicated
     module would need the base model's sharding machinery. The frozen base is not
     saved either: it stays byte-identical to the run's ``hf_checkpoint``.
+
+    ``projector_latest.pt`` is always written; ``numbered`` additionally keeps the
+    step's own ``projector_iter_*.pt``, which is what ``save_interval``
+    schedules. Refreshing ``projector_latest.pt`` after every applied step is
+    what makes "a finished run leaves the adapter it produced" independent of any
+    prediction of how many steps the run will perform — tens of megabytes,
+    against a step of a 744B forward and backward.
     """
     os.makedirs(save_dir, exist_ok=True)
     state = {
@@ -576,10 +606,14 @@ def write_projector_checkpoint(cfg: ProjectorSpec, save_dir: str, projector, ste
             "output_dim": _projector_output_dim(projector),
         },
     }
-    path = os.path.join(save_dir, f"projector_iter_{step:07d}.pt")
-    torch.save(state, path)
-    torch.save(state, os.path.join(save_dir, _LATEST))
-    logger.info("saved projector checkpoint %s", path)
+    latest = os.path.join(save_dir, _LATEST)
+    torch.save(state, latest)
+    if numbered:
+        path = os.path.join(save_dir, f"projector_iter_{step:07d}.pt")
+        torch.save(state, path)
+        logger.info("saved projector checkpoint %s", path)
+    else:
+        logger.info("refreshed projector checkpoint %s (step %d)", latest, step)
 
 
 def _projector_output_dim(projector) -> int:
@@ -599,7 +633,10 @@ class _ProjectorSaver:
     ever persist state one step stale and would miss the final step entirely, so
     the hook is used just to get hold of the optimizer, and the write hangs off
     ``optimizer.step``: counted in optimizer steps, so ``save_interval`` means
-    what it says, and the last step of the run always lands.
+    what it says. ``projector_latest.pt`` is refreshed on every applied step, so
+    the artifact survives a run that performs a different number of steps than
+    ``train_iters`` predicted; ``save_interval`` and that prediction decide only
+    which steps keep a numbered file too.
     """
 
     def __init__(self, args, model, optimizer) -> None:
@@ -636,10 +673,17 @@ class _ProjectorSaver:
         # which is what decides whether this was the last chance to write.
         if not (isinstance(out, tuple) and out and out[0] is False):
             self._steps += 1
-        if should_save_projector(
-            self._steps, self._attempts, self._total_steps, self._cfg.save_interval
-        ):
-            self._save()
+            # Every applied step refreshes projector_latest.pt, so the run leaves
+            # what it trained however many steps it turns out to take;
+            # ``train_iters`` only decides which steps also keep a numbered file.
+            self._save(
+                numbered=should_save_projector(
+                    self._steps,
+                    self._attempts,
+                    self._total_steps,
+                    self._cfg.save_interval,
+                )
+            )
         return out
 
     def _log_replica_state(self) -> None:
@@ -667,7 +711,7 @@ class _ProjectorSaver:
                 checksum,
             )
 
-    def _save(self) -> None:
+    def _save(self, numbered: bool = True) -> None:
         if not self._projectors:
             logger.warning(
                 "projector checkpoint skipped at step %d: no projector found on "
@@ -678,7 +722,11 @@ class _ProjectorSaver:
         if not _is_projector_writer():
             return
         write_projector_checkpoint(
-            self._cfg, self._save_dir, self._projectors[0], self._steps
+            self._cfg,
+            self._save_dir,
+            self._projectors[0],
+            self._steps,
+            numbered=numbered,
         )
 
 

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -80,8 +80,18 @@ class EmbeddingProjector(nn.Module):
         return self.norm(self.mlp(embeddings))
 
 
-def init_projector(projector: EmbeddingProjector, seed: int) -> None:
+def init_projector(
+    projector: EmbeddingProjector, seed: int, output_scale: float = 1.0
+) -> None:
     """Initialize from ``seed`` alone, so every replica agrees.
+
+    ``output_scale`` goes into the final ``LayerNorm``'s weight, which sets the
+    scale of everything the projector writes into the embedding stream. It has to
+    be small: a ``LayerNorm`` output is unit-std by construction, while a decoder's
+    token embeddings are ~1e-2 std, so a weight of 1.0 injects rows ~50-100x out
+    of distribution — which is what produced NaN gradients on exactly the ranks
+    holding projected positions on real hardware. It stays learnable, so training
+    can grow it if the data wants more.
 
     The projector is replicated and its gradients are all-reduced, so ranks that
     start from different weights stay different forever — silently, since the
@@ -106,7 +116,7 @@ def init_projector(projector: EmbeddingProjector, seed: int) -> None:
                         )
                     )
             elif isinstance(module, nn.LayerNorm):
-                module.weight.fill_(1.0)
+                module.weight.fill_(output_scale)
                 module.bias.zero_()
 
 
@@ -257,7 +267,20 @@ def _scatter_projected(
     if not local.numel():
         return unmerged()
     merged = embeddings_out.clone()
-    merged[local, 0] = embeds.to(merged.dtype)
+    kept = embeds.to(merged.dtype)
+    with torch.no_grad():
+        # The scales have to be comparable: a projector row far above the base's
+        # embedding scale is out of the decoder's distribution and overflows the
+        # forward, which shows up as NaN gradients on exactly the merging ranks.
+        logger.info(
+            "projector merge scale: base rms=%.6g absmax=%.6g, projected "
+            "rms=%.6g absmax=%.6g",
+            float(embeddings_out.detach().float().pow(2).mean().sqrt()),
+            float(embeddings_out.detach().float().abs().max()),
+            float(kept.detach().float().pow(2).mean().sqrt()),
+            float(kept.detach().float().abs().max()),
+        )
+    merged[local, 0] = kept
     return merged
 
 
@@ -372,7 +395,7 @@ def projector_model_provider(
             output_dim=cfg.output_dim or model.config.hidden_size,
             num_layers=cfg.num_layers,
         )
-        init_projector(projector, cfg.init_seed)
+        init_projector(projector, cfg.init_seed, cfg.output_scale)
         projector.to(
             device=torch.cuda.current_device(), dtype=model.config.params_dtype
         )

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -690,6 +690,20 @@ def projector_sft_rollout(args, rollout_id: int, data_buffer, evaluation: bool =
                 f"sample {sample.index} places an embedding at token "
                 f"{max_position} of a {len(token_ids)}-token sequence"
             )
+        budget = getattr(args, "seq_length", None)
+        if budget and len(token_ids) > budget:
+            # Positions are offsets into the tokens produced here, and the merge
+            # writes them into the packed micro-batch. Anything that shortens a
+            # sequence between the two shifts every later sample's offset, so a
+            # sample that does not fit the training sequence length is rejected
+            # here rather than merged onto whichever tokens survived.
+            raise ValueError(
+                f"sample {sample.index} tokenizes to {len(token_ids)} tokens, "
+                f"past the {budget}-token training sequence length. Projector "
+                "positions index the tokens this rollout emits, so a truncated "
+                "sequence would move the embeddings onto the wrong tokens; "
+                "shorten the conversation or raise seq_length."
+            )
         sample.multimodal_train_inputs = {
             cfg.embeddings_key: embeddings_t,
             cfg.positions_key: torch.tensor(positions, dtype=torch.long),

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -637,6 +637,13 @@ class _ProjectorSaver:
     the artifact survives a run that performs a different number of steps than
     ``train_iters`` predicted; ``save_interval`` and that prediction decide only
     which steps keep a numbered file too.
+
+    Hanging a collective (the projector gradient all-reduce) off ``optimizer.step``
+    is safe because the hook is per-rank: the pinned image calls
+    ``custom_before_train_step_hook`` unconditionally inside
+    ``megatron_utils/model.py``'s train step, with no rank guard, so every
+    training rank installs this wrapper. A rank that has no projector to reduce
+    would break that symmetry, so ``__init__`` refuses to install instead.
     """
 
     def __init__(self, args, model, optimizer) -> None:
@@ -646,6 +653,20 @@ class _ProjectorSaver:
         )
         chunks = model if isinstance(model, list) else [model]
         self._projectors = [p for c in chunks if (p := get_projector(c)) is not None]
+        if not self._projectors:
+            # Every rank's chunk holds a projector replica (the provider builds
+            # one, and PP>1 is rejected so there is only ever one stage). If one
+            # rank found none, its peers would enter the all-reduce below alone:
+            # fail here rather than hang there, or train replicas that silently
+            # diverge and write a checkpoint from one of them.
+            raise RuntimeError(
+                "projector-only training installed no saver: none of the "
+                f"{len(chunks)} model chunk(s) handed to miles' "
+                "before-train-step hook holds an EmbeddingProjector. The "
+                "custom model provider is what attaches it — check that "
+                "custom_model_provider_path points at "
+                "projector_model_provider."
+            )
         for chunk in chunks:
             direct = chunk.__dict__.get("_training_gym_projector")
             logger.info(
@@ -712,13 +733,6 @@ class _ProjectorSaver:
             )
 
     def _save(self, numbered: bool = True) -> None:
-        if not self._projectors:
-            logger.warning(
-                "projector checkpoint skipped at step %d: no projector found on "
-                "any model chunk handed to the before-train-step hook",
-                self._steps,
-            )
-            return
         if not _is_projector_writer():
             return
         write_projector_checkpoint(

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -142,17 +142,56 @@ def _build_base_model(args, pre_process: bool, post_process: bool, vp_stage):
     )
 
 
-def _mark_sequence_parallel(module: nn.Module) -> None:
-    """Tag replicated parameters so Megatron all-reduces their grads over TP.
+def projector_parameters(projector: nn.Module) -> list[tuple[str, torch.Tensor]]:
+    """Projector parameters in an order identical on every rank.
 
-    With sequence parallelism each tensor-parallel rank holds a different slice
-    of the sequence, so each sees a different subset of projected positions and
-    computes a different gradient for the same replicated weight. Megatron's
-    ``finalize_model_grads`` all-reduces exactly the parameters carrying this
-    attribute (the convention its LayerNorm weights use).
+    The gradient all-reduce below enqueues one collective per parameter, so the
+    iteration order has to agree across ranks or the collectives pair up wrongly
+    and deadlock. ``named_parameters`` walks the module tree deterministically
+    and every rank holds the same replica, but it is sorted anyway so the
+    guarantee does not rest on that.
     """
-    for param in module.parameters():
-        param.sequence_parallel = True
+    return sorted(projector.named_parameters(), key=lambda item: item[0])
+
+
+def all_reduce_projector_grads(projector: nn.Module) -> int:
+    """Sum the replicated projector's gradients across the tensor-parallel group.
+
+    Under sequence parallelism each tensor-parallel rank holds a disjoint slice
+    of the packed sequence, so each computes the gradient of the same replicated
+    weight with respect to a different subset of the projected positions. The
+    whole-sequence gradient is their **sum**, not their average; the
+    data-parallel average is DDP's job and is left alone.
+
+    Every rank enters this unconditionally, once per optimizer step, with a
+    tensor of the same shape for every parameter — materializing a zero gradient
+    when one is missing rather than skipping the collective. Riding Megatron's
+    ``sequence_parallel`` attribute instead (which
+    ``_allreduce_non_tensor_model_parallel_grads`` honors) is what deadlocked:
+    that path is entered per-rank depending on what that rank's gradients look
+    like, and a replicated module whose gradients are data-dependent cannot
+    safely take part.
+    """
+    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+    if ps.get_tensor_model_parallel_world_size() <= 1:
+        return 0
+    group = ps.get_tensor_model_parallel_group()
+    reduced = 0
+    for _, param in projector_parameters(projector):
+        grad = getattr(param, "main_grad", None)
+        if grad is None:
+            if param.grad is None:
+                # No gradient on this rank: still enter the collective, with a
+                # zero of the right shape, and leave the reduced result where
+                # the optimizer will read it.
+                param.grad = torch.zeros_like(param)
+            grad = param.grad
+        torch.distributed.all_reduce(
+            grad, op=torch.distributed.ReduceOp.SUM, group=group
+        )
+        reduced += 1
+    return reduced
 
 
 def _scatter_projected(sequence_parallel, embeddings_out, embeds, positions):
@@ -183,6 +222,12 @@ def _scatter_projected(sequence_parallel, embeddings_out, embeds, positions):
     else:
         local = positions
     if not local.numel():
+        # None of the projected positions live on this rank's sequence shard, so
+        # the projector contributes nothing here and its gradient stays at the
+        # zero Megatron's grad buffers start the iteration at. Keeping it in the
+        # graph with a zero multiplier instead would be a ``0 * inf`` trap; the
+        # unconditional all-reduce in ``all_reduce_projector_grads`` is what
+        # keeps the collectives symmetric.
         return embeddings_out
     merged = embeddings_out.clone()
     merged[local, 0] = embeds.to(merged.dtype)
@@ -257,9 +302,28 @@ class _ProjectorMerge:
 
 
 def get_projector(model) -> EmbeddingProjector | None:
-    """The projector attached to ``model``, if this rank holds one."""
-    projector = model.__dict__.get("_training_gym_projector")
-    return projector if isinstance(projector, EmbeddingProjector) else None
+    """The projector attached to ``model``, if this rank holds one.
+
+    Tolerates wrapping: by the time miles' hooks run, a model chunk is a
+    ``DistributedDataParallel(Float16Module(GPTModel))``, and ``__dict__``
+    indexing does not follow the wrappers' ``__getattr__`` forwarding. The
+    projector is registered with ``add_module("embedding_projector", ...)``, so
+    unwrapping ``.module`` and finally scanning the module tree always reaches
+    it.
+    """
+    obj, depth = model, 0
+    while obj is not None and depth <= 8:
+        projector = obj.__dict__.get("_training_gym_projector")
+        if isinstance(projector, EmbeddingProjector):
+            return projector
+        obj = getattr(obj, "module", None)
+        depth += 1
+    modules = getattr(model, "modules", None)
+    if callable(modules):
+        for sub in modules():
+            if isinstance(sub, EmbeddingProjector):
+                return sub
+    return None
 
 
 def projector_model_provider(
@@ -285,8 +349,6 @@ def projector_model_provider(
             device=torch.cuda.current_device(), dtype=model.config.params_dtype
         )
         projector.requires_grad_(True)
-        if model.config.sequence_parallel:
-            _mark_sequence_parallel(projector)
         model.__dict__["_training_gym_projector"] = projector
         # Registered so Megatron's DDP and the optimizer see the parameters.
         model.add_module("embedding_projector", projector)
@@ -433,13 +495,24 @@ def write_projector_checkpoint(cfg: ProjectorSpec, save_dir: str, projector, ste
             "input_dim": cfg.input_dim,
             "hidden_dim": cfg.hidden_dim,
             "num_layers": cfg.num_layers,
-            "output_dim": cfg.output_dim,
+            # The resolved width, not ``cfg.output_dim``, which is None whenever
+            # the projector's output was sized from the model's hidden size — a
+            # checkpoint has to describe its own shape.
+            "output_dim": _projector_output_dim(projector),
         },
     }
     path = os.path.join(save_dir, f"projector_iter_{step:07d}.pt")
     torch.save(state, path)
     torch.save(state, os.path.join(save_dir, _LATEST))
     logger.info("saved projector checkpoint %s", path)
+
+
+def _projector_output_dim(projector) -> int:
+    """The projector's actual output width, read off its last linear layer."""
+    linears = [m for m in projector.modules() if isinstance(m, nn.Linear)]
+    if linears:
+        return int(linears[-1].out_features)
+    return int(projector.norm.normalized_shape[0])
 
 
 class _ProjectorSaver:
@@ -461,13 +534,24 @@ class _ProjectorSaver:
         )
         chunks = model if isinstance(model, list) else [model]
         self._projectors = [p for c in chunks if (p := get_projector(c)) is not None]
+        for chunk in chunks:
+            direct = chunk.__dict__.get("_training_gym_projector")
+            logger.info(
+                "projector lookup: chunk type=%s bare __dict__ lookup=%s resolved=%s",
+                type(chunk).__name__,
+                "found" if isinstance(direct, EmbeddingProjector) else "None",
+                "found" if get_projector(chunk) is not None else "NOT FOUND",
+            )
         self._total_steps = int(getattr(args, "train_iters", 0) or 0)
         self._steps = 0
         self._original_step = optimizer.step
         optimizer.step = self._step
 
     def _step(self, *fargs, **fkwargs):
+        for projector in self._projectors:
+            all_reduce_projector_grads(projector)
         out = self._original_step(*fargs, **fkwargs)
+        self._log_replica_state()
         # Megatron returns (success, grad_norm, num_zeros); a step that did not
         # apply (gradient overflow) left the projector unchanged.
         if isinstance(out, tuple) and out and out[0] is False:
@@ -479,8 +563,40 @@ class _ProjectorSaver:
             self._save()
         return out
 
+    def _log_replica_state(self) -> None:
+        """Log a per-rank fingerprint of the projector, so replicas can be compared.
+
+        Every rank holds a replica whose gradients are all-reduced, so after a
+        step the weights must be bit-identical across ranks; a divergence here
+        means the all-reduce is misplaced and the ranks have silently forked.
+        """
+        import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+        for projector in self._projectors:
+            name, param = projector_parameters(projector)[0]
+            with torch.no_grad():
+                checksum = float(param.detach().float().abs().sum().item())
+                norm = float(param.detach().float().norm().item())
+            logger.info(
+                "projector replica after step %d: tp_rank=%d dp_rank=%d %s "
+                "norm=%.8f abs_sum=%.8f",
+                self._steps + 1,
+                ps.get_tensor_model_parallel_rank(),
+                ps.get_data_parallel_rank(),
+                name,
+                norm,
+                checksum,
+            )
+
     def _save(self) -> None:
-        if not self._projectors or not _is_projector_writer():
+        if not self._projectors:
+            logger.warning(
+                "projector checkpoint skipped at step %d: no projector found on "
+                "any model chunk handed to the before-train-step hook",
+                self._steps,
+            )
+            return
+        if not _is_projector_writer():
             return
         write_projector_checkpoint(
             self._cfg, self._save_dir, self._projectors[0], self._steps

--- a/modal_training_gym/frameworks/miles/phase_reporting.py
+++ b/modal_training_gym/frameworks/miles/phase_reporting.py
@@ -62,6 +62,16 @@ CUSTOM_BEFORE_TRAIN_STEP_HOOK_PATH_KEY = (
 
 
 def _hook_path_from_args(args: Any, path_key: str) -> str | None:
+    """The user hook this module's wrapper for ``path_key`` should dispatch to.
+
+    A nested container may hold this module's own wrapper path — the flag miles
+    was launched with often lands there too — and dispatching to it would
+    re-enter the wrapper forever, so only this module's own functions are
+    excluded. Other ``modal_training_gym`` hooks are dispatchable: the projector
+    recipe wraps one (its gradient all-reduce and checkpoint writer hang off it),
+    and skipping it would leave a run with unreduced gradients and no
+    checkpoints.
+    """
     direct = getattr(args, path_key, None)
     if isinstance(direct, str) and direct.strip():
         return direct
@@ -76,7 +86,7 @@ def _hook_path_from_args(args: Any, path_key: str) -> str | None:
             if (
                 isinstance(value, str)
                 and value.strip()
-                and not value.startswith("modal_training_gym.")
+                and not value.strip().startswith(f"{__name__}.")
             ):
                 return value
     return None

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -53,7 +53,9 @@ class ProjectorSpec:
         Directory for projector checkpoints; empty puts them under
         ``<save>/projector``.
     save_interval : int
-        Save the projector every N rollout steps.
+        Save the projector every N optimizer steps. The final step of a run is
+        always saved regardless, so a finished run leaves a checkpoint even when
+        the interval does not divide the step count.
     load : str
         Projector checkpoint (file or directory) to resume from.
     """
@@ -80,6 +82,20 @@ class ProjectorSpec:
             "save_interval": self.save_interval,
             "load": self.load,
         }
+
+
+def should_save_projector(
+    steps_done: int, total_steps: int, save_interval: int
+) -> bool:
+    """Whether the projector should be written after ``steps_done`` steps.
+
+    Steps are optimizer steps, and the run's last one always saves: a finished
+    run has to leave the adapter it spent its GPU budget producing, whether or
+    not the interval happens to divide the step count.
+    """
+    if total_steps > 0 and steps_done >= total_steps:
+        return True
+    return save_interval > 0 and steps_done % save_interval == 0
 
 
 def from_miles_args(args: object) -> ProjectorSpec:

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -58,6 +58,10 @@ class ProjectorSpec:
         the interval does not divide the step count.
     load : str
         Projector checkpoint (file or directory) to resume from.
+    init_seed : int
+        Seed the projector's weights are initialized from. Every rank holds a
+        replica whose gradients are all-reduced, so the initialization must not
+        depend on the ambient RNG state a rank happens to be in.
     """
 
     input_dim: int = 1536
@@ -69,6 +73,7 @@ class ProjectorSpec:
     save_dir: str = ""
     save_interval: int = 10
     load: str = ""
+    init_seed: int = 0
 
     def to_args_dict(self) -> dict[str, int | str | None]:
         return {
@@ -81,6 +86,7 @@ class ProjectorSpec:
             "save_dir": self.save_dir,
             "save_interval": self.save_interval,
             "load": self.load,
+            "init_seed": self.init_seed,
         }
 
 

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -124,17 +124,31 @@ class ProjectorSpec:
 
 
 def should_save_projector(
-    steps_done: int, total_steps: int, save_interval: int
+    steps_applied: int, steps_attempted: int, total_steps: int, save_interval: int
 ) -> bool:
-    """Whether the projector should be written after ``steps_done`` steps.
+    """Whether the projector should be written, after an optimizer step.
 
-    Steps are optimizer steps, and the run's last one always saves: a finished
-    run has to leave the adapter it spent its GPU budget producing, whether or
-    not the interval happens to divide the step count.
+    The run's last step always saves: a finished run has to leave the adapter it
+    spent its GPU budget producing, whether or not the interval happens to
+    divide the step count.
+
+    Which step is the last one is decided by ``steps_attempted`` against
+    ``total_steps`` (miles' ``train_iters``, a count of attempts), while the
+    interval counts ``steps_applied`` — so ``save_interval`` means what it says
+    and skipped updates do not shift it. Counting only applied steps for both
+    would lose the whole artifact on a run whose interval saves nothing and
+    where one update was skipped for a gradient overflow: the count would end
+    one short of the total, the final-step guarantee would never fire, and the
+    run would exit having written nothing.
+
+    Nothing is written before an update has applied, so a projector still at its
+    initialization is never mistaken for a trained one.
     """
-    if total_steps > 0 and steps_done >= total_steps:
+    if steps_applied <= 0:
+        return False
+    if total_steps > 0 and steps_attempted >= total_steps:
         return True
-    return save_interval > 0 and steps_done % save_interval == 0
+    return save_interval > 0 and steps_applied % save_interval == 0
 
 
 def from_miles_args(args: object) -> ProjectorSpec:

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -58,7 +58,9 @@ class ProjectorSpec:
         always saved regardless, so a finished run leaves a checkpoint even when
         the interval does not divide the step count.
     load : str
-        Projector checkpoint (file or directory) to resume from.
+        Projector checkpoint (file or directory) to resume from. The resumed
+        run continues that checkpoint's iteration numbering, so reusing one
+        ``save_dir`` across resumes does not overwrite what came before.
     output_scale : float
         Scale the projector's final ``LayerNorm`` starts at, and so the scale of
         the rows it writes into the embedding stream. A ``LayerNorm`` output is

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -29,6 +29,60 @@ ROLLOUT_PATH = (
 EMBEDDINGS_KEY = "projector_embeddings"
 POSITIONS_KEY = "projector_positions"
 
+_STEP_HOOK_KEY = "training_gym_custom_megatron_before_train_step_hook_path"
+
+
+def _step_hook_path(args) -> str | None:
+    """Resolve the hook miles' reporting wrapper will dispatch to.
+
+    Mirrors ``phase_reporting._hook_path_from_args``: the recipe's own hook
+    travels in ``extra_config`` (miles sets every key on ``args``) while the
+    ``--custom-megatron-before-train-step-hook-path`` flag names the gym's
+    reporting wrapper.
+    """
+    direct = getattr(args, _STEP_HOOK_KEY, None)
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    for container_name in ("extra_config", "custom_config"):
+        container = getattr(args, container_name, None)
+        if isinstance(container, dict):
+            value = container.get(_STEP_HOOK_KEY) or container.get(
+                _STEP_HOOK_KEY.removeprefix("training_gym_")
+            )
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def require_projector_step_hook(args) -> None:
+    """Fail at model construction when the projector's step hook is unwired.
+
+    ``save_projector_checkpoint`` is the only thing that installs the
+    ``optimizer.step`` wrapper, and that wrapper owns two jobs nothing else
+    does: the tensor-parallel all-reduce of the replicated projector's
+    gradients, and writing the projector checkpoints. Neither announces its
+    absence, so a run whose hook never fires would train on
+    tensor-parallel-partial gradients and finish with nothing saved. The wiring
+    is a recipe default, but it reaches the container through ``extra_config``,
+    so the provider checks it — miles has to call the provider for the run to
+    exist at all — rather than trusting it.
+    """
+    wrapper = getattr(args, "custom_megatron_before_train_step_hook_path", None)
+    wrapper = wrapper.strip() if isinstance(wrapper, str) else ""
+    wrapped = _step_hook_path(args)
+    if SAVE_HOOK_PATH in (wrapper, wrapped):
+        return
+    raise ValueError(
+        "projector-only training needs miles' before-train-step hook to reach "
+        f"'{SAVE_HOOK_PATH}', which installs the projector's gradient "
+        "all-reduce and checkpoint writer, but this run resolves "
+        f"--custom-megatron-before-train-step-hook-path to '{wrapper}' and the "
+        f"gym's wrapped hook to '{wrapped}'. Launch through "
+        "GLM_5_2_Projector_Recipe (or point "
+        "custom_megatron_before_train_step_hook at that path) rather than "
+        "training with unreduced gradients and no checkpoints."
+    )
+
 
 @dataclass(config=ConfigDict(extra="forbid"))
 class ProjectorSpec:

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -1,0 +1,94 @@
+"""Wire format between a projector-only recipe and the miles containers.
+
+Kept free of torch so the launching side can import it: the recipe serializes a
+:class:`ProjectorSpec` into ``extra_config`` under :data:`ARGS_KEY`, miles sets
+every ``extra_config`` key on ``args``, and
+:mod:`modal_training_gym.frameworks.miles.embedding_projector` reads it back
+inside the container. No new miles CLI flags are involved.
+"""
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+
+# Miles arg carrying the serialized ProjectorSpec.
+ARGS_KEY = "training_gym_projector"
+
+PROVIDER_PATH = (
+    "modal_training_gym.frameworks.miles.embedding_projector.projector_model_provider"
+)
+SAVE_HOOK_PATH = (
+    "modal_training_gym.frameworks.miles.embedding_projector.save_projector_checkpoint"
+)
+ROLLOUT_PATH = (
+    "modal_training_gym.frameworks.miles.embedding_projector.projector_sft_rollout"
+)
+
+# Keys of the per-sample tensor dict miles concatenates over a packed batch and
+# splats into ``model.forward``. ``_positions`` is miles' own suffix convention:
+# it offsets any such key by the sample's start in the packed sequence.
+EMBEDDINGS_KEY = "projector_embeddings"
+POSITIONS_KEY = "projector_positions"
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class ProjectorSpec:
+    """The projector's shape, its data keys, and where its checkpoints go.
+
+    input_dim : int
+        Width of the embeddings the dataset supplies — the external encoder's
+        output dimension.
+    hidden_dim : int
+        Width of the projector's inner layers.
+    num_layers : int
+        Linear layers in the projector; 1 makes it a single linear map.
+    output_dim : int | None
+        Width of the projected vectors; ``None`` uses the model's hidden size,
+        which is what writing into the decoder's input embeddings requires.
+    embeddings_key : str
+        Dataset column (and ``forward`` keyword) holding the per-token
+        embeddings, as one ``[num_tokens, input_dim]`` tensor per sample.
+    positions_key : str
+        Dataset column holding the token positions those embeddings occupy.
+    save_dir : str
+        Directory for projector checkpoints; empty puts them under
+        ``<save>/projector``.
+    save_interval : int
+        Save the projector every N rollout steps.
+    load : str
+        Projector checkpoint (file or directory) to resume from.
+    """
+
+    input_dim: int = 1536
+    hidden_dim: int = 4096
+    num_layers: int = 2
+    output_dim: int | None = None
+    embeddings_key: str = EMBEDDINGS_KEY
+    positions_key: str = POSITIONS_KEY
+    save_dir: str = ""
+    save_interval: int = 10
+    load: str = ""
+
+    def to_args_dict(self) -> dict[str, int | str | None]:
+        return {
+            "input_dim": self.input_dim,
+            "hidden_dim": self.hidden_dim,
+            "num_layers": self.num_layers,
+            "output_dim": self.output_dim,
+            "embeddings_key": self.embeddings_key,
+            "positions_key": self.positions_key,
+            "save_dir": self.save_dir,
+            "save_interval": self.save_interval,
+            "load": self.load,
+        }
+
+
+def from_miles_args(args: object) -> ProjectorSpec:
+    """Rebuild the spec the recipe serialized, from miles' parsed ``args``."""
+    raw = vars(args).get(ARGS_KEY)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"miles arg '{ARGS_KEY}' is missing or not a dict (got {raw!r}). A "
+            "projector-only run needs the recipe to serialize a ProjectorSpec "
+            "into extra_config."
+        )
+    return ProjectorSpec(**raw)

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -153,12 +153,27 @@ def should_save_projector(
 
 
 def from_miles_args(args: object) -> ProjectorSpec:
-    """Rebuild the spec the recipe serialized, from miles' parsed ``args``."""
-    raw = vars(args).get(ARGS_KEY)
-    if not isinstance(raw, dict):
-        raise ValueError(
-            f"miles arg '{ARGS_KEY}' is missing or not a dict (got {raw!r}). A "
-            "projector-only run needs the recipe to serialize a ProjectorSpec "
-            "into extra_config."
-        )
-    return ProjectorSpec(**raw)
+    """Rebuild the spec the recipe serialized, from miles' parsed ``args``.
+
+    The pinned image flattens every ``extra_config`` entry onto ``args``, which
+    is where this looks first. The nested containers are read as a fallback for
+    the same reason the gym's other in-container readers do
+    (:func:`modal_training_gym.common.reporting._arg_value`): a run must not
+    lose its projector to a config-plumbing change that keeps the dict nested.
+    """
+    candidates = [getattr(args, ARGS_KEY, None)]
+    for container_name in ("extra_config", "custom_config"):
+        container = getattr(args, container_name, None)
+        if isinstance(container, dict):
+            candidates.append(container.get(ARGS_KEY))
+
+    for raw in candidates:
+        if isinstance(raw, dict):
+            return ProjectorSpec(**raw)
+
+    raise ValueError(
+        f"miles arg '{ARGS_KEY}' is missing or not a dict (looked at args."
+        f"{ARGS_KEY}, args.extra_config and args.custom_config, got "
+        f"{candidates!r}). A projector-only run needs the recipe to serialize a "
+        "ProjectorSpec into extra_config."
+    )

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -126,27 +126,28 @@ class ProjectorSpec:
 def should_save_projector(
     steps_applied: int, steps_attempted: int, total_steps: int, save_interval: int
 ) -> bool:
-    """Whether the projector should be written, after an optimizer step.
+    """Whether this optimizer step keeps its own numbered projector checkpoint.
 
-    The run's last step always saves: a finished run has to leave the adapter it
-    spent its GPU budget producing, whether or not the interval happens to
-    divide the step count.
+    ``projector_latest.pt`` is refreshed after every applied step regardless, so
+    a finished run always leaves the adapter it spent its GPU budget producing;
+    this decides only which steps additionally keep a ``projector_iter_*.pt``.
+    That split is deliberate: ``total_steps`` is miles' ``train_iters``, which it
+    derives arithmetically from the rollout counts, and an epoch-driven
+    dynamically batched run need not perform exactly that many optimizer steps —
+    so nothing that matters may depend on the prediction being right.
 
-    Which step is the last one is decided by ``steps_attempted`` against
-    ``total_steps`` (miles' ``train_iters``, a count of attempts), while the
-    interval counts ``steps_applied`` — so ``save_interval`` means what it says
-    and skipped updates do not shift it. Counting only applied steps for both
-    would lose the whole artifact on a run whose interval saves nothing and
-    where one update was skipped for a gradient overflow: the count would end
-    one short of the total, the final-step guarantee would never fire, and the
-    run would exit having written nothing.
+    The interval counts ``steps_applied`` (so ``save_interval`` means what it
+    says and an overflow-skipped update does not shift it), while the predicted
+    last step is matched on ``steps_attempted``, which is what ``train_iters``
+    counts. It is an equality, not ``>=``: a run that outlives the prediction
+    should not then keep a numbered checkpoint on every step.
 
     Nothing is written before an update has applied, so a projector still at its
     initialization is never mistaken for a trained one.
     """
     if steps_applied <= 0:
         return False
-    if total_steps > 0 and steps_attempted >= total_steps:
+    if total_steps > 0 and steps_attempted == total_steps:
         return True
     return save_interval > 0 and steps_applied % save_interval == 0
 

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -7,7 +7,7 @@ every ``extra_config`` key on ``args``, and
 inside the container. No new miles CLI flags are involved.
 """
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 from pydantic.dataclasses import dataclass
 
 # Miles arg carrying the serialized ProjectorSpec.
@@ -48,7 +48,8 @@ class ProjectorSpec:
         Dataset column (and ``forward`` keyword) holding the per-token
         embeddings, as one ``[num_tokens, input_dim]`` tensor per sample.
     positions_key : str
-        Dataset column holding the token positions those embeddings occupy.
+        Dataset column holding the token positions those embeddings occupy. Has
+        to keep the ``_positions`` suffix miles' packing convention keys off.
     save_dir : str
         Directory for projector checkpoints; empty puts them under
         ``<save>/projector``.
@@ -74,6 +75,24 @@ class ProjectorSpec:
     save_interval: int = 10
     load: str = ""
     init_seed: int = 0
+
+    @model_validator(mode="after")
+    def _positions_key_keeps_miles_suffix(self) -> "ProjectorSpec":
+        """Miles only offsets packed-batch keys whose name ends in ``_positions``.
+
+        Positions are absolute offsets into the packed sequence, which only holds
+        because miles adds each sample's start offset to those keys. Under any
+        other name the offset is silently skipped and every sample's embeddings
+        land on the first sample's tokens.
+        """
+        if not self.positions_key.endswith("_positions"):
+            raise ValueError(
+                f"positions_key={self.positions_key!r} must end in '_positions': "
+                "miles adds each sample's offset in the packed batch only to keys "
+                "with that suffix, and the projector's positions are absolute "
+                "offsets into the packed sequence."
+            )
+        return self
 
     def to_args_dict(self) -> dict[str, int | str | None]:
         return {

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -59,6 +59,12 @@ class ProjectorSpec:
         the interval does not divide the step count.
     load : str
         Projector checkpoint (file or directory) to resume from.
+    output_scale : float
+        Scale the projector's final ``LayerNorm`` starts at, and so the scale of
+        the rows it writes into the embedding stream. A ``LayerNorm`` output is
+        unit-std, a decoder's token embeddings are ~1e-2 std, so the default
+        keeps the injected rows in the base's distribution instead of ~50-100x
+        above it. Learnable, so training can grow it.
     init_seed : int
         Seed the projector's weights are initialized from. Every rank holds a
         replica whose gradients are all-reduced, so the initialization must not
@@ -74,17 +80,24 @@ class ProjectorSpec:
     save_dir: str = ""
     save_interval: int = 10
     load: str = ""
+    output_scale: float = 0.01
     init_seed: int = 0
 
     @model_validator(mode="after")
-    def _positions_key_keeps_miles_suffix(self) -> "ProjectorSpec":
-        """Miles only offsets packed-batch keys whose name ends in ``_positions``.
+    def _reject_silently_wrong_settings(self) -> "ProjectorSpec":
+        """Both of these produce a run that trains on garbage without erroring.
 
-        Positions are absolute offsets into the packed sequence, which only holds
-        because miles adds each sample's start offset to those keys. Under any
-        other name the offset is silently skipped and every sample's embeddings
-        land on the first sample's tokens.
+        Miles offsets a packed-batch key by the sample's start in the packed
+        sequence only when the key's name ends in ``_positions``; under any other
+        name the offset is skipped and every sample's embeddings land on the first
+        sample's tokens.
         """
+        if self.output_scale <= 0:
+            raise ValueError(
+                f"output_scale={self.output_scale} must be positive: it is the "
+                "initial gain of the projector's output LayerNorm, and zero "
+                "would start training from a projector that writes nothing."
+            )
         if not self.positions_key.endswith("_positions"):
             raise ValueError(
                 f"positions_key={self.positions_key!r} must end in '_positions': "
@@ -94,7 +107,7 @@ class ProjectorSpec:
             )
         return self
 
-    def to_args_dict(self) -> dict[str, int | str | None]:
+    def to_args_dict(self) -> dict[str, int | float | str | None]:
         return {
             "input_dim": self.input_dim,
             "hidden_dim": self.hidden_dim,
@@ -105,6 +118,7 @@ class ProjectorSpec:
             "save_dir": self.save_dir,
             "save_interval": self.save_interval,
             "load": self.load,
+            "output_scale": self.output_scale,
             "init_seed": self.init_seed,
         }
 

--- a/modal_training_gym/frameworks/miles/projector_eval.py
+++ b/modal_training_gym/frameworks/miles/projector_eval.py
@@ -1,0 +1,459 @@
+"""Held-out evaluation of a projector-only checkpoint.
+
+A projector-only run trains supervised, with no rollout engine (see
+:class:`~modal_training_gym.train_recipes.miles_recipe.glm_5_2.GLM_5_2_Projector_Recipe`),
+so its loss is the only number it produces and miles' eval pass is rejected at
+launch — the rollout function has nothing to generate with. That leaves the
+question a projector run actually cares about unanswered: on proteins it never
+trained on, does the frozen base read the projected vector well enough to name
+the right answer?
+
+This module answers it outside miles. It loads the projector checkpoint the run
+wrote, rebuilds the module from the shape recorded in the checkpoint, loads the
+same base model as a plain HF causal LM, and for each held-out row scores every
+candidate answer by its mean token log-probability with the projected embedding
+written into ``inputs_embeds`` at the row's position — the same merge the
+training forward does. The prediction is the highest-scoring candidate.
+
+Three numbers come out, and only their differences mean anything:
+
+* the trained projector's accuracy,
+* the same architecture untrained (identical init to what training started
+  from), which is what "the projector contributes nothing" looks like, and
+* the majority-class share of the eval split, which is what a model that
+  ignores its input can score.
+
+Results are written to the metadata volume as a normal
+:class:`~modal_training_gym.common.eval.EvalResult`, so the run shows up in the
+dashboard's evals view next to every other eval, with per-row predictions.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.ids import create_hash
+
+#: Rows whose generated text is printed and stored for eyeballing. Generation is
+#: much slower than scoring and adds nothing to the metric, so it is sampled.
+_GENERATE_ROWS = 8
+
+
+@dataclass
+class ProjectorEvalRow:
+    """One held-out row: what the model was asked, and what it answered."""
+
+    prompt: str
+    target: str
+    prediction: str
+    correct: bool
+    scores: dict[str, float]
+    generated: str = ""
+
+
+@dataclass
+class ProjectorEvalReport:
+    """Accuracy of a projector checkpoint against its two baselines."""
+
+    model_name: str
+    checkpoint: str
+    iteration: int
+    classes: list[str]
+    rows: list[ProjectorEvalRow] = field(default_factory=list)
+    untrained_rows: list[ProjectorEvalRow] = field(default_factory=list)
+
+    @staticmethod
+    def _accuracy(rows: list[ProjectorEvalRow]) -> float:
+        return sum(row.correct for row in rows) / len(rows) if rows else 0.0
+
+    @property
+    def accuracy(self) -> float:
+        return self._accuracy(self.rows)
+
+    @property
+    def untrained_accuracy(self) -> float:
+        return self._accuracy(self.untrained_rows)
+
+    @property
+    def majority_accuracy(self) -> float:
+        """What predicting the eval split's most common class alone scores."""
+        counts: dict[str, int] = {}
+        for row in self.rows:
+            counts[row.target] = counts.get(row.target, 0) + 1
+        return max(counts.values()) / len(self.rows) if self.rows else 0.0
+
+    def summary(self) -> str:
+        if not self.classes:
+            return "no classes"
+        return (
+            f"{self.checkpoint} (iteration {self.iteration}) on "
+            f"{len(self.rows)} held-out rows, {len(self.classes)} classes: "
+            f"trained {self.accuracy:.3f}, untrained {self.untrained_accuracy:.3f}, "
+            f"majority class {self.majority_accuracy:.3f}, "
+            f"uniform {1 / len(self.classes):.3f}"
+        )
+
+    def publish(self) -> str:
+        """Save as an :class:`EvalResult` so the dashboard renders the run.
+
+        Returns the ``eval_id``. Per-row predictions ride in ``metadata`` and the
+        headline mean is accuracy, since each row scores 1 or 0.
+        """
+        from modal_training_gym.common.eval import (
+            EvalConfigDurable,
+            EvalResult,
+            EvalRowResult,
+        )
+
+        eval_config_id = create_hash(
+            "eval-config", "ProjectorEval", self.model_name, ",".join(self.classes)
+        )
+        EvalConfigDurable(
+            eval_config_id=eval_config_id,
+            dataset_name="projector-heldout",
+            eval_fn_name="projector_class_scoring",
+        ).save()
+        result = EvalResult(
+            eval_id=create_hash("eval", eval_config_id, self.checkpoint),
+            eval_config_id=eval_config_id,
+            model_name=self.model_name,
+            rows=[
+                EvalRowResult(
+                    score=1.0 if row.correct else 0.0,
+                    response=row.prediction,
+                    prompt=row.prompt,
+                    metadata={
+                        "target": row.target,
+                        "generated": row.generated,
+                        "scores": row.scores,
+                        "checkpoint": self.checkpoint,
+                        "iteration": self.iteration,
+                        "untrained_accuracy": self.untrained_accuracy,
+                        "majority_accuracy": self.majority_accuracy,
+                    },
+                )
+                for row in self.rows
+            ],
+        )
+        result.save()
+        return result.eval_id
+
+
+@dataclass
+class ProjectorEval:
+    """Run :func:`evaluate_projector` on Modal against a finished run's outputs.
+
+    Takes the same three objects the training run took plus its
+    ``training_run_id``, and reads what that run left on the volumes: the eval
+    split the dataset's ``prepare()`` wrote, and the projector checkpoint the
+    save hook wrote under the run's checkpoint directory. One GPU container, no
+    cluster — the eval is a forward pass per (row, candidate) over a frozen
+    base.
+    """
+
+    model: Any
+    recipe: Any
+    dataset: Any
+    training_run_id: str
+    gpu: str = ""
+    timeout: int = 2 * 60 * 60
+    checkpoint: str = ""
+
+    def _volume_prefix(self) -> str:
+        # Same derivation as build_miles_app, so this reads the volumes the run
+        # wrote rather than creating empty ones next to them.
+        return (
+            getattr(self.recipe, "name", "")
+            or f"miles-{type(self.recipe).__name__.lstrip('_').lower()}"
+        )
+
+    def _checkpoint_path(self) -> str:
+        from modal_training_gym.train_recipes.base import CHECKPOINTS_PATH
+
+        if self.checkpoint:
+            return self.checkpoint
+        save_dir = self.recipe.projector.save_dir or (
+            f"{CHECKPOINTS_PATH}/{self.training_run_id}/projector"
+        )
+        return f"{save_dir}/projector_latest.pt"
+
+    def _eval_path(self) -> str:
+        from modal_training_gym.train_recipes.base import TrainRecipe
+
+        _train, eval_paths = TrainRecipe._resolve_data_paths(self.dataset)
+        if not eval_paths:
+            raise TrainingGymConfigError(
+                f"{type(self.dataset).__name__} writes no eval split, so there "
+                "is nothing held out to evaluate on. Use a dataset whose "
+                "prepare() materializes an eval path (writes_eval_paths=True)."
+            )
+        return eval_paths["eval"]
+
+    def run(self, publish: bool = True) -> ProjectorEvalReport:
+        import modal
+
+        from modal_training_gym.common import hf_secrets
+        from modal_training_gym.train_recipes.base import (
+            CHECKPOINTS_PATH,
+            DATA_PATH,
+            HF_CACHE_PATH,
+        )
+
+        prefix = self._volume_prefix()
+        image = (
+            modal.Image.from_registry(self.recipe.docker_image)
+            .entrypoint([])
+            .add_local_python_source("modal_training_gym", copy=True)
+        )
+        app = modal.App(f"{prefix}-projector-eval", image=image)
+        volumes = {
+            str(HF_CACHE_PATH): modal.Volume.from_name(
+                "huggingface-cache", create_if_missing=True
+            ),
+            str(DATA_PATH): modal.Volume.from_name(
+                f"{prefix}-data", create_if_missing=True
+            ),
+            str(CHECKPOINTS_PATH): modal.Volume.from_name(
+                f"{prefix}-checkpoints", create_if_missing=True
+            ),
+        }
+        gpu = (
+            self.gpu or f"{self.recipe.gpu_type}:{self.recipe.actor_num_gpus_per_node}"
+        )
+        model_name = self.model.model_name
+        checkpoint, eval_path = self._checkpoint_path(), self._eval_path()
+        spec = self.recipe.projector
+
+        @app.function(
+            gpu=gpu,
+            volumes=volumes,
+            timeout=self.timeout,
+            secrets=hf_secrets(),
+            serialized=True,
+            name="evaluate",
+        )
+        def evaluate() -> ProjectorEvalReport:
+            report = evaluate_projector(
+                model_name=model_name,
+                checkpoint=checkpoint,
+                eval_path=eval_path,
+                embeddings_key=spec.embeddings_key,
+                positions_key=spec.positions_key,
+            )
+            if publish:
+                print(f"published eval {report.publish()}", flush=True)
+            return report
+
+        with app.run():
+            return evaluate.remote()
+
+
+def read_eval_rows(path: str, embeddings_key: str, positions_key: str) -> list[dict]:
+    """Read the JSONL an ``EmbeddingProjectorDataset`` wrote for its eval split.
+
+    The candidate answers are the distinct assistant turns in the file rather
+    than a list passed in: the dataset already decided what the targets are, and
+    a second declaration of them is a second thing to keep in sync.
+    """
+    rows: list[dict[str, Any]] = []
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            messages = record.get("messages") or []
+            metadata = record.get("metadata") or {}
+            targets = [m for m in messages if m.get("role") == "assistant"]
+            if not targets:
+                raise TrainingGymConfigError(
+                    f"{path} has a row with no assistant turn, so it declares no "
+                    "answer to score against"
+                )
+            rows.append(
+                {
+                    "messages": [m for m in messages if m.get("role") != "assistant"],
+                    "target": str(targets[-1].get("content", "")).strip(),
+                    "embeddings": metadata[embeddings_key],
+                    "positions": metadata[positions_key],
+                }
+            )
+    if not rows:
+        raise TrainingGymConfigError(f"{path} is empty")
+    return rows
+
+
+def load_projector(checkpoint: str, dtype: Any = None, trained: bool = True):
+    """Rebuild the projector from ``checkpoint``'s recorded shape.
+
+    ``trained=False`` returns the same architecture at the initialization the
+    run started from — the baseline that isolates training from the mere
+    presence of a vector in the embedding stream.
+    """
+    import torch
+
+    from modal_training_gym.frameworks.miles.embedding_projector import (
+        EmbeddingProjector,
+        init_projector,
+    )
+    from modal_training_gym.frameworks.miles.projector_config import ProjectorSpec
+
+    state = torch.load(checkpoint, map_location="cpu", weights_only=True)
+    config = state["config"]
+    projector = EmbeddingProjector(
+        input_dim=config["input_dim"],
+        hidden_dim=config["hidden_dim"],
+        output_dim=config["output_dim"],
+        num_layers=config["num_layers"],
+    )
+    if trained:
+        projector.load_state_dict(state["state_dict"])
+    else:
+        defaults = ProjectorSpec()
+        init_projector(projector, defaults.init_seed, defaults.output_scale)
+    if dtype is not None:
+        projector = projector.to(dtype)
+    projector.eval()
+    return projector, int(state.get("iteration", 0))
+
+
+def _candidate_scores(model, tokenizer, prompt_ids, inputs_embeds, candidates):
+    """Mean log-probability of each candidate answer after the prompt.
+
+    Mean rather than sum: the candidates are class names of different token
+    lengths ("nucleus" against "endoplasmic reticulum"), and a summed
+    log-probability would rank by brevity as much as by fit.
+    """
+    import torch
+
+    embed = model.get_input_embeddings()
+    scores: dict[str, float] = {}
+    for candidate in candidates:
+        answer_ids = tokenizer(candidate, add_special_tokens=False)["input_ids"]
+        answer = torch.tensor([answer_ids], device=inputs_embeds.device)
+        full = torch.cat([inputs_embeds, embed(answer).to(inputs_embeds.dtype)], dim=1)
+        with torch.no_grad():
+            logits = model(
+                inputs_embeds=full,
+                attention_mask=torch.ones(full.shape[:2], device=full.device),
+            ).logits
+        # Position of the logits that predict the answer's first token: the last
+        # prompt position.
+        start = prompt_ids.shape[1] - 1
+        logprobs = torch.log_softmax(
+            logits[0, start : start + len(answer_ids)].float(), dim=-1
+        )
+        total = logprobs[torch.arange(len(answer_ids)), answer[0]].sum().item()
+        scores[candidate] = total / len(answer_ids)
+    return scores
+
+
+def evaluate_projector(
+    model_name: str,
+    checkpoint: str,
+    eval_path: str,
+    embeddings_key: str,
+    positions_key: str,
+    generate_rows: int = _GENERATE_ROWS,
+) -> ProjectorEvalReport:
+    """Score a projector checkpoint on a held-out split. Runs on a GPU container."""
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    rows = read_eval_rows(eval_path, embeddings_key, positions_key)
+    classes = sorted({row["target"] for row in rows})
+    if len(classes) < 2:
+        raise TrainingGymConfigError(
+            f"{eval_path} has a single distinct answer ({classes}), so accuracy "
+            "on it says nothing"
+        )
+    print(f"{len(rows)} held-out rows, {len(classes)} classes: {classes}", flush=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        trust_remote_code=True,
+        torch_dtype=torch.bfloat16,
+        device_map="auto",
+    )
+    model.eval()
+    device = next(model.parameters()).device
+    embed = model.get_input_embeddings()
+
+    trained, iteration = load_projector(checkpoint, torch.bfloat16, trained=True)
+    untrained, _ = load_projector(checkpoint, torch.bfloat16, trained=False)
+    trained, untrained = trained.to(device), untrained.to(device)
+
+    report = ProjectorEvalReport(
+        model_name=model_name,
+        checkpoint=checkpoint,
+        iteration=iteration,
+        classes=classes,
+    )
+
+    for index, row in enumerate(rows):
+        rendered = tokenizer.apply_chat_template(
+            row["messages"], add_generation_prompt=True, tokenize=False
+        )
+        prompt_ids = torch.tensor(
+            [tokenizer(rendered, add_special_tokens=False)["input_ids"]], device=device
+        )
+        vectors = torch.tensor(row["embeddings"], dtype=torch.bfloat16, device=device)
+        positions = list(row["positions"])
+        if max(positions) >= prompt_ids.shape[1]:
+            raise TrainingGymConfigError(
+                f"row {index} places an embedding at token {max(positions)} of a "
+                f"{prompt_ids.shape[1]}-token prompt"
+            )
+
+        for projector, bucket in (
+            (trained, report.rows),
+            (untrained, report.untrained_rows),
+        ):
+            inputs_embeds = embed(prompt_ids).clone()
+            with torch.no_grad():
+                projected = projector(vectors)
+            for offset, position in enumerate(positions):
+                inputs_embeds[0, position, :] = projected[offset].to(
+                    inputs_embeds.dtype
+                )
+            scores = _candidate_scores(
+                model, tokenizer, prompt_ids, inputs_embeds, classes
+            )
+            prediction = max(scores, key=lambda candidate: scores[candidate])
+            generated = ""
+            if bucket is report.rows and index < generate_rows:
+                with torch.no_grad():
+                    out = model.generate(
+                        inputs_embeds=inputs_embeds,
+                        attention_mask=torch.ones(
+                            inputs_embeds.shape[:2], device=device
+                        ),
+                        max_new_tokens=12,
+                        do_sample=False,
+                    )
+                generated = tokenizer.decode(out[0], skip_special_tokens=True)
+            bucket.append(
+                ProjectorEvalRow(
+                    prompt=rendered,
+                    target=row["target"],
+                    prediction=prediction,
+                    correct=prediction == row["target"],
+                    scores=scores,
+                    generated=generated,
+                )
+            )
+
+        last = report.rows[-1]
+        print(
+            f"row {index}: target={last.target!r} prediction={last.prediction!r} "
+            f"untrained={report.untrained_rows[-1].prediction!r}"
+            + (f" generated={last.generated!r}" if last.generated else ""),
+            flush=True,
+        )
+
+    print(report.summary(), flush=True)
+    return report

--- a/modal_training_gym/frameworks/miles/projector_eval.py
+++ b/modal_training_gym/frameworks/miles/projector_eval.py
@@ -41,6 +41,9 @@ from modal_training_gym.common.ids import create_hash
 #: much slower than scoring and adds nothing to the metric, so it is sampled.
 _GENERATE_ROWS = 8
 
+# Not ``HF_CACHE_PATH``: see the mount comment in ``ProjectorEval.run``.
+_HF_CACHE_MOUNT = "/hf"
+
 
 @dataclass
 class ProjectorEvalRow:
@@ -109,7 +112,11 @@ class ProjectorEvalReport:
         )
 
         eval_config_id = create_hash(
-            "eval-config", "ProjectorEval", self.model_name, ",".join(self.classes)
+            "eval-config",
+            "ProjectorEval",
+            self.model_name,
+            "projector_class_scoring",
+            ",".join(self.classes),
         )
         EvalConfigDurable(
             eval_config_id=eval_config_id,
@@ -117,7 +124,13 @@ class ProjectorEvalReport:
             eval_fn_name="projector_class_scoring",
         ).save()
         result = EvalResult(
-            eval_id=create_hash("eval", eval_config_id, self.checkpoint),
+            eval_id=create_hash(
+                "eval",
+                eval_config_id,
+                self.model_name,
+                self.checkpoint,
+                str(self.iteration),
+            ),
             eval_config_id=eval_config_id,
             model_name=self.model_name,
             rows=[
@@ -181,9 +194,9 @@ class ProjectorEval:
         return f"{save_dir}/projector_latest.pt"
 
     def _eval_path(self) -> str:
-        from modal_training_gym.train_recipes.base import TrainRecipe
+        from modal_training_gym.train_recipes.base import BaseTrainRecipe
 
-        _train, eval_paths = TrainRecipe._resolve_data_paths(self.dataset)
+        _train, eval_paths = BaseTrainRecipe._resolve_data_paths(self.dataset)
         if not eval_paths:
             raise TrainingGymConfigError(
                 f"{type(self.dataset).__name__} writes no eval split, so there "
@@ -199,18 +212,24 @@ class ProjectorEval:
         from modal_training_gym.train_recipes.base import (
             CHECKPOINTS_PATH,
             DATA_PATH,
-            HF_CACHE_PATH,
         )
 
         prefix = self._volume_prefix()
         image = (
             modal.Image.from_registry(self.recipe.docker_image)
             .entrypoint([])
+            # The miles image ships a populated ``~/.cache/huggingface``, and
+            # Modal refuses to mount a volume onto a non-empty path, so the
+            # shared cache goes somewhere unused and HF_HOME is pointed at it.
+            .env({"HF_HOME": _HF_CACHE_MOUNT})
+            # The gym's id helper needs it and the miles image doesn't ship it,
+            # so publishing to the dashboard fails at the last line otherwise.
+            .pip_install("randomname")
             .add_local_python_source("modal_training_gym", copy=True)
         )
         app = modal.App(f"{prefix}-projector-eval", image=image)
         volumes = {
-            str(HF_CACHE_PATH): modal.Volume.from_name(
+            _HF_CACHE_MOUNT: modal.Volume.from_name(
                 "huggingface-cache", create_if_missing=True
             ),
             str(DATA_PATH): modal.Volume.from_name(

--- a/modal_training_gym/frameworks/miles/projector_eval.py
+++ b/modal_training_gym/frameworks/miles/projector_eval.py
@@ -291,7 +291,12 @@ def load_projector(checkpoint: str, dtype: Any = None, trained: bool = True):
 
     ``trained=False`` returns the same architecture at the initialization the
     run started from — the baseline that isolates training from the mere
-    presence of a vector in the embedding stream.
+    presence of a vector in the embedding stream. The seed and output scale come
+    from the checkpoint rather than from ``ProjectorSpec()``: a run that
+    customized either started somewhere else, and comparing against the
+    defaults' init would make the baseline a different model. Checkpoints
+    written before those keys existed fall back to the defaults they were
+    written under.
     """
     import torch
 
@@ -313,7 +318,11 @@ def load_projector(checkpoint: str, dtype: Any = None, trained: bool = True):
         projector.load_state_dict(state["state_dict"])
     else:
         defaults = ProjectorSpec()
-        init_projector(projector, defaults.init_seed, defaults.output_scale)
+        init_projector(
+            projector,
+            int(config.get("init_seed", defaults.init_seed)),
+            float(config.get("output_scale", defaults.output_scale)),
+        )
     if dtype is not None:
         projector = projector.to(dtype)
     projector.eval()

--- a/modal_training_gym/train_recipes/miles_recipe/__init__.py
+++ b/modal_training_gym/train_recipes/miles_recipe/__init__.py
@@ -2,6 +2,10 @@ from modal_training_gym.train_recipes.miles_recipe.recipe import MilesRecipe
 from modal_training_gym.train_recipes.miles_recipe.gemma4_26b_a4b import (
     Gemma4_26B_A4B_Recipe,
 )
+from modal_training_gym.train_recipes.miles_recipe.glm_5_2 import (
+    GLM_5_2_5Layer_Projector_Recipe,
+    GLM_5_2_Projector_Recipe,
+)
 from modal_training_gym.train_recipes.miles_recipe.moonlight_16b_a3b import (
     Moonlight_16B_A3B_Recipe,
 )
@@ -12,6 +16,8 @@ from modal_training_gym.train_recipes.miles_recipe.qwen3_5_4b import (
 __all__ = [
     "MilesRecipe",
     "Gemma4_26B_A4B_Recipe",
+    "GLM_5_2_Projector_Recipe",
+    "GLM_5_2_5Layer_Projector_Recipe",
     "Moonlight_16B_A3B_Recipe",
     "Qwen3_5_4b_Miles_Recipe",
 ]

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -195,15 +195,16 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     attention_backend: str | None = "flash"
     update_weight_buffer_size: int | None = 2 * 1024**3
 
-    # GLM-5.2's MoE args, as upstream's run script emits them for every shape
-    # including the single-node 5-layer test (megatron_use_deepep defaults on).
-    # Without them Megatron falls back to the allgather dispatcher, which the
-    # pinned image warns does not support the variable sequence lengths
-    # ``use_dynamic_batch_size`` produces -- and the first backward of a run
-    # without them returned NaN into the embedding stream from inside the
-    # frozen base.
-    moe_enable_deepep: bool = True
-    moe_token_dispatcher_type: str = "flex"
+    # GLM-5.2's MoE dispatcher, which upstream's run script always names —
+    # ``alltoall`` on its no-DeepEP branch, ``flex`` with ``--moe-enable-deepep``
+    # otherwise. Naming neither leaves Megatron on the allgather dispatcher,
+    # which the pinned image warns does not support the variable sequence
+    # lengths ``use_dynamic_batch_size`` produces, and a run without it returned
+    # NaN into the embedding stream out of the frozen base's first backward.
+    # ``alltoall`` rather than DeepEP's ``flex`` because the miles GLM-5.2 model
+    # preset turns on ``moe_shared_expert_overlap``, which Megatron accepts only
+    # with this dispatcher.
+    moe_token_dispatcher_type: str = "alltoall"
     data_pad_size_multiplier: int = 1024
 
     @model_validator(mode="after")

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -177,10 +177,12 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     # wants a 4D query.
     use_dynamic_batch_size: bool = False
     micro_batch_size: int | None = 1
-    # DSA kernel backend, and the query layout it dictates (upstream derives
-    # ``--qkv-format`` from it the same way).
-    dsa_attention_backend: str = "megatron"
-    qkv_format: str = "bshd"
+    # The DSA kernel backend and query layout are left to the miles model
+    # preset (``tilelang``/``thd``). The alternative, ``megatron``/``bshd``, is
+    # unusable with the activation recompute this recipe needs: the pinned image
+    # asserts that DSA's cross-layer index share is not recompute-safe there,
+    # because the per-microbatch top-k holder rides on ``packed_seq_params``,
+    # which only the ``thd`` layout supplies.
 
     num_rollout: int = 10
     rollout_batch_size: int = 8

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -170,8 +170,16 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     recompute_granularity: str | None = "full"
     recompute_method: str | None = "uniform"
     recompute_num_layers: int | None = 1
-    use_dynamic_batch_size: bool = True
-    max_tokens_per_gpu: int = 8192
+    # Upstream's GLM-5.2 script forbids dynamic batching outright: "The DSA
+    # kernel backend dictates the query layout; both forbid
+    # --use-dynamic-batch-size, hence --micro-batch-size 1" — tilelang's fused
+    # sparse-MLA kernels index by cu_seqlens, megatron's unfused core attention
+    # wants a 4D query. With it on, the 5-layer base's forward stayed finite
+    # while SparseMLA's backward returned NaN into the embedding stream, on a
+    # run whose projected rows were multiplied by zero — i.e. independent of
+    # anything the projector wrote.
+    use_dynamic_batch_size: bool = False
+    micro_batch_size: int | None = 1
 
     num_rollout: int = 10
     rollout_batch_size: int = 8
@@ -198,9 +206,7 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     # GLM-5.2's MoE dispatcher, which upstream's run script always names —
     # ``alltoall`` on its no-DeepEP branch, ``flex`` with ``--moe-enable-deepep``
     # otherwise. Naming neither leaves Megatron on the allgather dispatcher,
-    # which the pinned image warns does not support the variable sequence
-    # lengths ``use_dynamic_batch_size`` produces, and a run without it returned
-    # NaN into the embedding stream out of the frozen base's first backward.
+    # which the pinned image warns does not support variable sequence lengths.
     # ``alltoall`` rather than DeepEP's ``flex`` because the miles GLM-5.2 model
     # preset turns on ``moe_shared_expert_overlap``, which Megatron accepts only
     # with this dispatcher.
@@ -234,6 +240,30 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
                 self,
                 "train_function_kwargs",
                 {"ephemeral_disk": _EPHEMERAL_DISK_MIB, **kwargs},
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _reject_dynamic_batch_size(self) -> "GLM_5_2_Projector_Recipe":
+        """Reject dynamic batching: GLM-5.2's DSA kernels do not support it.
+
+        Upstream's ``scripts/run_glm5_2_744b_a40b_lora.py`` states the
+        constraint for both DSA backends and pins ``--micro-batch-size 1``
+        instead. A run with it on trained nothing: the sparse-MLA backward
+        returned NaN, and ``check_for_nan_in_loss_and_grad`` aborted the step.
+        """
+        if self.use_dynamic_batch_size:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs use_dynamic_batch_size=False: "
+                "GLM-5.2's DSA attention kernels forbid it (upstream's run "
+                "script pins micro_batch_size=1 for exactly this reason), and "
+                "with it on the base's sparse-MLA backward returns NaN."
+            )
+        if self.micro_batch_size != 1:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs micro_batch_size=1 (got "
+                f"{self.micro_batch_size}), the only batching GLM-5.2's DSA "
+                "kernels take without dynamic batching."
             )
         return self
 
@@ -465,8 +495,7 @@ class GLM_5_2_5Layer_Projector_Recipe(GLM_5_2_Projector_Recipe):
     """The projector path on the 5-layer pruned GLM-5.2, 1×8×H200.
 
     Upstream's own single-node smoke shape (the ``num_nodes == 1`` branch of
-    ``scripts/run_glm5_2_744b_a40b.py``): 5 decoder layers, TP4/EP8, tokens per
-    GPU cut to 2048. Exercises the same freezing, forward merge and projector
+    ``scripts/run_glm5_2_744b_a40b.py``): 5 decoder layers, TP4/EP8. Exercises the same freezing, forward merge and projector
     checkpoint as the 744B recipe for one node's cost. The base is pruned, so
     its outputs mean nothing — this proves plumbing, not quality.
     """
@@ -479,4 +508,3 @@ class GLM_5_2_5Layer_Projector_Recipe(GLM_5_2_Projector_Recipe):
     actor_num_nodes: int = 1
     actor_num_gpus_per_node: int = 8
     expert_model_parallel_size: int = 8
-    max_tokens_per_gpu: int = 2048

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -117,6 +117,15 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
 
     gpu_type: str = "H200"
     colocate: bool = True
+    # Megatron allocates the DDP parameter buffer inside
+    # ``torch_memory_saver.region(tag="param_buffer", enable_cpu_backup=False)``
+    # (Megatron-LM ``param_and_grad_buffer.py``), and miles' ``sleep()`` pauses
+    # every tag unless ``rematerialize_param_from_master_weight`` is set. Paused
+    # memory without a backup comes back **zeroed**, and with the base frozen
+    # that buffer holds nothing but the projector: offloading a projector-only
+    # run zeroes exactly the weights it is training. There is nothing to make
+    # room for either — ``debug_train_only`` starts no rollout engine.
+    no_offload_train: bool = True
     train_function_kwargs: dict[str, Any] = field(
         default_factory=lambda: {"ephemeral_disk": _EPHEMERAL_DISK_MIB}
     )
@@ -314,6 +323,35 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
         return self
 
     @model_validator(mode="after")
+    def _reject_offload_train(self) -> "GLM_5_2_Projector_Recipe":
+        """Reject offloading the train model: it zeroes the projector's weights.
+
+        Megatron allocates the DDP parameter buffer in
+        ``torch_memory_saver.region(tag="param_buffer", enable_cpu_backup=False)``,
+        and a region without a backup does not survive a
+        ``pause()``/``resume()`` — it comes back zeroed (verified against the
+        pinned image). miles' ``sleep()`` pauses every tag when
+        ``rematerialize_param_from_master_weight`` is off, which is the only
+        thing that would rebuild that buffer from the optimizer's fp32 master
+        weights. The base being frozen is what makes this fatal rather than
+        redundant: DDP builds buffers only for parameters that require grad, so
+        the paused buffer holds the projector and nothing else. A run offloaded
+        this way wakes up with projector weights that read exactly zero, so it
+        merges zero rows for every embedding its encoder produced and trains on
+        no signal at all — on real hardware it died with NaN gradients instead.
+        """
+        if not self.no_offload_train:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs no_offload_train=True: with the "
+                "base frozen, Megatron's parameter buffer holds only the "
+                "projector, and miles offloads it into a torch_memory_saver "
+                "region that has no backup, so the projector's weights come "
+                "back zeroed after the first rollout. debug_train_only starts "
+                "no engine, so there is nothing to offload for."
+            )
+        return self
+
+    @model_validator(mode="after")
     def _reject_distributed_optimizer(self) -> "GLM_5_2_Projector_Recipe":
         """Reject the distributed optimizer: it shards the gradient we sum.
 
@@ -356,6 +394,7 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
         self._reject_megatron_load()
         self._require_pretrained_base()
         self._reject_distributed_optimizer()
+        self._reject_offload_train()
         if self.save_interval is not None and self.save_interval <= self.num_rollout:
             warnings.warn(
                 f"{type(self).__name__} has save_interval={self.save_interval} "

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -185,8 +185,14 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     # which only the ``thd`` layout supplies.
 
     num_rollout: int = 10
-    rollout_batch_size: int = 8
-    global_batch_size: int = 8
+    # One sample per data-parallel rank per step, at this shape's DP width of
+    # 64 GPUs / TP4 = 16. Without dynamic batching Megatron's micro-batch
+    # calculator requires ``global_batch_size % (micro_batch_size * DP) == 0``,
+    # and a rollout of fewer samples than DP ranks cannot be split across them
+    # at all — see ``_require_batch_covers_data_parallel``, which checks this for
+    # any topology a caller sets rather than only for these defaults.
+    rollout_batch_size: int = 16
+    global_batch_size: int = 16
     # Only the projector is written, by the hook.
     save_interval: int = 1_000_000
 
@@ -418,6 +424,46 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
             )
         return self
 
+    def _require_batch_covers_data_parallel(self) -> None:
+        """Require a step's samples to divide evenly among the data-parallel ranks.
+
+        With dynamic batching rejected, Megatron's constant micro-batch
+        calculator asserts ``global_batch_size % (micro_batch_size * DP) == 0``,
+        and a rollout that yields fewer samples than there are data-parallel
+        ranks cannot be split across them however it is batched. Neither is
+        checked before the cluster starts otherwise, so a topology change (more
+        nodes, less tensor parallelism) surfaces as an assertion inside the
+        containers after the base checkpoint has been downloaded.
+        """
+        gpus = self.actor_num_nodes * self.actor_num_gpus_per_node
+        shard = (
+            self.tensor_model_parallel_size
+            * self.pipeline_model_parallel_size
+            * self.context_parallel_size
+        )
+        if not gpus or not shard or gpus % shard:
+            # Divisibility of the GPU count by the model shards is the base
+            # class's preflight; nothing to say about batches until it holds.
+            return
+        data_parallel = gpus // shard
+        per_step = self.rollout_batch_size * self.n_samples_per_prompt
+        micro = self.micro_batch_size or 1
+        if self.global_batch_size % (micro * data_parallel) or per_step % data_parallel:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} spreads {gpus} GPU(s) over "
+                f"TP{self.tensor_model_parallel_size}/"
+                f"PP{self.pipeline_model_parallel_size}/"
+                f"CP{self.context_parallel_size}, so {data_parallel} "
+                f"data-parallel rank(s), but a step has "
+                f"global_batch_size={self.global_batch_size} over "
+                f"micro_batch_size={micro} and the rollout yields {per_step} "
+                f"sample(s) (rollout_batch_size={self.rollout_batch_size} x "
+                f"n_samples_per_prompt={self.n_samples_per_prompt}). Both have "
+                f"to be multiples of {data_parallel}: without dynamic batching "
+                "Megatron divides the global batch by micro-batch size and "
+                "data-parallel width, and each rank needs samples of its own."
+            )
+
     def _recheck_mutable_launch_invariants(self) -> None:
         """Re-run the guards that assignment after construction can defeat.
 
@@ -439,6 +485,7 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
         self._reject_distributed_optimizer()
         self._reject_offload_train()
         self._reject_dynamic_batch_size()
+        self._require_batch_covers_data_parallel()
         if self.save_interval is not None and self.save_interval <= self.num_rollout:
             warnings.warn(
                 f"{type(self).__name__} has save_interval={self.save_interval} "
@@ -510,3 +557,6 @@ class GLM_5_2_5Layer_Projector_Recipe(GLM_5_2_Projector_Recipe):
     actor_num_nodes: int = 1
     actor_num_gpus_per_node: int = 8
     expert_model_parallel_size: int = 8
+    # One node over TP4 is 2 data-parallel ranks, not the 744B shape's 16.
+    rollout_batch_size: int = 8
+    global_batch_size: int = 8

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -255,6 +255,24 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
         return self
 
     @model_validator(mode="after")
+    def _reject_evaluation(self) -> "GLM_5_2_Projector_Recipe":
+        """Reject an eval schedule: the rollout function cannot evaluate.
+
+        ``projector_sft_rollout`` raises on ``evaluation=True`` — a supervised
+        projector run has no generation path to evaluate with — so an
+        ``eval_interval`` would kill the run partway through instead of at
+        launch.
+        """
+        if self.eval_interval is not None:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} cannot evaluate (got "
+                f"eval_interval={self.eval_interval}): its rollout function is "
+                "supervised and does not generate, so miles' eval pass has "
+                "nothing to run. Leave eval_interval unset."
+            )
+        return self
+
+    @model_validator(mode="after")
     def _reject_distributed_optimizer(self) -> "GLM_5_2_Projector_Recipe":
         """Reject the distributed optimizer: it shards the gradient we sum.
 

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -1,0 +1,249 @@
+"""GLM-5.2 projector-only miles recipes.
+
+Trains an embedding projector against a frozen GLM-5.2 — no LoRA, no optimizer
+state for 744B parameters, no weight sync, no engines — which is what brings a
+744B-A40B model's adapter training down to a shape worth running.
+
+``GLM_5_2_Projector_Recipe``
+    The 744B checkpoint, 8×8×H200, TP4/EP32 with the base frozen.
+``GLM_5_2_5Layer_Projector_Recipe``
+    The same plumbing against upstream's 5-layer pruned checkpoint on
+    1×8×H200, for proving freezing, the forward merge and the projector
+    checkpoint at a single node's cost.
+
+Full-weight or LoRA GLM-5.2 GRPO is not covered here: that is upstream's
+``scripts/run_glm5_2_744b_a40b.py`` shape at 32 nodes per training group.
+"""
+
+from dataclasses import field
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pydantic import ConfigDict, model_validator
+from pydantic.dataclasses import dataclass
+
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.models import GLM_5_2, GLM_5_2_5Layer
+from modal_training_gym.frameworks.miles.projector_config import (
+    ARGS_KEY,
+    PROVIDER_PATH,
+    ROLLOUT_PATH,
+    SAVE_HOOK_PATH,
+    ProjectorSpec,
+)
+from modal_training_gym.train_recipes.miles_recipe.recipe import MilesRecipe
+
+if TYPE_CHECKING:
+    from modal_training_gym.common.models import ModelConfig
+
+# 1 TiB: the 744B checkpoint plus its torch_dist conversion overflows the
+# container's default disk.
+_EPHEMERAL_DISK_MIB = 1_048_576
+
+
+@dataclass(config=ConfigDict(extra="forbid", arbitrary_types_allowed=True))
+class GLM_5_2_Projector_Recipe(MilesRecipe):
+    """Projector-only supervised training against a frozen GLM-5.2 (8×8×H200).
+
+    The trainable set is the projector alone::
+
+        TrainConfig(
+            model=GLM_5_2(),
+            dataset=my_embedding_dataset,  # embeddings + positions columns
+            recipe=GLM_5_2_Projector_Recipe(
+                projector=ProjectorSpec(input_dim=1536),
+            ),
+        ).train()
+
+    ``miles_model_name`` points at miles' own
+    ``scripts/models/glm5.2-744B-A40B.py``, so the DSA attention spec, the
+    cross-layer index and the MoE routing come from upstream rather than being
+    restated here — which is also why
+    :class:`~modal_training_gym.common.models.GLM_5_2` carries no
+    ``ModelArchitecture``.
+
+    How each part of "train only the projector" is arranged:
+
+    *Freezing.* ``custom_model_provider_path`` builds the model the model script
+    asks for, sets ``requires_grad=False`` on every base parameter, then
+    attaches the projector — all before Megatron builds the optimizer, which
+    skips parameters that do not require grad. Optimizer state, gradient
+    buffers and checkpoints are therefore proportional to the projector, not to
+    744B parameters, which is what removes the node count LoRA was being
+    considered for.
+
+    *Weight sync.* There is none: ``debug_train_only`` runs the training path
+    with no engines. Miles' non-LoRA sync pushes the full base model to SGLang
+    (its ``skip_base_sync`` is gated on ``is_lora``), so projector-only sync is
+    not something the pinned image can express, and a supervised run has
+    nothing to generate. An RL variant needs either a projector-aware sync path
+    in miles or a full sync paid once per rollout.
+
+    *Data.* The dataset's embeddings ride in the ``metadata`` column
+    (:class:`~modal_training_gym.common.dataset.EmbeddingProjectorDataset`),
+    which miles carries onto each ``Sample``; the recipe's rollout function
+    turns them into per-sample tensors that miles concatenates over the packed
+    batch and splats into ``forward``.
+
+    *Checkpointing.* The before-train-step hook writes the projector's own state
+    dict (:mod:`modal_training_gym.frameworks.miles.embedding_projector`). The
+    frozen base needs no checkpoint: it stays byte-identical to the HF
+    checkpoint the run started from, so the projector file plus that model name
+    describe the trained artifact completely. ``save_interval`` is left far
+    above ``num_rollout`` so Megatron never writes terabytes of unchanged
+    weights.
+
+    ``pipeline_model_parallel_size`` is 1: with the base frozen only the first
+    pipeline stage holds trainable parameters, so later stages would build an
+    optimizer over an empty parameter set. Scale with tensor, context or expert
+    parallelism instead.
+    """
+
+    _SKIP_FIELDS: ClassVar[frozenset[str]] = MilesRecipe._SKIP_FIELDS | {"projector"}
+    model_config_class: ClassVar[type["ModelConfig"]] = GLM_5_2
+
+    projector: ProjectorSpec = field(default_factory=ProjectorSpec)
+
+    gpu_type: str = "H200"
+    colocate: bool = True
+    train_function_kwargs: dict[str, Any] = field(
+        default_factory=lambda: {"ephemeral_disk": _EPHEMERAL_DISK_MIB}
+    )
+
+    hf_checkpoint: str = "zai-org/GLM-5.2"
+    miles_model_name: str = "glm5.2-744B-A40B"
+    megatron_to_hf_mode: str = "bridge"
+
+    custom_model_provider_path: str | None = PROVIDER_PATH
+    custom_megatron_before_train_step_hook: str | None = SAVE_HOOK_PATH
+
+    # Supervised: the dataset carries the targets, so there is nothing to
+    # generate, score, or turn into advantages. The rollout function is miles'
+    # own SFT one plus the step that lifts each row's embeddings into the tensor
+    # dict the model's forward receives.
+    loss_type: str | None = "sft_loss"
+    rollout_function: str | None = ROLLOUT_PATH
+    disable_compute_advantages_and_returns: bool = True
+    debug_train_only: bool = True
+    calculate_per_token_loss: bool = True
+    num_epoch: int | None = 1
+    n_samples_per_prompt: int = 1
+    ref_load: str = ""
+
+    actor_num_nodes: int = 8
+    actor_num_gpus_per_node: int = 8
+
+    train_backend: str = "megatron"
+    tensor_model_parallel_size: int = 4
+    sequence_parallel: bool = True
+    pipeline_model_parallel_size: int = 1
+    context_parallel_size: int = 1
+    expert_model_parallel_size: int = 32
+    expert_tensor_parallel_size: int = 1
+
+    recompute_granularity: str | None = "full"
+    recompute_method: str | None = "uniform"
+    recompute_num_layers: int | None = 1
+    use_dynamic_batch_size: bool = True
+    max_tokens_per_gpu: int = 8192
+
+    num_rollout: int = 10
+    rollout_batch_size: int = 8
+    global_batch_size: int = 8
+    # Only the projector is written, by the hook.
+    save_interval: int = 1_000_000
+
+    # An adapter trained from random initialization, unlike the frozen base it
+    # feeds, so far above the 1e-6 a full-weight GLM-5.2 run uses.
+    optimizer: str = "adam"
+    lr: float = 1e-4
+    lr_decay_style: str = "cosine"
+    weight_decay: float = 0.1
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.98
+
+    attention_dropout: float = 0.0
+    hidden_dropout: float = 0.0
+    accumulate_allreduce_grads_in_fp32: bool = True
+    attention_softmax_in_fp32: bool = True
+    attention_backend: str | None = "flash"
+    update_weight_buffer_size: int | None = 2 * 1024**3
+
+    @model_validator(mode="after")
+    def _serialize_projector(self) -> "GLM_5_2_Projector_Recipe":
+        """Carry the projector spec to the containers through ``extra_config``.
+
+        Miles sets every ``extra_config`` key on ``args``, so the provider and
+        the checkpoint hook read the spec back without new CLI flags.
+        """
+        cfg = dict(self.extra_config) if isinstance(self.extra_config, dict) else {}
+        if cfg.get(ARGS_KEY) != self.projector.to_args_dict():
+            cfg[ARGS_KEY] = self.projector.to_args_dict()
+            object.__setattr__(self, "extra_config", cfg)
+        return self
+
+    @model_validator(mode="after")
+    def _keep_disk_reservation(self) -> "GLM_5_2_Projector_Recipe":
+        """Keep the reservation when a caller supplies their own train kwargs.
+
+        Replacing ``train_function_kwargs`` wholesale would otherwise drop it,
+        and the run would die part-way through the checkpoint download. A caller
+        naming ``ephemeral_disk`` still wins.
+        """
+        kwargs = self.train_function_kwargs or {}
+        if "ephemeral_disk" not in kwargs:
+            object.__setattr__(
+                self,
+                "train_function_kwargs",
+                {"ephemeral_disk": _EPHEMERAL_DISK_MIB, **kwargs},
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _reject_lora(self) -> "GLM_5_2_Projector_Recipe":
+        """Reject LoRA: two adapter mechanisms cannot both own the base.
+
+        miles' LoRA path drives its own freezing, weight sync and checkpoint
+        format, none of which the projector plumbing goes through.
+        """
+        if self.lora_rank:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} trains a projector over a frozen base, so "
+                f"lora_rank must be unset (got {self.lora_rank}). A LoRA or "
+                "full-weight GLM-5.2 run is upstream's "
+                "scripts/run_glm5_2_744b_a40b.py shape, not this recipe."
+            )
+        return self
+
+    def validate_model_parallelism(self, model: "ModelConfig") -> None:
+        super().validate_model_parallelism(model)
+        if self.pipeline_model_parallel_size != 1:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs pipeline_model_parallel_size=1: the "
+                "projector lives on the first pipeline stage and the base is frozen, "
+                "so every later stage would build an optimizer over an empty "
+                f"parameter set. Got {self.pipeline_model_parallel_size}; scale with "
+                "tensor_model_parallel_size, context_parallel_size or "
+                "expert_model_parallel_size."
+            )
+
+
+@dataclass(config=ConfigDict(extra="forbid", arbitrary_types_allowed=True))
+class GLM_5_2_5Layer_Projector_Recipe(GLM_5_2_Projector_Recipe):
+    """The projector path on the 5-layer pruned GLM-5.2, 1×8×H200.
+
+    Upstream's own single-node smoke shape (the ``num_nodes == 1`` branch of
+    ``scripts/run_glm5_2_744b_a40b.py``): 5 decoder layers, TP4/EP8, tokens per
+    GPU cut to 2048. Exercises the same freezing, forward merge and projector
+    checkpoint as the 744B recipe for one node's cost. The base is pruned, so
+    its outputs mean nothing — this proves plumbing, not quality.
+    """
+
+    model_config_class: ClassVar[type["ModelConfig"]] = GLM_5_2_5Layer
+
+    hf_checkpoint: str = "Pinaster/GLM-5.2_5layer"
+    miles_model_name: str = "glm5.2-744B-A40B_5layer"
+
+    actor_num_nodes: int = 1
+    actor_num_gpus_per_node: int = 8
+    expert_model_parallel_size: int = 8
+    max_tokens_per_gpu: int = 2048

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -167,9 +167,17 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     expert_model_parallel_size: int = 32
     expert_tensor_parallel_size: int = 1
 
-    recompute_granularity: str | None = "full"
-    recompute_method: str | None = "uniform"
-    recompute_num_layers: int | None = 1
+    # No activation recompute, which is not a free choice either: the layout the
+    # only working attention backend needs (see below) is the one the pinned
+    # image refuses to recompute — "DSA cross-layer index-share is not
+    # recompute-safe in the bshd layout ... use --qkv-format thd ... or disable
+    # activation recompute". A projector-only run backpropagates to the input
+    # embeddings, so every layer's activations are live; if the 744B shape runs
+    # out of memory on this, the way out is more nodes or a shorter sequence,
+    # not recompute.
+    recompute_granularity: str | None = None
+    recompute_method: str | None = None
+    recompute_num_layers: int | None = None
     # Upstream's GLM-5.2 script forbids dynamic batching outright: "The DSA
     # kernel backend dictates the query layout; both forbid
     # --use-dynamic-batch-size, hence --micro-batch-size 1" — tilelang's fused
@@ -183,13 +191,17 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     # "bshd"``). miles defaults the backend to ``megatron``, while MilesRecipe
     # defaults the layout to ``thd``, so naming neither pairs megatron's unfused
     # attention with a packed layout it does not implement — the forward returns
-    # finite logits and the backward hands the embedding stream NaN. Named as a
-    # pair here, and ``tilelang`` rather than ``megatron``/``bshd`` because the
-    # latter is not recompute-safe: the pinned image asserts that DSA's
-    # cross-layer index share needs the top-k holder that rides on
-    # ``packed_seq_params``, which only ``thd`` supplies.
-    dsa_attention_backend: str = "tilelang"
-    qkv_format: str = "thd"
+    # finite logits and the backward hands the embedding stream NaN.
+    #
+    # ``megatron``/``bshd`` rather than ``tilelang``/``thd`` because only the
+    # former backpropagates to the embeddings. Both give a finite forward, but
+    # tilelang's ``sparse_mla_bwd`` returns a NaN dq on this shape (localized on
+    # 8xH200 to ``decoder.layers.4.self_attention.linear_q_up_proj``, with every
+    # grad above it finite, and independent of the loss mask and of recompute),
+    # which upstream's own runs never see: LoRA trains weights inside attention
+    # and never needs dq to reach the input embeddings, and a projector does.
+    dsa_attention_backend: str = "megatron"
+    qkv_format: str = "bshd"
 
     num_rollout: int = 10
     # One sample per data-parallel rank per step, at this shape's DP width of
@@ -278,6 +290,36 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
                 f"{type(self).__name__} needs micro_batch_size=1 (got "
                 f"{self.micro_batch_size}), the only batching GLM-5.2's DSA "
                 "kernels take without dynamic batching."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_working_attention_backward(self) -> "GLM_5_2_Projector_Recipe":
+        """Reject the backend/layout/recompute combinations that lose the grad.
+
+        A projector-only run is the one GLM-5.2 shape whose gradient has to
+        reach the input embeddings, so it is the one that cares which DSA
+        backend runs the backward: ``tilelang``'s fused ``sparse_mla_bwd``
+        returns NaN dq (proven on 8xH200, finite forward, finite grad down to
+        the query projection), and ``megatron``'s unfused attention is finite
+        but only ever paired with ``bshd``, which the image will not recompute.
+        """
+        if self.dsa_attention_backend != "megatron" or self.qkv_format != "bshd":
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs "
+                'dsa_attention_backend="megatron" with qkv_format="bshd" (got '
+                f'"{self.dsa_attention_backend}"/"{self.qkv_format}"): it is '
+                "the only pairing whose backward carries a finite gradient to "
+                "the input embeddings, which is the one thing a projector-only "
+                "run cannot do without."
+            )
+        if self.recompute_granularity is not None:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs recompute_granularity=None (got "
+                f'"{self.recompute_granularity}"): the pinned image refuses to '
+                "recompute DSA's cross-layer index share in the bshd layout "
+                "this recipe's attention backend requires. Fit the run with "
+                "nodes or sequence length instead."
             )
         return self
 
@@ -492,6 +534,7 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
         self._reject_distributed_optimizer()
         self._reject_offload_train()
         self._reject_dynamic_batch_size()
+        self._require_working_attention_backward()
         self._require_batch_covers_data_parallel()
         if self.save_interval is not None and self.save_interval <= self.num_rollout:
             warnings.warn(

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -240,6 +240,30 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
             )
         return self
 
+    @model_validator(mode="after")
+    def _reject_distributed_optimizer(self) -> "GLM_5_2_Projector_Recipe":
+        """Reject the distributed optimizer: it shards the gradient we sum.
+
+        The projector's tensor-parallel gradient sum reads each parameter's
+        ``main_grad`` whole. Under ``use_distributed_optimizer`` that buffer is
+        a reduce-scattered shard of a bucket, and summing shards across the
+        tensor-parallel group is not the replicated weight's whole-sequence
+        gradient — it would train on a silently wrong gradient rather than
+        fail. There is nothing to gain either: the optimizer state a
+        projector-only run carries is the projector's, tens of megabytes, so
+        sharding it saves nothing against a frozen 744B base.
+        """
+        if self.use_distributed_optimizer:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs use_distributed_optimizer=False: "
+                "the replicated projector's gradients are summed across the "
+                "tensor-parallel group from whole main_grad buffers, which the "
+                "distributed optimizer replaces with reduce-scattered shards. "
+                "Its only benefit is sharding optimizer state, and the base is "
+                "frozen, so this run's optimizer state is the projector's alone."
+            )
+        return self
+
     def validate_model_parallelism(self, model: "ModelConfig") -> None:
         super().validate_model_parallelism(model)
         if self.pipeline_model_parallel_size != 1:

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -243,6 +243,16 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
         ``ref_load`` have nothing to offer here and a strict key check would
         fail. Resume by pointing ``projector.load`` at a
         ``projector_iter_*.pt``; the base comes from ``hf_checkpoint``.
+
+        Safe because of the bridge-mode branch in the pinned image's
+        ``miles/utils/arguments.py``: with no usable ``--load`` directory it sets
+        ``args.load = args.ref_load or args.hf_checkpoint``, and
+        ``megatron_utils/checkpoint.py`` routes a non-Megatron directory into
+        ``_load_checkpoint_hf``. ``ref_load`` is therefore an alternative
+        spelling of the same load here, not the only one — bridge recipes that
+        set it (``Gemma4_26B_A4B_Recipe``) point it at the same HF reference as
+        ``hf_checkpoint``. ``_require_pretrained_base`` keeps that fallback
+        populated.
         """
         if self.load or self.ref_load:
             raise TrainingGymConfigError(
@@ -251,6 +261,36 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
                 f"ref_load={self.ref_load!r}). The frozen base is loaded from "
                 f"hf_checkpoint={self.hf_checkpoint!r} and only the projector "
                 "is ever written."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_pretrained_base(self) -> "GLM_5_2_Projector_Recipe":
+        """Require the one field that makes the frozen base a pretrained base.
+
+        With ``load`` and ``ref_load`` both rejected, ``hf_checkpoint`` is the
+        only source the bridge-mode fallback
+        (``args.load = args.ref_load or args.hf_checkpoint``) has left. Were it
+        empty, miles would log one ``--load '' is empty; starting from
+        model_provider-initialized weights`` warning and train the projector
+        against a *randomly initialized* base — a run that costs a full GPU
+        budget and produces an adapter for a model that does not exist. Same for
+        a non-bridge ``megatron_to_hf_mode``, whose branch falls back to
+        ``ref_load`` alone.
+        """
+        if not self.hf_checkpoint:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs hf_checkpoint set: it is the only "
+                "source the frozen base can be loaded from once load/ref_load "
+                "are rejected, and miles would otherwise train the projector "
+                "against randomly initialized base weights."
+            )
+        if self.megatron_to_hf_mode != "bridge":
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} requires megatron_to_hf_mode='bridge' "
+                f"(got {self.megatron_to_hf_mode!r}): only the bridge branch "
+                "falls back to hf_checkpoint for the base weights, and this "
+                "recipe rejects the ref_load the other branch needs."
             )
         return self
 

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -195,6 +195,17 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     attention_backend: str | None = "flash"
     update_weight_buffer_size: int | None = 2 * 1024**3
 
+    # GLM-5.2's MoE args, as upstream's run script emits them for every shape
+    # including the single-node 5-layer test (megatron_use_deepep defaults on).
+    # Without them Megatron falls back to the allgather dispatcher, which the
+    # pinned image warns does not support the variable sequence lengths
+    # ``use_dynamic_batch_size`` produces -- and the first backward of a run
+    # without them returned NaN into the embedding stream from inside the
+    # frozen base.
+    moe_enable_deepep: bool = True
+    moe_token_dispatcher_type: str = "flex"
+    data_pad_size_multiplier: int = 1024
+
     @model_validator(mode="after")
     def _serialize_projector(self) -> "GLM_5_2_Projector_Recipe":
         """Carry the projector spec to the containers through ``extra_config``.

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -15,6 +15,7 @@ Full-weight or LoRA GLM-5.2 GRPO is not covered here: that is upstream's
 ``scripts/run_glm5_2_744b_a40b.py`` shape at 32 nodes per training group.
 """
 
+import warnings
 from dataclasses import field
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -336,8 +337,38 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
             )
         return self
 
+    def _recheck_mutable_launch_invariants(self) -> None:
+        """Re-run the guards that assignment after construction can defeat.
+
+        Pydantic dataclasses do not re-validate on assignment, and callers do
+        assign: ``scripts/validate_model_configs.py`` sets ``eval_interval`` and
+        ``save_interval`` on the recipe the backend built. Re-checking here (on
+        the preflight ``_fields`` runs while emitting flags) means an override
+        that would kill the run mid-flight fails at launch instead.
+
+        ``save_interval`` is only warned about: it re-enables Megatron's
+        full-model save, which writes the *unchanged* frozen base — terabytes of
+        it at the 744B shape — but a run that pays for it still trains
+        correctly, and the projector's own cadence is ``projector.save_interval``.
+        """
+        self._reject_evaluation()
+        self._reject_lora()
+        self._reject_megatron_load()
+        self._require_pretrained_base()
+        self._reject_distributed_optimizer()
+        if self.save_interval is not None and self.save_interval <= self.num_rollout:
+            warnings.warn(
+                f"{type(self).__name__} has save_interval={self.save_interval} "
+                f"with num_rollout={self.num_rollout}: Megatron will write the "
+                "frozen base (unchanged, and terabytes of it at the 744B shape) "
+                "during the run. Only the projector needs saving; its cadence "
+                "is projector.save_interval.",
+                stacklevel=2,
+            )
+
     def validate_model_parallelism(self, model: "ModelConfig") -> None:
         super().validate_model_parallelism(model)
+        self._recheck_mutable_launch_invariants()
         if self.pipeline_model_parallel_size != 1:
             raise TrainingGymConfigError(
                 f"{type(self).__name__} needs pipeline_model_parallel_size=1: the "

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -260,6 +260,17 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
                 "on the wrong tokens. Scale with tensor_model_parallel_size or "
                 "expert_model_parallel_size."
             )
+        if self.tensor_model_parallel_size > 1 and not self.sequence_parallel:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs sequence_parallel=True when "
+                f"tensor_model_parallel_size > 1 (got "
+                f"TP={self.tensor_model_parallel_size}). The projector is "
+                "replicated across the tensor-parallel group and its gradients "
+                "are summed over it, which is the whole-sequence gradient only "
+                "while each rank merges a disjoint sequence shard; without "
+                "sequence parallelism every rank merges every position, so the "
+                "sum would scale the projector's gradient by TP."
+            )
 
 
 @dataclass(config=ConfigDict(extra="forbid", arbitrary_types_allowed=True))

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -84,8 +84,9 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     turns them into per-sample tensors that miles concatenates over the packed
     batch and splats into ``forward``.
 
-    *Checkpointing.* The before-train-step hook writes the projector's own state
-    dict (:mod:`modal_training_gym.frameworks.miles.embedding_projector`). The
+    *Checkpointing.* Every ``projector.save_interval`` optimizer steps, and
+    always on the run's last one, the projector's own state dict is written
+    (:mod:`modal_training_gym.frameworks.miles.embedding_projector`). The
     frozen base needs no checkpoint: it stays byte-identical to the HF
     checkpoint the run started from, so the projector file plus that model name
     describe the trained artifact completely. ``save_interval`` is left far
@@ -94,8 +95,10 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
 
     ``pipeline_model_parallel_size`` is 1: with the base frozen only the first
     pipeline stage holds trainable parameters, so later stages would build an
-    optimizer over an empty parameter set. Scale with tensor, context or expert
-    parallelism instead.
+    optimizer over an empty parameter set. ``context_parallel_size`` is 1 too,
+    because the merge rebases the data's token positions onto a tensor/sequence
+    shard and not onto Megatron's context-parallel chunking. Scale with tensor
+    or expert parallelism.
     """
 
     _SKIP_FIELDS: ClassVar[frozenset[str]] = MilesRecipe._SKIP_FIELDS | {"projector"}
@@ -245,7 +248,16 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
                 "projector lives on the first pipeline stage and the base is frozen, "
                 "so every later stage would build an optimizer over an empty "
                 f"parameter set. Got {self.pipeline_model_parallel_size}; scale with "
-                "tensor_model_parallel_size, context_parallel_size or "
+                "tensor_model_parallel_size or expert_model_parallel_size."
+            )
+        if self.context_parallel_size != 1:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs context_parallel_size=1: the "
+                "projected embeddings are written into the input embeddings at "
+                "the dataset's token positions, which are rebased onto a "
+                "tensor/sequence shard but not onto Megatron's context-parallel "
+                f"chunking, so CP={self.context_parallel_size} would land them "
+                "on the wrong tokens. Scale with tensor_model_parallel_size or "
                 "expert_model_parallel_size."
             )
 

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -39,6 +39,14 @@ if TYPE_CHECKING:
 # container's default disk.
 _EPHEMERAL_DISK_MIB = 1_048_576
 
+# Routed experts in miles' ``scripts/models/glm5.2-744B-A40B.py`` (``--num-experts
+# 256``, top-8, 1 shared), which the 5-layer checkpoint keeps. The gym's
+# expert-parallel preflight reads this off a model's ``ModelArchitecture``, and
+# GLM-5.2 has none — the DSA spec and the indexer are not representable there,
+# so the model script owns the arch args. Kept here instead, where the model
+# script is pinned, so changing EP is still checked before the cluster starts.
+_NUM_ROUTED_EXPERTS = 256
+
 
 @dataclass(config=ConfigDict(extra="forbid", arbitrary_types_allowed=True))
 class GLM_5_2_Projector_Recipe(MilesRecipe):
@@ -130,6 +138,12 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     calculate_per_token_loss: bool = True
     num_epoch: int | None = 1
     n_samples_per_prompt: int = 1
+    # No evaluation pass: the rollout function has nothing to generate with, so
+    # it raises when miles calls it with ``evaluation=True``. Leaving this to
+    # miles' own gate on ``eval_interval`` would make a user-launched run's
+    # survival depend on that gate, while the dataset still emits
+    # ``--eval-prompt-data``.
+    skip_eval_before_train: bool = True
     ref_load: str = ""
 
     actor_num_nodes: int = 8
@@ -283,6 +297,15 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
                 f"chunking, so CP={self.context_parallel_size} would land them "
                 "on the wrong tokens. Scale with tensor_model_parallel_size or "
                 "expert_model_parallel_size."
+            )
+        if (
+            self.expert_model_parallel_size
+            and _NUM_ROUTED_EXPERTS % self.expert_model_parallel_size
+        ):
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs expert_model_parallel_size to "
+                f"divide the model script's {_NUM_ROUTED_EXPERTS} routed "
+                f"experts, got EP={self.expert_model_parallel_size}."
             )
         if self.tensor_model_parallel_size > 1 and not self.sequence_parallel:
             raise TrainingGymConfigError(

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -174,12 +174,13 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     # kernel backend dictates the query layout; both forbid
     # --use-dynamic-batch-size, hence --micro-batch-size 1" — tilelang's fused
     # sparse-MLA kernels index by cu_seqlens, megatron's unfused core attention
-    # wants a 4D query. With it on, the 5-layer base's forward stayed finite
-    # while SparseMLA's backward returned NaN into the embedding stream, on a
-    # run whose projected rows were multiplied by zero — i.e. independent of
-    # anything the projector wrote.
+    # wants a 4D query.
     use_dynamic_batch_size: bool = False
     micro_batch_size: int | None = 1
+    # DSA kernel backend, and the query layout it dictates (upstream derives
+    # ``--qkv-format`` from it the same way).
+    dsa_attention_backend: str = "megatron"
+    qkv_format: str = "bshd"
 
     num_rollout: int = 10
     rollout_batch_size: int = 8
@@ -249,15 +250,13 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
 
         Upstream's ``scripts/run_glm5_2_744b_a40b_lora.py`` states the
         constraint for both DSA backends and pins ``--micro-batch-size 1``
-        instead. A run with it on trained nothing: the sparse-MLA backward
-        returned NaN, and ``check_for_nan_in_loss_and_grad`` aborted the step.
+        instead.
         """
         if self.use_dynamic_batch_size:
             raise TrainingGymConfigError(
                 f"{type(self).__name__} needs use_dynamic_batch_size=False: "
                 "GLM-5.2's DSA attention kernels forbid it (upstream's run "
-                "script pins micro_batch_size=1 for exactly this reason), and "
-                "with it on the base's sparse-MLA backward returns NaN."
+                "script pins micro_batch_size=1 for exactly this reason)."
             )
         if self.micro_batch_size != 1:
             raise TrainingGymConfigError(
@@ -437,6 +436,7 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
         self._require_pretrained_base()
         self._reject_distributed_optimizer()
         self._reject_offload_train()
+        self._reject_dynamic_batch_size()
         if self.save_interval is not None and self.save_interval <= self.num_rollout:
             warnings.warn(
                 f"{type(self).__name__} has save_interval={self.save_interval} "

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -214,6 +214,29 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
             )
         return self
 
+    @model_validator(mode="after")
+    def _reject_megatron_load(self) -> "GLM_5_2_Projector_Recipe":
+        """Reject Megatron checkpoint loading: resume goes through the projector.
+
+        The projector is registered as a submodule of the actor (Megatron's DDP
+        and optimizer only see parameters in the module tree), so it shows up in
+        the model's ``state_dict`` under ``embedding_projector.*``. A Megatron
+        checkpoint written before this recipe existed has no such keys, and the
+        base itself never changes during a projector-only run, so ``load`` /
+        ``ref_load`` have nothing to offer here and a strict key check would
+        fail. Resume by pointing ``projector.load`` at a
+        ``projector_iter_*.pt``; the base comes from ``hf_checkpoint``.
+        """
+        if self.load or self.ref_load:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} resumes through projector.load, not "
+                f"Megatron's load/ref_load (got load={self.load!r}, "
+                f"ref_load={self.ref_load!r}). The frozen base is loaded from "
+                f"hf_checkpoint={self.hf_checkpoint!r} and only the projector "
+                "is ever written."
+            )
+        return self
+
     def validate_model_parallelism(self, model: "ModelConfig") -> None:
         super().validate_model_parallelism(model)
         if self.pipeline_model_parallel_size != 1:

--- a/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
+++ b/modal_training_gym/train_recipes/miles_recipe/glm_5_2.py
@@ -177,12 +177,19 @@ class GLM_5_2_Projector_Recipe(MilesRecipe):
     # wants a 4D query.
     use_dynamic_batch_size: bool = False
     micro_batch_size: int | None = 1
-    # The DSA kernel backend and query layout are left to the miles model
-    # preset (``tilelang``/``thd``). The alternative, ``megatron``/``bshd``, is
-    # unusable with the activation recompute this recipe needs: the pinned image
-    # asserts that DSA's cross-layer index share is not recompute-safe there,
-    # because the per-microbatch top-k holder rides on ``packed_seq_params``,
-    # which only the ``thd`` layout supplies.
+    # GLM-5.2's sparse attention has two kernel backends, and the query layout
+    # is not free to choose alongside them: upstream derives one from the other
+    # (``qkv_format = "thd" if dsa_attention_backend == "tilelang" else
+    # "bshd"``). miles defaults the backend to ``megatron``, while MilesRecipe
+    # defaults the layout to ``thd``, so naming neither pairs megatron's unfused
+    # attention with a packed layout it does not implement — the forward returns
+    # finite logits and the backward hands the embedding stream NaN. Named as a
+    # pair here, and ``tilelang`` rather than ``megatron``/``bshd`` because the
+    # latter is not recompute-safe: the pinned image asserts that DSA's
+    # cross-layer index share needs the top-k holder that rides on
+    # ``packed_seq_params``, which only ``thd`` supplies.
+    dsa_attention_backend: str = "tilelang"
+    qkv_format: str = "thd"
 
     num_rollout: int = 10
     # One sample per data-parallel rank per step, at this shape's DP width of

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -272,6 +272,19 @@ class MilesRecipe(BaseTrainRecipe):
         Entropy bonus coefficient.
     calculate_per_token_loss : bool
         Average the loss over tokens instead of over samples.
+    loss_type : str | None
+        Training objective; ``None`` keeps miles' policy-gradient default and
+        ``"sft_loss"`` trains on the dataset's own targets.
+    disable_compute_advantages_and_returns : bool
+        Skip advantage/return computation — required by supervised objectives,
+        which have no rewards to normalize.
+    debug_train_only : bool
+        Run the training path alone: no SGLang engines, no rollout, no weight
+        sync. Supervised runs need no engines, and it makes a one-step proof of
+        a large model cheap.
+    num_epoch : int | None
+        Passes over the dataset, for supervised runs that iterate a fixed set
+        instead of generating rollouts.
     ref_load : str
         Checkpoint the reference model is read from (for KL terms).
     use_tis : bool
@@ -406,6 +419,11 @@ class MilesRecipe(BaseTrainRecipe):
         Hook run in the Megatron trainer before log-prob computation.
     custom_megatron_before_train_step_hook : Callable | str | None
         Hook run in the Megatron trainer before each train step.
+    custom_model_provider_path : str | None
+        Import path of the function building the Megatron model, replacing the
+        provider the model script selects. Used to wrap the upstream model —
+        freezing it and attaching an adapter, say — rather than to reimplement
+        it.
 
     ## Config Overrides
 
@@ -585,6 +603,10 @@ class MilesRecipe(BaseTrainRecipe):
     use_kl_loss: bool = False
     calculate_per_token_loss: bool = False
     rm_type: str | None = None
+    loss_type: str | None = None
+    disable_compute_advantages_and_returns: bool = False
+    debug_train_only: bool = False
+    num_epoch: int | None = None
 
     # ── Dynamic sampling (DAPO) ────────────────────────────────────────────
     over_sampling_batch_size: int | None = None
@@ -652,6 +674,7 @@ class MilesRecipe(BaseTrainRecipe):
     custom_eval_rollout_log_function: Callable | str | None = None
     custom_megatron_before_log_prob_hook: Callable | str | None = None
     custom_megatron_before_train_step_hook: Callable | str | None = None
+    custom_model_provider_path: str | None = None
 
     # ── Per-sample execution tracing (dashboard timeline) ───────────────────
     # When True, the rollout recorder attaches miles' per-sample trace (the
@@ -821,6 +844,10 @@ class MilesRecipe(BaseTrainRecipe):
         from modal_training_gym.train_recipes.miles_recipe.gemma4_26b_a4b import (
             Gemma4_26B_A4B_Recipe,
         )
+        from modal_training_gym.train_recipes.miles_recipe.glm_5_2 import (
+            GLM_5_2_5Layer_Projector_Recipe,
+            GLM_5_2_Projector_Recipe,
+        )
         from modal_training_gym.train_recipes.miles_recipe.moonlight_16b_a3b import (
             Moonlight_16B_A3B_Recipe,
         )
@@ -834,6 +861,12 @@ class MilesRecipe(BaseTrainRecipe):
             return Moonlight_16B_A3B_Recipe()
         if model_config.model_name == "google/gemma-4-26B-A4B-it":
             return Gemma4_26B_A4B_Recipe()
+        # GLM-5.2's only gym recipe is the projector one: full-weight or LoRA
+        # GLM-5.2 RL is upstream's 32-node script, not a gym preset.
+        if model_config.model_name == "zai-org/GLM-5.2":
+            return GLM_5_2_Projector_Recipe()
+        if model_config.model_name == "Pinaster/GLM-5.2_5layer":
+            return GLM_5_2_5Layer_Projector_Recipe()
         return None
 
     def download_model(self) -> None:

--- a/scripts/api_reference_manifest.py
+++ b/scripts/api_reference_manifest.py
@@ -57,6 +57,13 @@ API_REFERENCE_MANIFEST = [
         "sidebar_label": "EmbeddingProjectorDataset",
     },
     {
+        "class_name": "ProteinLocalizationDataset",
+        "module": "modal_training_gym.common.dataset",
+        "group": "core",
+        "class_type": "config_data",
+        "sidebar_label": "ProteinLocalizationDataset",
+    },
+    {
         "class_name": "WandbConfig",
         "module": "modal_training_gym.common.wandb",
         "group": "core",
@@ -288,6 +295,13 @@ API_REFERENCE_MANIFEST = [
         "group": "training",
         "class_type": "config_data",
         "sidebar_label": "ProjectorSpec",
+    },
+    {
+        "class_name": "ProjectorEval",
+        "module": "modal_training_gym.frameworks.miles.projector_eval",
+        "group": "training",
+        "class_type": "config_data",
+        "sidebar_label": "ProjectorEval",
     },
     {
         "class_name": "Qwen3_6_35b_Recipe",

--- a/scripts/api_reference_manifest.py
+++ b/scripts/api_reference_manifest.py
@@ -50,6 +50,13 @@ API_REFERENCE_MANIFEST = [
         "sidebar_label": "HarborDataset",
     },
     {
+        "class_name": "EmbeddingProjectorDataset",
+        "module": "modal_training_gym.common.dataset",
+        "group": "core",
+        "class_type": "config_data",
+        "sidebar_label": "EmbeddingProjectorDataset",
+    },
+    {
         "class_name": "WandbConfig",
         "module": "modal_training_gym.common.wandb",
         "group": "core",
@@ -170,6 +177,20 @@ API_REFERENCE_MANIFEST = [
         "sidebar_label": "Gemma-4-26B-A4B-it",
     },
     {
+        "class_name": "GLM_5_2",
+        "module": "modal_training_gym.common.models.glm_5_2",
+        "group": "models",
+        "class_type": "config_data",
+        "sidebar_label": "GLM-5.2",
+    },
+    {
+        "class_name": "GLM_5_2_5Layer",
+        "module": "modal_training_gym.common.models.glm_5_2",
+        "group": "models",
+        "class_type": "config_data",
+        "sidebar_label": "GLM-5.2-5layer",
+    },
+    {
         "class_name": "Qwen3_6_35B",
         "module": "modal_training_gym.common.models.qwen3_6_35b",
         "group": "models",
@@ -246,6 +267,27 @@ API_REFERENCE_MANIFEST = [
         "group": "training",
         "class_type": "config_data",
         "sidebar_label": "Gemma4_26B_A4B_Recipe",
+    },
+    {
+        "class_name": "GLM_5_2_Projector_Recipe",
+        "module": "modal_training_gym.train_recipes.miles_recipe.glm_5_2",
+        "group": "training",
+        "class_type": "config_data",
+        "sidebar_label": "GLM_5_2_Projector_Recipe",
+    },
+    {
+        "class_name": "GLM_5_2_5Layer_Projector_Recipe",
+        "module": "modal_training_gym.train_recipes.miles_recipe.glm_5_2",
+        "group": "training",
+        "class_type": "config_data",
+        "sidebar_label": "GLM_5_2_5Layer_Projector_Recipe",
+    },
+    {
+        "class_name": "ProjectorSpec",
+        "module": "modal_training_gym.frameworks.miles.projector_config",
+        "group": "training",
+        "class_type": "config_data",
+        "sidebar_label": "ProjectorSpec",
     },
     {
         "class_name": "Qwen3_6_35b_Recipe",

--- a/scripts/validation_backends/miles.py
+++ b/scripts/validation_backends/miles.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
-from modal_training_gym.common.dataset import DatasetConfig, HuggingFaceDataset
+from modal_training_gym.common.dataset import (
+    DatasetConfig,
+    EmbeddingProjectorDataset,
+    HuggingFaceDataset,
+)
 from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.models import ModelConfig
 from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+from modal_training_gym.train_recipes.miles_recipe.glm_5_2 import (
+    GLM_5_2_Projector_Recipe,
+)
 
 
 class DapoMath17kDataset(HuggingFaceDataset):
@@ -26,10 +33,14 @@ def build_miles_validation(
 ) -> tuple[MilesRecipe, DatasetConfig]:
     """The model's base miles recipe and its validation dataset.
 
-    Every miles recipe today is a math-RL recipe scored by ``deepscaler``, so
-    they all validate against DAPO-Math-17k. Every rollout step consumes
-    ``rollout_batch_size`` prompts, so materialize enough for the whole run
-    rather than assuming the loader wraps epochs.
+    Miles recipes are math-RL recipes scored by ``deepscaler``, so they validate
+    against DAPO-Math-17k. Every rollout step consumes ``rollout_batch_size``
+    prompts, so materialize enough for the whole run rather than assuming the
+    loader wraps epochs.
+
+    Projector-only recipes are the exception: they train supervised on external
+    embeddings, which no prompt dataset carries, so they validate on synthetic
+    embedding rows sized to the projector's input dimension.
 
     The recipe is used as it comes out of ``get_base_recipe``, image included:
     the image a miles model trains on belongs in ``MilesRecipe``, not in the
@@ -42,6 +53,11 @@ def build_miles_validation(
             "which is registered as a miles validation target"
         )
     recipe.skip_eval_before_train = True
+    if isinstance(recipe, GLM_5_2_Projector_Recipe):
+        return recipe, EmbeddingProjectorDataset.synthetic(
+            n_rows=recipe.rollout_batch_size * step_count,
+            input_dim=recipe.projector.input_dim,
+        )
     prompts_per_step = max(
         recipe.rollout_batch_size, recipe.over_sampling_batch_size or 0
     )

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -39,6 +39,7 @@ PKG_ROOT = REPO_ROOT / "modal_training_gym"
 # fails on a rename or deletion.
 REMOTE_ONLY = frozenset(
     {
+        "modal_training_gym.frameworks.miles.embedding_projector",
         "modal_training_gym.frameworks.miles.modal_helpers.patches.patch_gemma4_vl_rollout_text",
         "modal_training_gym.frameworks.miles.modal_helpers.patches.patch_router_startup_timeout",
         "modal_training_gym.frameworks.miles.modal_helpers.patches.patch_sglang_abort",

--- a/tests/test_miles_recipe_hooks.py
+++ b/tests/test_miles_recipe_hooks.py
@@ -96,3 +96,12 @@ def test_hook_lookup_never_dispatches_to_gym_wrapper() -> None:
         }
     )
     assert _hook_path_from_args(args, _KEY) is None
+
+
+def test_hook_lookup_dispatches_gym_hooks_that_are_not_the_wrapper() -> None:
+    """The projector's grad all-reduce and checkpoint writer hang off one."""
+    from modal_training_gym.frameworks.miles.projector_config import SAVE_HOOK_PATH
+
+    key = "training_gym_custom_megatron_before_train_step_hook_path"
+    args = SimpleNamespace(extra_config={key: SAVE_HOOK_PATH})
+    assert _hook_path_from_args(args, key) == SAVE_HOOK_PATH

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -1,0 +1,162 @@
+"""Projector-only training: the path from a recipe field to miles' CLI and data.
+
+The container-side halves (provider, forward merge, checkpoint hook) need torch
+and a GPU, so what is pinned here is the wiring the launcher owns: the spec
+reaching the containers, the flags that make the run supervised and engine-free,
+the guards against configurations that silently train nothing, and the dataset
+columns miles reads.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from modal_training_gym import (
+    GLM_5_2,
+    GLM_5_2_5Layer,
+    EmbeddingProjectorDataset,
+    GLM_5_2_5Layer_Projector_Recipe,
+    GLM_5_2_Projector_Recipe,
+    ProjectorSpec,
+)
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.frameworks.miles.projector_config import (
+    ARGS_KEY,
+    PROVIDER_PATH,
+    ROLLOUT_PATH,
+    SAVE_HOOK_PATH,
+    from_miles_args,
+)
+from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+
+
+def _flags(args: list[str]) -> dict[str, str]:
+    return {
+        args[i]: (
+            args[i + 1]
+            if i + 1 < len(args) and not args[i + 1].startswith("--")
+            else ""
+        )
+        for i in range(len(args))
+        if args[i].startswith("--")
+    }
+
+
+def _dataset() -> EmbeddingProjectorDataset:
+    return EmbeddingProjectorDataset(
+        rows=[
+            {
+                "messages": [
+                    {"role": "user", "content": "protein?"},
+                    {"role": "assistant", "content": "kinase"},
+                ],
+                "embeddings": [[0.0] * 4, [1.0] * 4],
+                "positions": [2, 3],
+            }
+        ]
+    )
+
+
+def test_spec_reaches_containers_through_extra_config():
+    recipe = GLM_5_2_5Layer_Projector_Recipe(
+        projector=ProjectorSpec(input_dim=4, hidden_dim=8, num_layers=1)
+    )
+    payload = recipe.extra_config[ARGS_KEY]
+    assert payload["input_dim"] == 4 and payload["num_layers"] == 1
+    # miles sets every extra_config key on args, which is how the provider and
+    # the checkpoint hook read the spec back without new CLI flags.
+    spec = from_miles_args(_FakeArgs(payload))
+    assert spec.input_dim == 4
+    assert spec.embeddings_key == "projector_embeddings"
+
+
+class _FakeArgs:
+    def __init__(self, payload: dict) -> None:
+        setattr(self, ARGS_KEY, payload)
+
+
+def test_missing_spec_is_a_clear_error():
+    with pytest.raises(ValueError, match=ARGS_KEY):
+        from_miles_args(_FakeArgs.__new__(_FakeArgs))
+
+
+def test_recipe_emits_supervised_engine_free_flags():
+    recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
+    flags = _flags(recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer()))
+
+    assert flags["--custom-model-provider-path"] == PROVIDER_PATH
+    assert flags["--rollout-function-path"] == ROLLOUT_PATH
+    assert flags["--loss-type"] == "sft_loss"
+    assert "--debug-train-only" in flags
+    assert "--disable-compute-advantages-and-returns" in flags
+    # No LoRA anywhere: the whole point of freezing the base instead.
+    assert "--lora-rank" not in flags
+    # The projector spec travels in the YAML config, never as a flag.
+    assert "--projector" not in flags
+
+
+def test_save_hook_runs_through_the_gyms_phase_reporting_wrapper():
+    """Dashboard phase/substep timing must survive the projector's own hook."""
+    recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
+    flags = _flags(recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer()))
+    assert flags["--custom-megatron-before-train-step-hook-path"].startswith(
+        "modal_training_gym.frameworks.miles.phase_reporting"
+    )
+    assert (
+        recipe.extra_config["training_gym_custom_megatron_before_train_step_hook_path"]
+        == SAVE_HOOK_PATH
+    )
+
+
+def test_lora_is_rejected():
+    # Pydantic wraps the validator's error; the message is what a user reads.
+    with pytest.raises(ValidationError, match="lora_rank must be unset"):
+        GLM_5_2_Projector_Recipe(lora_rank=16)
+
+
+def test_pipeline_parallelism_is_rejected():
+    """PP>1 would give later stages an optimizer over an empty parameter set."""
+    recipe = GLM_5_2_Projector_Recipe(pipeline_model_parallel_size=2)
+    with pytest.raises(TrainingGymConfigError, match="pipeline_model_parallel_size=1"):
+        recipe.validate_model_parallelism(GLM_5_2())
+
+
+def test_disk_reservation_survives_caller_supplied_train_kwargs():
+    recipe = GLM_5_2_Projector_Recipe(train_function_kwargs={"timeout": 60})
+    assert recipe.train_function_kwargs["timeout"] == 60
+    assert recipe.train_function_kwargs["ephemeral_disk"] > 0
+
+
+def test_base_recipe_lookup():
+    assert isinstance(MilesRecipe.get_base_recipe(GLM_5_2()), GLM_5_2_Projector_Recipe)
+    assert isinstance(
+        MilesRecipe.get_base_recipe(GLM_5_2_5Layer()),
+        GLM_5_2_5Layer_Projector_Recipe,
+    )
+
+
+def test_dataset_writes_embeddings_into_the_metadata_column(tmp_path):
+    dataset = _dataset()
+    out = str(tmp_path / "train.jsonl")
+    dataset.prepare(out)
+    dataset.validate_prepared(out)
+    row = json.loads(open(out).readline())
+    assert row["metadata"]["projector_positions"] == [2, 3]
+    assert len(row["metadata"]["projector_embeddings"]) == 2
+    # The conversation stays a message list: the SFT loss mask is built by
+    # splitting it, which a rendered string would not allow.
+    assert isinstance(row["messages"], list)
+
+
+def test_dataset_rejects_mismatched_embeddings_and_positions():
+    with pytest.raises(TrainingGymConfigError, match="position"):
+        EmbeddingProjectorDataset(
+            rows=[
+                {
+                    "messages": [{"role": "user", "content": "x"}],
+                    "embeddings": [[0.0], [1.0]],
+                    "positions": [1],
+                }
+            ]
+        )

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -107,6 +107,25 @@ def test_frozen_base_cannot_be_left_uninitialized():
     assert GLM_5_2_Projector_Recipe().hf_checkpoint == "zai-org/GLM-5.2"
 
 
+def test_overrides_assigned_after_construction_are_still_rejected():
+    """Pydantic dataclasses do not re-validate on assignment, but callers assign.
+
+    ``scripts/validate_model_configs.py`` sets ``eval_interval`` on the recipe
+    the backend built, which would otherwise reach the rollout function's hard
+    raise mid-run.
+    """
+    recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
+    recipe.eval_interval = 5
+    with pytest.raises(TrainingGymConfigError, match="cannot evaluate"):
+        recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer())
+
+    recipe.eval_interval = None
+    recipe.save_interval = 1
+    # Writing the unchanged frozen base is wasteful, not wrong: warn, don't fail.
+    with pytest.warns(UserWarning, match="frozen base"):
+        recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer())
+
+
 def test_recipe_emits_supervised_engine_free_flags():
     recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
     flags = _flags(recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer()))

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -123,6 +123,13 @@ def test_pipeline_parallelism_is_rejected():
         recipe.validate_model_parallelism(GLM_5_2())
 
 
+def test_context_parallelism_is_rejected():
+    """CP shards the sequence its own way; the merge rebases only TP/SP."""
+    recipe = GLM_5_2_Projector_Recipe(context_parallel_size=2)
+    with pytest.raises(TrainingGymConfigError, match="context_parallel_size=1"):
+        recipe.validate_model_parallelism(GLM_5_2())
+
+
 def test_megatron_checkpoint_loading_is_rejected():
     """The projector is a submodule, so base state dicts lack its keys."""
     with pytest.raises(ValidationError, match="resumes through projector.load"):

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -130,6 +130,26 @@ def test_context_parallelism_is_rejected():
         recipe.validate_model_parallelism(GLM_5_2())
 
 
+def test_tensor_parallelism_without_sequence_parallelism_is_rejected():
+    """Summing the replicated projector's grads over TP assumes disjoint shards."""
+    recipe = GLM_5_2_Projector_Recipe(sequence_parallel=False)
+    with pytest.raises(TrainingGymConfigError, match="sequence_parallel=True"):
+        recipe.validate_model_parallelism(GLM_5_2())
+    # TP=1 has nothing to sum over, so the combination is fine there.
+    GLM_5_2_Projector_Recipe(
+        sequence_parallel=False,
+        tensor_model_parallel_size=1,
+        expert_model_parallel_size=1,
+    ).validate_model_parallelism(GLM_5_2())
+
+
+def test_renaming_the_positions_column_is_rejected():
+    """Miles offsets packed-batch keys only when they end in ``_positions``."""
+    with pytest.raises(ValidationError, match="must end in '_positions'"):
+        ProjectorSpec(positions_key="proj_pos")
+    assert ProjectorSpec(positions_key="protein_positions").positions_key
+
+
 def test_megatron_checkpoint_loading_is_rejected():
     """The projector is a submodule, so base state dicts lack its keys."""
     with pytest.raises(ValidationError, match="resumes through projector.load"):

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -27,6 +27,7 @@ from modal_training_gym.frameworks.miles.projector_config import (
     ROLLOUT_PATH,
     SAVE_HOOK_PATH,
     from_miles_args,
+    should_save_projector,
 )
 from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
 
@@ -120,6 +121,42 @@ def test_pipeline_parallelism_is_rejected():
     recipe = GLM_5_2_Projector_Recipe(pipeline_model_parallel_size=2)
     with pytest.raises(TrainingGymConfigError, match="pipeline_model_parallel_size=1"):
         recipe.validate_model_parallelism(GLM_5_2())
+
+
+def test_megatron_checkpoint_loading_is_rejected():
+    """The projector is a submodule, so base state dicts lack its keys."""
+    with pytest.raises(ValidationError, match="resumes through projector.load"):
+        GLM_5_2_Projector_Recipe(load="/checkpoints/glm")
+    with pytest.raises(ValidationError, match="resumes through projector.load"):
+        GLM_5_2_Projector_Recipe(ref_load="/checkpoints/glm")
+
+
+def test_a_finished_run_always_leaves_a_projector_checkpoint():
+    """The run's last optimizer step saves even when the interval misses it."""
+    assert [
+        s for s in range(1, 11) if should_save_projector(s, 10, save_interval=4)
+    ] == [4, 8, 10]
+    # The shipped defaults: one save, at the end of the run.
+    recipe = GLM_5_2_Projector_Recipe()
+    total = (
+        recipe.num_rollout
+        * recipe.rollout_batch_size
+        * recipe.n_samples_per_prompt
+        // recipe.global_batch_size
+    )
+    assert [
+        s
+        for s in range(1, total + 1)
+        if should_save_projector(s, total, recipe.projector.save_interval)
+    ] == [total]
+    # An interval of 0 turns periodic saves off, but not the final one.
+    assert not should_save_projector(3, total, 0)
+    assert should_save_projector(total, total, 0)
+
+
+def test_synthetic_validation_data_is_regenerated_per_run():
+    """The on-volume path is class-derived, so stale rows would be reused."""
+    assert EmbeddingProjectorDataset.synthetic(n_rows=2, input_dim=4).always_prepare
 
 
 def test_disk_reservation_survives_caller_supplied_train_kwargs():

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -19,6 +19,7 @@ from modal_training_gym import (
     GLM_5_2_5Layer_Projector_Recipe,
     GLM_5_2_Projector_Recipe,
     ProjectorSpec,
+    ProteinLocalizationDataset,
 )
 from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.frameworks.miles.projector_config import (
@@ -490,3 +491,119 @@ def test_a_hook_call_without_an_optimizer_fails_rather_than_skipping():
         save_projector_checkpoint(
             object(), rollout_id=0, step_id=0, model=[], optimizer=None
         )
+
+
+# ── Real biological data: ESM-2 over DeepLoc ──────────────────────────────────
+
+
+def test_protein_dataset_turns_deeploc_locations_into_answer_words():
+    """The target has to be words, since the model answers by generating them.
+
+    DeepLocMulti's label is ``"Endoplasmic.reticulum,M"``; DeepLocBinary's is a
+    bare ``"M"``/``"S"``. Neither is something a decoder should be asked to emit.
+    """
+    dataset = ProteinLocalizationDataset()
+    assert dataset._class_word("Endoplasmic.reticulum,M") == "endoplasmic reticulum"
+    assert dataset._class_word("Nucleus,U") == "nucleus"
+    assert dataset._class_word("M") == "membrane"
+    assert dataset._class_word("S") == "soluble"
+
+
+def test_protein_dataset_holds_its_eval_split_out_by_construction():
+    """Train and eval come from DeepLoc's own disjoint splits, not a resample."""
+    dataset = ProteinLocalizationDataset()
+    assert dataset.train_split != dataset.eval_split
+    assert dataset.always_prepare, "stale rows on the volume would be reused"
+    train_path, eval_paths = MilesRecipe._resolve_data_paths(dataset)
+    assert eval_paths and eval_paths["eval"] != train_path
+
+
+def test_protein_dataset_rejects_an_encoder_the_projector_is_not_shaped_for():
+    """Caught while materializing data, not after a cluster is up."""
+    dataset = ProteinLocalizationDataset(input_dim=1536)
+    dataset._encode = lambda sequences: [[0.0] * 640 for _ in sequences]  # pyright: ignore[reportAttributeAccessIssue]
+    with pytest.raises(TrainingGymConfigError, match="640-wide"):
+        dataset._split_rows("test", 1)
+
+
+def test_protein_rows_carry_the_embedding_in_the_column_miles_reads():
+    dataset = ProteinLocalizationDataset(rows=[])
+    row = dataset._to_row(
+        {
+            "messages": [
+                {"role": "user", "content": dataset.prompt},
+                {"role": "assistant", "content": "nucleus"},
+            ],
+            "embeddings": [[0.5] * 640],
+            "positions": [1],
+            "label": "nucleus",
+        }
+    )
+    assert row["metadata"]["projector_embeddings"] == [[0.5] * 640]
+    assert row["metadata"]["projector_positions"] == [1]
+
+
+def test_the_held_out_eval_reads_targets_and_embeddings_back(tmp_path):
+    """The eval's candidate set is the file's own answers, not a second list."""
+    from modal_training_gym.frameworks.miles.projector_eval import read_eval_rows
+
+    path = tmp_path / "eval.jsonl"
+    dataset = ProteinLocalizationDataset(rows=[])
+    with open(path, "w") as f:
+        for word in ("nucleus", "membrane"):
+            f.write(
+                json.dumps(
+                    dataset._to_row(
+                        {
+                            "messages": [
+                                {"role": "user", "content": dataset.prompt},
+                                {"role": "assistant", "content": word},
+                            ],
+                            "embeddings": [[0.25] * 640],
+                            "positions": [1],
+                            "label": word,
+                        }
+                    )
+                )
+                + "\n"
+            )
+
+    rows = read_eval_rows(str(path), "projector_embeddings", "projector_positions")
+    assert [r["target"] for r in rows] == ["nucleus", "membrane"]
+    # The answer is removed from what the model is shown, or accuracy is free.
+    assert all(m["role"] != "assistant" for r in rows for m in r["messages"])
+    assert rows[0]["embeddings"] == [[0.25] * 640] and rows[0]["positions"] == [1]
+
+
+def test_the_report_states_both_baselines_it_has_to_beat():
+    from modal_training_gym.frameworks.miles.projector_eval import (
+        ProjectorEvalReport,
+        ProjectorEvalRow,
+    )
+
+    def row(target: str, prediction: str) -> ProjectorEvalRow:
+        return ProjectorEvalRow(
+            prompt="p",
+            target=target,
+            prediction=prediction,
+            correct=target == prediction,
+            scores={},
+        )
+
+    report = ProjectorEvalReport(
+        model_name="m",
+        checkpoint="c",
+        iteration=40,
+        classes=["nucleus", "membrane"],
+        rows=[
+            row("nucleus", "nucleus"),
+            row("nucleus", "nucleus"),
+            row("membrane", "membrane"),
+            row("membrane", "nucleus"),
+        ],
+        untrained_rows=[row("nucleus", "nucleus")] + [row("membrane", "nucleus")] * 3,
+    )
+    assert report.accuracy == 0.75
+    assert report.untrained_accuracy == 0.25
+    assert report.majority_accuracy == 0.5
+    assert "trained 0.750" in report.summary()

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -202,6 +202,21 @@ def test_a_finished_run_always_leaves_a_projector_checkpoint():
     assert not should_save_projector(0, total, total, 0)
 
 
+def test_expert_parallel_size_must_divide_the_model_scripts_experts():
+    """GLM-5.2 has no ModelArchitecture, so the gym's own EP preflight is a no-op."""
+    with pytest.raises(TrainingGymConfigError, match="256 routed experts"):
+        GLM_5_2_Projector_Recipe(
+            expert_model_parallel_size=24
+        ).validate_model_parallelism(GLM_5_2())
+    for recipe in (GLM_5_2_Projector_Recipe(), GLM_5_2_5Layer_Projector_Recipe()):
+        recipe.validate_model_parallelism(GLM_5_2())
+
+
+def test_no_eval_pass_is_configured():
+    """The rollout raises on evaluation, so the run must not schedule one."""
+    assert GLM_5_2_Projector_Recipe().skip_eval_before_train is True
+
+
 def test_synthetic_validation_data_is_regenerated_per_run():
     """The on-volume path is class-derived, so stale rows would be reused."""
     assert EmbeddingProjectorDataset.synthetic(n_rows=2, input_dim=4).always_prepare

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -436,3 +436,22 @@ def test_a_zeroed_projector_is_caught_at_the_first_forward():
         check_projector_weights(projector)
     # Every row it would merge is exactly zero, whatever the encoder produced.
     assert float(projector(torch.ones(2, 4)).abs().max()) == 0.0
+
+
+def test_a_hook_call_without_an_optimizer_fails_rather_than_skipping():
+    """The saver owns the grad all-reduce, so skipping it trains partial grads.
+
+    The pinned image passes the optimizer, and the GPU runs installed the saver
+    and wrote checkpoints; if a future image stops doing so, the run has to stop
+    rather than quietly train tensor-parallel-partial gradients and produce no
+    adapter.
+    """
+    pytest.importorskip("torch")
+    from modal_training_gym.frameworks.miles.embedding_projector import (
+        save_projector_checkpoint,
+    )
+
+    with pytest.raises(RuntimeError, match="without an optimizer"):
+        save_projector_checkpoint(
+            object(), rollout_id=0, step_id=0, model=[], optimizer=None
+        )

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -204,11 +204,14 @@ def test_tensor_parallelism_without_sequence_parallelism_is_rejected():
     recipe = GLM_5_2_Projector_Recipe(sequence_parallel=False)
     with pytest.raises(TrainingGymConfigError, match="sequence_parallel=True"):
         recipe.validate_model_parallelism(GLM_5_2())
-    # TP=1 has nothing to sum over, so the combination is fine there.
+    # TP=1 has nothing to sum over, so the combination is fine there — at a
+    # batch that still covers the 64 data-parallel ranks TP=1 leaves.
     GLM_5_2_Projector_Recipe(
         sequence_parallel=False,
         tensor_model_parallel_size=1,
         expert_model_parallel_size=1,
+        rollout_batch_size=64,
+        global_batch_size=64,
     ).validate_model_parallelism(GLM_5_2())
 
 
@@ -285,6 +288,16 @@ def test_expert_parallel_size_must_divide_the_model_scripts_experts():
         ).validate_model_parallelism(GLM_5_2())
     for recipe in (GLM_5_2_Projector_Recipe(), GLM_5_2_5Layer_Projector_Recipe()):
         recipe.validate_model_parallelism(GLM_5_2())
+
+
+def test_a_step_must_have_a_sample_for_every_data_parallel_rank():
+    """Both shipped shapes, and a rejection when a topology outgrows the batch."""
+    for recipe in (GLM_5_2_Projector_Recipe(), GLM_5_2_5Layer_Projector_Recipe()):
+        recipe.validate_model_parallelism(GLM_5_2())
+    with pytest.raises(TrainingGymConfigError, match="16 data-parallel rank"):
+        GLM_5_2_Projector_Recipe(
+            rollout_batch_size=8, global_batch_size=8
+        ).validate_model_parallelism(GLM_5_2())
 
 
 def test_no_eval_pass_is_configured():

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -357,6 +357,41 @@ def test_synthetic_validation_data_is_regenerated_per_run():
     assert EmbeddingProjectorDataset.synthetic(n_rows=2, input_dim=4).always_prepare
 
 
+def test_the_labelled_synthetic_task_puts_the_answer_only_in_the_embedding():
+    """What makes the loss curve mean something: the prompt cannot answer it.
+
+    Every row shares one prompt and the target follows from the embedding alone,
+    so a falling loss is the projector carrying information rather than the base
+    reading the question. The control deletes exactly that information and
+    nothing else.
+    """
+    rows = EmbeddingProjectorDataset.synthetic_classification(
+        n_rows=8, input_dim=16, n_classes=4
+    ).rows
+    prompts = {r["messages"][0]["content"] for r in rows}
+    targets = [r["messages"][1]["content"] for r in rows]
+    assert len(prompts) == 1
+    assert len(set(targets)) == 4
+    # One vector per class, identical across the rows sharing a class.
+    per_class = {t: tuple(r["embeddings"][0]) for t, r in zip(targets, rows)}
+    assert len(set(per_class.values())) == 4
+    assert all(any(v) for v in per_class.values())
+
+    control = EmbeddingProjectorDataset.synthetic_classification(
+        n_rows=8, input_dim=16, n_classes=4, zero_embeddings=True
+    ).rows
+    assert [r["messages"] for r in control] == [r["messages"] for r in rows]
+    assert all(not any(r["embeddings"][0]) for r in control)
+
+
+def test_the_labelled_synthetic_task_rejects_more_classes_than_it_has_words():
+    dataset = EmbeddingProjectorDataset.synthetic_classification(
+        n_rows=2, input_dim=4, n_classes=99
+    )
+    with pytest.raises(TrainingGymConfigError, match="class words"):
+        dataset.rows
+
+
 def test_disk_reservation_survives_caller_supplied_train_kwargs():
     recipe = GLM_5_2_Projector_Recipe(train_function_kwargs={"timeout": 60})
     assert recipe.train_function_kwargs["timeout"] == 60

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -177,7 +177,7 @@ def test_megatron_checkpoint_loading_is_rejected():
 def test_a_finished_run_always_leaves_a_projector_checkpoint():
     """The run's last optimizer step saves even when the interval misses it."""
     assert [
-        s for s in range(1, 11) if should_save_projector(s, 10, save_interval=4)
+        s for s in range(1, 11) if should_save_projector(s, s, 10, save_interval=4)
     ] == [4, 8, 10]
     # The shipped defaults: one save, at the end of the run.
     recipe = GLM_5_2_Projector_Recipe()
@@ -190,11 +190,16 @@ def test_a_finished_run_always_leaves_a_projector_checkpoint():
     assert [
         s
         for s in range(1, total + 1)
-        if should_save_projector(s, total, recipe.projector.save_interval)
+        if should_save_projector(s, s, total, recipe.projector.save_interval)
     ] == [total]
     # An interval of 0 turns periodic saves off, but not the final one.
-    assert not should_save_projector(3, total, 0)
-    assert should_save_projector(total, total, 0)
+    assert not should_save_projector(3, 3, total, 0)
+    assert should_save_projector(total, total, total, 0)
+    # A skipped update (gradient overflow) consumed one of the run's steps, so
+    # the last attempt still saves what the applied steps produced.
+    assert should_save_projector(total - 1, total, total, 0)
+    # ...but a run where nothing ever applied has no trained adapter to write.
+    assert not should_save_projector(0, total, total, 0)
 
 
 def test_synthetic_validation_data_is_regenerated_per_run():

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -82,6 +82,31 @@ def test_missing_spec_is_a_clear_error():
         from_miles_args(_FakeArgs.__new__(_FakeArgs))
 
 
+@pytest.mark.parametrize("container", ["extra_config", "custom_config"])
+def test_spec_is_also_found_nested_under_the_config_containers(container: str):
+    """Mirrors the gym's other in-container readers, which try both spellings.
+
+    The pinned image flattens ``extra_config`` onto ``args``; a plumbing change
+    that kept the dict nested must not silently lose the projector.
+    """
+    args = _FakeArgs.__new__(_FakeArgs)
+    setattr(args, container, {ARGS_KEY: ProjectorSpec(input_dim=7).to_args_dict()})
+    assert from_miles_args(args).input_dim == 7
+
+
+def test_frozen_base_cannot_be_left_uninitialized():
+    """``hf_checkpoint`` is the only base-weight source once ref_load is rejected.
+
+    Bridge mode falls back to ``args.load = args.ref_load or args.hf_checkpoint``,
+    so an empty one would train the projector against random base weights.
+    """
+    with pytest.raises(ValidationError, match="hf_checkpoint"):
+        GLM_5_2_Projector_Recipe(hf_checkpoint="")
+    with pytest.raises(ValidationError, match="bridge"):
+        GLM_5_2_Projector_Recipe(megatron_to_hf_mode="dist")
+    assert GLM_5_2_Projector_Recipe().hf_checkpoint == "zai-org/GLM-5.2"
+
+
 def test_recipe_emits_supervised_engine_free_flags():
     recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
     flags = _flags(recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer()))

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -493,6 +493,37 @@ def test_a_hook_call_without_an_optimizer_fails_rather_than_skipping():
         )
 
 
+def test_the_untrained_baseline_starts_where_the_run_started(tmp_path):
+    """A custom init has to survive into the eval, or the baseline is a different model.
+
+    ``load_projector(trained=False)`` is the "the projector contributes nothing"
+    number, and it only means that if it inits from the seed and scale the run
+    used rather than from ``ProjectorSpec()``'s.
+    """
+    torch = pytest.importorskip("torch")
+    from modal_training_gym.frameworks.miles.embedding_projector import (
+        EmbeddingProjector,
+        init_projector,
+        write_projector_checkpoint,
+    )
+    from modal_training_gym.frameworks.miles.projector_eval import load_projector
+
+    spec = ProjectorSpec(
+        input_dim=4, hidden_dim=8, output_dim=6, init_seed=7, output_scale=0.25
+    )
+    projector = EmbeddingProjector(input_dim=4, hidden_dim=8, output_dim=6)
+    init_projector(projector, spec.init_seed, spec.output_scale)
+    expected = {k: v.clone() for k, v in projector.state_dict().items()}
+    write_projector_checkpoint(spec, str(tmp_path), projector, step=3, numbered=False)
+
+    baseline, iteration = load_projector(
+        str(tmp_path / "projector_latest.pt"), trained=False
+    )
+    assert iteration == 3
+    for name, param in baseline.state_dict().items():
+        assert torch.equal(param, expected[name]), name
+
+
 # ── Real biological data: ESM-2 over DeepLoc ──────────────────────────────────
 
 

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -638,3 +638,66 @@ def test_the_report_states_both_baselines_it_has_to_beat():
     assert report.untrained_accuracy == 0.25
     assert report.majority_accuracy == 0.5
     assert "trained 0.750" in report.summary()
+
+
+def test_publishing_the_report_reaches_the_dashboard_store(monkeypatch):
+    """The eval only counts if it lands in the dashboard, so publish is exercised.
+
+    Both of the bugs this catches were invisible until a GPU eval had already
+    finished: ``publish()`` is the last line of a multi-minute remote call, so a
+    wrong ``create_hash`` arity there costs a whole eval to discover.
+    """
+    from modal_training_gym.frameworks.miles.projector_eval import (
+        ProjectorEvalReport,
+        ProjectorEvalRow,
+    )
+
+    written: dict[str, dict] = {}
+    monkeypatch.setattr(
+        "modal_training_gym.common.eval.vol_put",
+        lambda store, key, value, **kw: written.__setitem__(key, value),
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.eval.vol_get",
+        lambda store, key, **kw: written.get(key, {}),
+    )
+
+    report = ProjectorEvalReport(
+        model_name="zai-org/GLM-5.2",
+        checkpoint="/checkpoints/run/projector/projector_latest.pt",
+        iteration=150,
+        classes=["nucleus", "membrane"],
+        rows=[
+            ProjectorEvalRow(
+                prompt="p",
+                target="nucleus",
+                prediction="nucleus",
+                correct=True,
+                scores={"nucleus": -1.0, "membrane": -2.0},
+            )
+        ],
+    )
+    eval_id = report.publish()
+    assert written[eval_id]["rows"][0]["score"] == 1.0
+    assert written[eval_id]["model_name"] == "zai-org/GLM-5.2"
+
+
+def test_the_eval_resolves_the_held_out_split_the_run_wrote(monkeypatch):
+    """``ProjectorEval`` reads the training run's paths, not paths of its own."""
+    from modal_training_gym.frameworks.miles.projector_eval import ProjectorEval
+    from modal_training_gym.train_recipes.miles_recipe.glm_5_2 import (
+        GLM_5_2_5Layer_Projector_Recipe,
+    )
+
+    recipe = GLM_5_2_5Layer_Projector_Recipe(num_rollout=4)
+    dataset = ProteinLocalizationDataset()
+    ev = ProjectorEval(
+        model=GLM_5_2_5Layer(),
+        recipe=recipe,
+        dataset=dataset,
+        training_run_id="some-run-id",
+    )
+    assert ev._eval_path().endswith(".jsonl")
+    assert ev._checkpoint_path() == (
+        "/checkpoints/some-run-id/projector/projector_latest.pt"
+    )

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -179,6 +179,29 @@ def test_an_unwired_step_hook_fails_at_model_construction():
         require_projector_step_hook(wired)
 
 
+def test_only_the_attention_backend_that_keeps_the_gradient_is_allowed():
+    """tilelang's fused sparse-MLA backward hands the embeddings NaN dq.
+
+    Verified on 8xH200: finite forward and finite grads down to the query
+    projection, then NaN out of ``sparse_mla_bwd`` — harmless for the LoRA runs
+    upstream ships, fatal for a projector whose gradient comes from there. The
+    working pairing is unrecomputable, so recompute is rejected with it.
+    """
+    for override in (
+        {"dsa_attention_backend": "tilelang", "qkv_format": "thd"},
+        {"qkv_format": "thd"},
+    ):
+        with pytest.raises(ValidationError, match='dsa_attention_backend="megatron"'):
+            GLM_5_2_Projector_Recipe(**override)
+    with pytest.raises(ValidationError, match="recompute_granularity=None"):
+        GLM_5_2_Projector_Recipe(recompute_granularity="full")
+    recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
+    assert (recipe.dsa_attention_backend, recipe.qkv_format) == ("megatron", "bshd")
+    recipe.recompute_granularity = "full"
+    with pytest.raises(TrainingGymConfigError, match="recompute_granularity=None"):
+        recipe.validate_model_parallelism(GLM_5_2_5Layer())
+
+
 def test_lora_is_rejected():
     # Pydantic wraps the validator's error; the message is what a user reads.
     with pytest.raises(ValidationError, match="lora_rank must be unset"):

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -143,6 +143,13 @@ def test_tensor_parallelism_without_sequence_parallelism_is_rejected():
     ).validate_model_parallelism(GLM_5_2())
 
 
+def test_distributed_optimizer_is_rejected():
+    """It replaces the main_grad buffers the projector's TP sum reads whole."""
+    with pytest.raises(ValidationError, match="use_distributed_optimizer=False"):
+        GLM_5_2_Projector_Recipe(use_distributed_optimizer=True)
+    assert GLM_5_2_Projector_Recipe().use_distributed_optimizer is False
+
+
 def test_projector_starts_at_the_bases_embedding_scale():
     """A unit-std LayerNorm output is ~100x the scale of a token embedding."""
     spec = ProjectorSpec()

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -154,6 +154,31 @@ def test_save_hook_runs_through_the_gyms_phase_reporting_wrapper():
     )
 
 
+def test_an_unwired_step_hook_fails_at_model_construction():
+    """Without the hook there is no grad all-reduce and no checkpoint at all."""
+    from types import SimpleNamespace
+
+    from modal_training_gym.frameworks.miles.projector_config import (
+        require_projector_step_hook,
+    )
+
+    recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
+    flags = _flags(recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer()))
+    wired = SimpleNamespace(
+        custom_megatron_before_train_step_hook_path=flags[
+            "--custom-megatron-before-train-step-hook-path"
+        ],
+        extra_config=dict(recipe.extra_config or {}),
+    )
+    require_projector_step_hook(wired)
+
+    wired.extra_config.pop(
+        "training_gym_custom_megatron_before_train_step_hook_path", None
+    )
+    with pytest.raises(ValueError, match="unreduced gradients and no checkpoints"):
+        require_projector_step_hook(wired)
+
+
 def test_lora_is_rejected():
     # Pydantic wraps the validator's error; the message is what a user reads.
     with pytest.raises(ValidationError, match="lora_rank must be unset"):

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -312,3 +312,44 @@ def test_dataset_rejects_mismatched_embeddings_and_positions():
                 }
             ]
         )
+
+
+def test_offloading_the_train_model_is_rejected():
+    """Offloading zeroes the parameter buffer, which holds only the projector.
+
+    Megatron allocates it in a torch_memory_saver region with no backup, and
+    miles' ``sleep()`` pauses every tag, so a projector-only run would wake up
+    training weights that read exactly zero (verified on 8xH200).
+    """
+    with pytest.raises(ValidationError, match="no_offload_train=True"):
+        GLM_5_2_Projector_Recipe(no_offload_train=False)
+    assert GLM_5_2_Projector_Recipe().no_offload_train is True
+    recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))
+    recipe.no_offload_train = False
+    with pytest.raises(TrainingGymConfigError, match="no_offload_train=True"):
+        recipe.cli_args(dataset=_dataset(), model=GLM_5_2_5Layer())
+
+
+def test_a_zeroed_projector_is_caught_at_the_first_forward():
+    """Zeroed weights write exactly-zero rows: trained, but on no signal at all."""
+    torch = pytest.importorskip("torch")
+    from modal_training_gym.frameworks.miles.embedding_projector import (
+        EmbeddingProjector,
+        check_projector_weights,
+        init_projector,
+    )
+
+    projector = EmbeddingProjector(input_dim=4, hidden_dim=8, output_dim=6)
+    init_projector(projector, seed=0, output_scale=0.01)
+    stats = check_projector_weights(projector)
+    assert "mlp.0.weight rms=" in stats and "norm.weight rms=0.01" in stats
+    out = projector(torch.zeros(2, 4))
+    assert torch.isfinite(out).all() and float(out.abs().max()) > 0.0
+
+    with torch.no_grad():
+        for param in projector.parameters():
+            param.zero_()
+    with pytest.raises(ValueError, match="no_offload_train=True"):
+        check_projector_weights(projector)
+    # Every row it would merge is exactly zero, whatever the encoder produced.
+    assert float(projector(torch.ones(2, 4)).abs().max()) == 0.0

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -143,6 +143,15 @@ def test_tensor_parallelism_without_sequence_parallelism_is_rejected():
     ).validate_model_parallelism(GLM_5_2())
 
 
+def test_projector_starts_at_the_bases_embedding_scale():
+    """A unit-std LayerNorm output is ~100x the scale of a token embedding."""
+    spec = ProjectorSpec()
+    assert spec.output_scale == 0.01
+    assert spec.to_args_dict()["output_scale"] == 0.01
+    with pytest.raises(ValidationError, match="output_scale=0.0 must be positive"):
+        ProjectorSpec(output_scale=0.0)
+
+
 def test_renaming_the_positions_column_is_rejected():
     """Miles offsets packed-batch keys only when they end in ``_positions``."""
     with pytest.raises(ValidationError, match="must end in '_positions'"):

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -174,8 +174,14 @@ def test_megatron_checkpoint_loading_is_rejected():
         GLM_5_2_Projector_Recipe(ref_load="/checkpoints/glm")
 
 
-def test_a_finished_run_always_leaves_a_projector_checkpoint():
-    """The run's last optimizer step saves even when the interval misses it."""
+def test_numbered_checkpoints_do_not_depend_on_the_predicted_step_count():
+    """``train_iters`` is a prediction; only numbered files may depend on it."""
+    total = 10
+    # A run that outlives the prediction keeps one numbered file, not one per
+    # step from then on. Every applied step refreshes projector_latest.pt.
+    assert [
+        s for s in range(1, 14) if should_save_projector(s, s, total, save_interval=0)
+    ] == [total]
     assert [
         s for s in range(1, 11) if should_save_projector(s, s, 10, save_interval=4)
     ] == [4, 8, 10]
@@ -215,6 +221,8 @@ def test_expert_parallel_size_must_divide_the_model_scripts_experts():
 def test_no_eval_pass_is_configured():
     """The rollout raises on evaluation, so the run must not schedule one."""
     assert GLM_5_2_Projector_Recipe().skip_eval_before_train is True
+    with pytest.raises(ValidationError, match="cannot evaluate"):
+        GLM_5_2_Projector_Recipe(eval_interval=5)
 
 
 def test_synthetic_validation_data_is_regenerated_per_run():

--- a/tests/test_projector_only_training.py
+++ b/tests/test_projector_only_training.py
@@ -141,6 +141,28 @@ def test_recipe_emits_supervised_engine_free_flags():
     assert "--projector" not in flags
 
 
+def test_the_fields_this_adds_to_the_base_recipe_change_no_other_recipe():
+    """The projector's five new ``MilesRecipe`` fields are opt-in, not defaults.
+
+    They default to values ``cli_args`` skips, so every miles recipe that existed
+    before this change emits the command line it emitted before — which is the
+    only thing keeping a projector-shaped flag out of a Qwen or Moonlight run.
+    """
+    from modal_training_gym.common.models.qwen3_5_4b import Qwen3_5_4B
+    from modal_training_gym.train_recipes.miles_recipe import Qwen3_5_4b_Miles_Recipe
+
+    recipe = Qwen3_5_4b_Miles_Recipe()
+    flags = _flags(recipe.cli_args(dataset=_dataset(), model=Qwen3_5_4B()))
+    for flag in (
+        "--custom-model-provider-path",
+        "--loss-type",
+        "--num-epoch",
+        "--debug-train-only",
+        "--disable-compute-advantages-and-returns",
+    ):
+        assert flag not in flags
+
+
 def test_save_hook_runs_through_the_gyms_phase_reporting_wrapper():
     """Dashboard phase/substep timing must survive the projector's own hook."""
     recipe = GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=4))


### PR DESCRIPTION
[closed bc there's not a good case rn to train a projector with just rl, so we're not adding to the gym]

Adds GLM-5.2 to the gym as a **projector-only** miles workload: a trainable embedding
projector (external encoder → decoder hidden space) over a **fully frozen** base, no
LoRA. Freezing before Megatron builds the optimizer is what removes the nodes — optimizer
state, grad buffers and checkpoints scale with the projector, not with 744B parameters.

```python
TrainConfig(
    model=GLM_5_2_5Layer(),                       # or GLM_5_2()
    dataset=EmbeddingProjectorDataset(...),        # messages + embeddings + positions
    recipe=GLM_5_2_5Layer_Projector_Recipe(projector=ProjectorSpec(input_dim=1536)),
).train()
```

### How the three hard parts are arranged

**Model.** `custom_model_provider_path` → `projector_model_provider`: build the model
*miles itself would have built* (`get_model_provider_func(args)` with our provider path
temporarily cleared, so GLM-5.2's DSA spec, cross-layer indexer and MoE routing come from
`scripts/models/glm5.2-744B-A40B.py` verbatim), then `requires_grad_(False)` everywhere,
then attach the projector on the first pipeline stage.

**Forward merge.** miles splats `multimodal_train_inputs` into `model(**kwargs)`, but
`GPTModel.forward` accepts no such keys, so they are stripped there and merged in a
forward hook on `model.embedding` — the only place whose layout (`[s, b, h]`) and
sequence-parallel sharding are already settled. Positions are rebased onto the local
sequence shard and rows owned by other TP ranks dropped; projector params are tagged
`sequence_parallel = True` so Megatron all-reduces their grads across TP.

**Checkpointing + sync.** The before-train-step hook writes the projector's own state
dict; `save_interval` is parked above `num_rollout` so Megatron never writes terabytes of
unchanged base weights. The frozen base needs no checkpoint — it stays byte-identical to
`hf_checkpoint`, so `(hf_checkpoint, projector_iter_*.pt)` describes the artifact
completely. Weight sync: **none**, deliberately. miles' non-LoRA sync pushes the whole
base to SGLang (`skip_base_sync` is gated on `is_lora`), so projector-only sync is not
expressible on the pinned image; the recipe therefore ships the supervised
`debug_train_only` path (no engines, no rollout, no sync) and documents that RL needs
either an upstream projector-aware sync path or a full 744B sync per rollout.

`pipeline_model_parallel_size` is validated to 1: with the base frozen, only the first
stage holds trainable parameters, so later stages would build an optimizer over an empty
parameter set. Scale with TP/CP/EP. `lora_rank` is rejected — miles' LoRA path owns its
own freezing, sync and checkpoint format.

### Shapes

| | 5-layer (`Pinaster/GLM-5.2_5layer`) | full (`zai-org/GLM-5.2`) |
| --- | --- | --- |
| nodes × GPUs | 1 × 8 H200 | 8 × 8 H200 |
| TP/PP/CP/EP/ETP | 4/1/1/8/1 | 4/1/1/32/1 |
| tokens/GPU | 2048 | 8192 |

The 1-node column is upstream's own smoke shape. The 8-node column departs from upstream's
≥16-node full-model shape because that shape sizes for full-parameter RL (optimizer state
+ engines + full sync), none of which exists here — it is a hypothesis until a step runs.

### Validation status

Everything below ran on GPUs on `Pinaster/GLM-5.2_5layer` (the 5-layer pruned GLM-5.2, 1×8
H200). The full `zai-org/GLM-5.2` 8×8 shape has **not** been run.

**Plumbing (3 steps + resume).** 203 base parameter tensors frozen, 31,479,808 trainable
projector params, finite grads, three applied optimizer steps, projector checkpoints 1–3
written, and a resumed run wrote checkpoint 4 without overwriting them.
[flush-instructor-609cb526b64b](https://modal-labs--training-gym-dashboard-fastapi-app.modal.run/training/flush-instructor-609cb526b64b),
[mechanical-classic-f0bd8799285f](https://modal-labs--training-gym-dashboard-fastapi-app.modal.run/training/mechanical-classic-f0bd8799285f)

**Learning (40 steps, synthetic).** Loss 8.70 → 3.68 on a task whose answer exists only in
the injected vector; the identical run with the embeddings zeroed plateaus at 5.51. The
1.83-nat gap is larger than the `ln 4` a class prior alone buys, so information is reaching
the frozen decoder through the projector.
[brownian-commit-ed01e9276f94](https://modal-labs--training-gym-dashboard-fastapi-app.modal.run/training/brownian-commit-ed01e9276f94)
(signal),
[energetic-gravel-bb503c614ab0](https://modal-labs--training-gym-dashboard-fastapi-app.modal.run/training/energetic-gravel-bb503c614ab0)
(control)

**Representative data (150 steps, real protein embeddings).** `ProteinLocalizationDataset`
encodes `AI4Protein/DeepLocMulti` sequences with `facebook/esm2_t30_150M_UR50D`
(mean-pooled last hidden state over the attention mask, 512-residue truncation, 640-wide),
writes one vector per row at token position 1, and answers with the localization word
(`Endoplasmic.reticulum,M` → `endoplasmic reticulum`). 512 rows from `train`, 128 held-out
rows from `test`, 10 classes.
[relaxed-transfer-dc153e9f589c](https://modal-labs--training-gym-dashboard-fastapi-app.modal.run/training/relaxed-transfer-dc153e9f589c)

`ProjectorEval` then scores every class word on the held-out split against three baselines
(eval `concrete-column-b2c7348ecd8e` on the dashboard's
[evals](https://modal-labs--training-gym-dashboard-fastapi-app.modal.run/evals) page):

| | held-out accuracy |
| --- | --- |
| trained projector (iteration 150) | **0.453** |
| same projector at its initialization | 0.219 |
| majority class | 0.258 |
| uniform over 10 classes | 0.100 |

The untrained-projector row is the one that matters: it is the same architecture at the
seed and scale *this run started from* (both are recorded in the checkpoint), so the gap is
training rather than the mere presence of a vector in the embedding stream.

**What is deliberately not claimed.** Generations on this base are degenerate — the trained
projector emits the right class word (`nucleus` for nuclear proteins, `endoplasmiculum…`
for ER) but not fluent English, because a 5-layer pruned stub cannot produce fluent English
regardless of the projector; output *quality* is a 744B question. And miles' own
`rollout/raw_reward` stays 0.0: `skip_base_sync` is gated on `is_lora` *and* the pinned
rollout has no `input_embeds` path (SGLang's entrypoint accepts the key, miles never sends
it), so a *generating* projector run needs a miles-side change. The shipped path is
supervised.

Local gates green: `ruff check`, `ruff format --check`, `compileall`, full `pytest` (864
passed, 4 skipped, incl. the projector/dataset/eval tests). Both models are registered with
`run_on_pr=False` (too large to fan out per PR). Everything asserted about the pinned image
(`radixark/miles:dev-202608120325`) was read out of the image rather than assumed.

## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->