### PR TITLE
Projector-only Qwen3.6-35B-A3B training on slime (frozen MoE base, no LoRA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Models with a built-in training recipe, with the `ModelConfig` and recipe classe
 | `Qwen/Qwen3.5-4B` | `slime`, `miles` | `Qwen3_5_4B` | `Qwen3_5_4b_Recipe`, `Qwen3_5_4b_Miles_Recipe` |
 | `Qwen/Qwen3.5-9B` | `slime` | `Qwen3_5_9B` | `Qwen3_5_9b_Recipe` |
 | `Qwen/Qwen3.6-27B` | `slime` | `Qwen3_6_27B` | `Qwen3_6_27b_Recipe` |
-| `Qwen/Qwen3.6-35B-A3B` | `slime` | `Qwen3_6_35B` | `Qwen3_6_35b_Recipe` |
+| `Qwen/Qwen3.6-35B-A3B` | `slime` | `Qwen3_6_35B` | `Qwen3_6_35b_Recipe`, `Qwen3_6_35b_Projector_Recipe` |
 | `Qwen/Qwen3.8-27B` | `slime` | `Qwen3_8_27B` | `Qwen3_8_27b_Recipe` |
 | `google/gemma-4-26B-A4B-it` | `miles` | `Gemma4_26B_A4B` | `Gemma4_26B_A4B_Recipe` |
 | `moonshotai/Moonlight-16B-A3B-Instruct` | `miles` | `Moonlight_16B_A3B_Instruct` | `Moonlight_16B_A3B_Recipe` |

--- a/docs-next/public/llms.txt
+++ b/docs-next/public/llms.txt
@@ -97,6 +97,7 @@ Repo: https://github.com/modal-projects/training-gym
 - [GLM_5_2_5Layer_Projector_Recipe](https://gym.modal.dev/reference/training/glm_5_2_5layer_projector_recipe/): `GLM_5_2_5Layer_Projector_Recipe`
 - [ProjectorSpec](https://gym.modal.dev/reference/training/projectorspec/): `ProjectorSpec`
 - [Qwen3_6_35b_Recipe](https://gym.modal.dev/reference/training/qwen3_6_35b_recipe/): `Qwen3_6_35b_Recipe`
+- [Qwen3_6_35b_Projector_Recipe](https://gym.modal.dev/reference/training/qwen3_6_35b_projector_recipe/): `Qwen3_6_35b_Projector_Recipe`
 - [Qwen3_6_27b_Recipe](https://gym.modal.dev/reference/training/qwen3_6_27b_recipe/): `Qwen3_6_27b_Recipe`
 - [Qwen3_8_27b_Recipe](https://gym.modal.dev/reference/training/qwen3_8_27b_recipe/): `Qwen3_8_27b_Recipe`
 - [Qwen3.5-0.8b_Recipe](https://gym.modal.dev/reference/training/qwen3_5_0_8b_recipe/): `Qwen3_5_0_8b_Recipe`

--- a/modal_training_gym/__init__.py
+++ b/modal_training_gym/__init__.py
@@ -42,8 +42,12 @@ _EXPORTS = {
         "modal_training_gym.train_recipes.miles_recipe",
         "GLM_5_2_5Layer_Projector_Recipe",
     ),
+    "Qwen3_6_35b_Projector_Recipe": (
+        "modal_training_gym.train_recipes.slime_recipe",
+        "Qwen3_6_35b_Projector_Recipe",
+    ),
     "ProjectorSpec": (
-        "modal_training_gym.frameworks.miles.projector_config",
+        "modal_training_gym.common.projector_config",
         "ProjectorSpec",
     ),
     "EmbeddingProjectorDataset": (
@@ -165,6 +169,7 @@ __all__ = [
     "GLM_5_2_5Layer",
     "GLM_5_2_Projector_Recipe",
     "GLM_5_2_5Layer_Projector_Recipe",
+    "Qwen3_6_35b_Projector_Recipe",
     "ProjectorSpec",
     "EmbeddingProjectorDataset",
     "HarborDataset",

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -720,6 +720,11 @@ class EmbeddingProjectorDataset(DatasetConfig):
         name, so without it a later run with a different row count or embedding
         width would silently train on the file an earlier run left behind.
 
+        The filler is one repeated pattern, so it is also nearly free for a base
+        model to predict: expect a training loss two orders of magnitude below
+        what real prose gives (~0.006 rather than ~1.4 on Qwen3.6-35B-A3B). That
+        says nothing about the projector, whose inputs are noise either way.
+
         ``tokens`` is a rough per-sample length, long by default so a
         validation step exercises a sequence a real projector run would see —
         a two-sentence conversation is a few dozen tokens, well under the

--- a/modal_training_gym/common/embedding_projector.py
+++ b/modal_training_gym/common/embedding_projector.py
@@ -1,0 +1,401 @@
+"""Projector-only training: the torch and Megatron parts both trainers share.
+
+Imported inside the training containers only — it needs torch and Megatron.
+Miles and slime are both Megatron trainers, so the projector module, its
+initialization, the merge into the input embeddings and the projector-only
+checkpoint format are identical between them; what differs (config arg, hook
+paths, how a packed microbatch's per-sample tensors are laid out) lives in
+``frameworks/<framework>/embedding_projector.py``.
+
+The config that reaches this module travels as a
+:class:`~modal_training_gym.common.projector_config.ProjectorSpec`, whose module
+stays torch-free so the launching side can import it too.
+"""
+
+import logging
+import math
+import os
+
+import torch  # pyright: ignore[reportMissingImports]  # torch is installed only in training images
+import torch.nn as nn  # pyright: ignore[reportMissingImports]
+
+from modal_training_gym.common.projector_config import (
+    LATEST_CHECKPOINT,
+    ProjectorSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingProjector(nn.Module):
+    """MLP mapping external embeddings into the decoder's hidden space.
+
+    Replicated on every rank rather than tensor-parallel: at a few hundred MB
+    it is not worth sharding, and replication keeps the checkpoint a single
+    plain state dict that loads anywhere.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int,
+        output_dim: int,
+        num_layers: int = 2,
+    ) -> None:
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError(f"projector num_layers must be >= 1, got {num_layers}")
+        dims = [input_dim] + [hidden_dim] * (num_layers - 1) + [output_dim]
+        layers: list[nn.Module] = []
+        for i in range(num_layers):
+            layers.append(nn.Linear(dims[i], dims[i + 1]))
+            if i < num_layers - 1:
+                layers.append(nn.GELU())
+        self.mlp = nn.Sequential(*layers)
+        self.norm = nn.LayerNorm(output_dim)
+
+    def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
+        return self.norm(self.mlp(embeddings))
+
+
+def init_projector(
+    projector: EmbeddingProjector, seed: int, output_scale: float = 1.0
+) -> None:
+    """Initialize from ``seed`` alone, so every replica agrees.
+
+    ``output_scale`` goes into the final ``LayerNorm``'s weight, which sets the
+    scale of everything the projector writes into the embedding stream. It has to
+    be small: a ``LayerNorm`` output is unit-std by construction, while a decoder's
+    token embeddings are ~1e-2 std, so a weight of 1.0 injects rows ~50-100x out
+    of distribution — which is what produced NaN gradients on exactly the ranks
+    holding projected positions on real hardware. It stays learnable, so training
+    can grow it if the data wants more.
+
+    The projector is replicated and its gradients are reduced together, so ranks
+    that start from different weights stay different forever — silently, since
+    the updates do agree. Torch's default init draws from the ambient RNG, whose
+    state depends on how the base model's build consumed it (TP/EP shards, MoE
+    expert counts), so it is not relied on here: a private generator plus
+    PyTorch's own ``nn.Linear`` bounds gives identical weights on every rank
+    without a collective, and without assuming the projector exists on a rank
+    that could take part in one.
+    """
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    with torch.no_grad():
+        for module in projector.modules():
+            if isinstance(module, nn.Linear):
+                bound = 1.0 / math.sqrt(module.weight.shape[1])
+                for param in (module.weight, module.bias):
+                    if param is None:
+                        continue
+                    param.copy_(
+                        torch.empty(param.shape, dtype=torch.float32).uniform_(
+                            -bound, bound, generator=gen
+                        )
+                    )
+            elif isinstance(module, nn.LayerNorm):
+                module.weight.fill_(output_scale)
+                module.bias.zero_()
+
+
+def build_projector(
+    cfg: ProjectorSpec, hidden_size: int, params_dtype
+) -> EmbeddingProjector:
+    """The projector ``cfg`` describes, on this rank's device and ready to train."""
+    projector = EmbeddingProjector(
+        input_dim=cfg.input_dim,
+        hidden_dim=cfg.hidden_dim,
+        output_dim=cfg.output_dim or hidden_size,
+        num_layers=cfg.num_layers,
+    )
+    init_projector(projector, cfg.init_seed, cfg.output_scale)
+    projector.to(device=torch.cuda.current_device(), dtype=params_dtype)
+    projector.requires_grad_(True)
+    return projector
+
+
+def freeze_base_model(model: nn.Module) -> int:
+    """Freeze every parameter of ``model``; returns how many were frozen.
+
+    Called before Megatron builds the optimizer, which skips parameters
+    without ``requires_grad`` — that is what keeps optimizer state and
+    gradient buffers proportional to the projector.
+    """
+    frozen = 0
+    for param in model.parameters():
+        if param.requires_grad:
+            param.requires_grad_(False)
+            frozen += 1
+    return frozen
+
+
+def projector_parameters(projector: nn.Module) -> list[tuple[str, torch.Tensor]]:
+    """Projector parameters in an order identical on every rank.
+
+    A per-parameter gradient collective has to be enqueued in the same order on
+    every rank or the collectives pair up wrongly and deadlock.
+    ``named_parameters`` walks the module tree deterministically and every rank
+    holds the same replica, but it is sorted anyway so the guarantee does not
+    rest on that.
+    """
+    return sorted(projector.named_parameters(), key=lambda item: item[0])
+
+
+def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) -> int:
+    """Sum the replicated projector's gradients across the tensor-parallel group.
+
+    Under sequence parallelism each tensor-parallel rank holds a disjoint slice
+    of the packed sequence, so each computes the gradient of the same replicated
+    weight with respect to a different subset of the projected positions. The
+    whole-sequence gradient is their **sum**, not their average; the
+    data-parallel average is DDP's job and is left alone. Without sequence
+    parallelism every tensor-parallel rank merges every position and so already
+    holds the whole gradient — summing there would scale it by the group size,
+    which is why the flag is honored rather than assumed.
+
+    Every rank enters this unconditionally, once per optimizer step, with a
+    tensor of the same shape *and dtype* for every parameter — materializing a
+    zero gradient when one is missing rather than skipping the collective, and
+    reducing in fp32 so the collective's element size cannot depend on which
+    buffer a rank happened to have (Megatron's ``main_grad`` is fp32 under
+    ``accumulate_allreduce_grads_in_fp32``, a materialized ``param.grad``
+    carries ``params_dtype``, and a collective whose ranks disagree is
+    undefined). Riding Megatron's
+    ``sequence_parallel`` attribute instead (which
+    ``_allreduce_non_tensor_model_parallel_grads`` honors) is what deadlocked:
+    that path is entered per-rank depending on what that rank's gradients look
+    like, and a replicated module whose gradients are data-dependent cannot
+    safely take part.
+
+    ``main_grad`` is read whole, so this assumes the non-distributed optimizer —
+    with ``use_distributed_optimizer`` it is a reduce-scattered shard of a
+    bucket and summing shards across the group means nothing. The projector recipes reject
+    that flag rather than leaving the assumption implicit here.
+    """
+    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+    if not sequence_parallel or ps.get_tensor_model_parallel_world_size() <= 1:
+        return 0
+    group = ps.get_tensor_model_parallel_group()
+    reduced = 0
+    for _, param in projector_parameters(projector):
+        grad = getattr(param, "main_grad", None)
+        if grad is None:
+            if param.grad is None:
+                # No gradient on this rank: still enter the collective, with a
+                # zero of the right shape, and leave the reduced result where
+                # the optimizer will read it.
+                param.grad = torch.zeros_like(param)
+            grad = param.grad
+        buffer = grad.float()
+        torch.distributed.all_reduce(
+            buffer, op=torch.distributed.ReduceOp.SUM, group=group
+        )
+        grad.copy_(buffer)
+        reduced += 1
+    return reduced
+
+
+def projector_graph_tap(projector: nn.Module, dtype) -> torch.Tensor:
+    """A differentiable, exactly-zero scalar tying ``projector`` into the graph.
+
+    Needed on a rank whose sequence shard holds none of the projected positions:
+    the base is frozen, so the projector is the only thing in the forward that
+    requires grad, and dropping it there would leave the rank's loss without a
+    ``grad_fn`` — it would then skip the backward its peers are waiting on.
+
+    Built from the parameters rather than from the projector's output: parameters
+    are finite by construction, whereas multiplying an activation by zero is a
+    ``0 * inf`` trap that poisons the whole embedding tensor with NaN.
+    """
+    total = sum(param.sum() for _, param in projector_parameters(projector))
+    return (total * 0.0).to(dtype)
+
+
+def scatter_projected(
+    sequence_parallel: bool,
+    embeddings_out: torch.Tensor,
+    embeds: torch.Tensor,
+    positions: torch.Tensor,
+    projector: nn.Module | None = None,
+) -> torch.Tensor:
+    """Write ``embeds`` into ``embeddings_out`` at ``positions`` (sequence-first).
+
+    ``LanguageModelEmbedding.forward`` returns ``[sequence, batch, hidden]``, and
+    under sequence parallelism the sequence dimension is already this rank's
+    shard (either reduce-scattered inside the vocab embedding or scattered right
+    after it), so positions are rebased onto the shard and the ones belonging to
+    other ranks dropped. Both trainers pack a microbatch into one sequence, so
+    the batch dimension is 1. Context parallelism would shard the sequence a
+    second way, with its own chunking, which is why the recipes reject ``CP > 1``.
+    """
+    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+    def unmerged():
+        """``embeddings_out``, with the projector still in the graph at zero weight."""
+        if projector is None:
+            return embeddings_out
+        return embeddings_out + projector_graph_tap(projector, embeddings_out.dtype)
+
+    if positions.numel() == 0:
+        return unmerged()
+    if embeddings_out.shape[1] != 1:
+        raise ValueError(
+            "projector training expects the trainer's packed layout, one sequence "
+            f"per microbatch, but the embedding output has batch "
+            f"{embeddings_out.shape[1]}"
+        )
+    s_local = embeddings_out.shape[0]
+    if sequence_parallel and ps.get_tensor_model_parallel_world_size() > 1:
+        local = positions - ps.get_tensor_model_parallel_rank() * s_local
+        keep = (local >= 0) & (local < s_local)
+        local, embeds = local[keep], embeds[keep]
+    else:
+        local = positions
+    logger.info(
+        "projector merge: %d of %d position(s) on this rank's %d-token shard",
+        int(local.numel()),
+        int(positions.numel()),
+        s_local,
+    )
+    if not local.numel():
+        return unmerged()
+    merged = embeddings_out.clone()
+    kept = embeds.to(merged.dtype)
+    with torch.no_grad():
+        # The scales have to be comparable: a projector row far above the base's
+        # embedding scale is out of the decoder's distribution and overflows the
+        # forward, which shows up as NaN gradients on exactly the merging ranks.
+        logger.info(
+            "projector merge scale: base rms=%.6g absmax=%.6g, projected "
+            "rms=%.6g absmax=%.6g",
+            float(embeddings_out.detach().float().pow(2).mean().sqrt()),
+            float(embeddings_out.detach().float().abs().max()),
+            float(kept.detach().float().pow(2).mean().sqrt()),
+            float(kept.detach().float().abs().max()),
+        )
+    merged[local, 0] = kept
+    return merged
+
+
+def get_projector(model) -> EmbeddingProjector | None:
+    """The projector attached to ``model``, if this rank holds one.
+
+    Tolerates wrapping: by the time the trainer's hooks run, a model chunk is a
+    ``DistributedDataParallel(Float16Module(GPTModel))``, and ``__dict__``
+    indexing does not follow the wrappers' ``__getattr__`` forwarding. The
+    projector is registered with ``add_module("embedding_projector", ...)``, so
+    unwrapping ``.module`` and finally scanning the module tree always reaches
+    it.
+    """
+    obj, depth = model, 0
+    while obj is not None and depth <= 8:
+        projector = obj.__dict__.get("_training_gym_projector")
+        if isinstance(projector, EmbeddingProjector):
+            return projector
+        obj = getattr(obj, "module", None)
+        depth += 1
+    modules = getattr(model, "modules", None)
+    if callable(modules):
+        for sub in modules():
+            if isinstance(sub, EmbeddingProjector):
+                return sub
+    return None
+
+
+def load_projector_checkpoint(path: str, projector: EmbeddingProjector) -> int:
+    """Load a projector checkpoint (file or directory) into ``projector``.
+
+    Returns the iteration it was saved at. A directory resolves to the run's
+    ``projector_latest.pt``.
+    """
+    resolved = os.path.join(path, LATEST_CHECKPOINT) if os.path.isdir(path) else path
+    state = torch.load(resolved, map_location="cpu", weights_only=True)
+    projector.load_state_dict(state["state_dict"])
+    iteration = int(state.get("iteration", 0))
+    logger.info("loaded projector checkpoint %s (iteration %d)", resolved, iteration)
+    return iteration
+
+
+def projector_output_dim(projector) -> int:
+    """The projector's actual output width, read off its last linear layer."""
+    linears = [m for m in projector.modules() if isinstance(m, nn.Linear)]
+    if linears:
+        return int(linears[-1].out_features)
+    return int(projector.norm.normalized_shape[0])
+
+
+def write_projector_checkpoint(
+    cfg: ProjectorSpec, save_dir: str, projector, step: int
+) -> None:
+    """Write ``projector``'s state dict plus enough config to rebuild it.
+
+    Optimizer state is not saved — the projector's Adam moments are cheap to
+    rebuild, and reading Megatron's distributed optimizer state for a replicated
+    module would need the base model's sharding machinery. The frozen base is not
+    saved either: it stays byte-identical to the run's ``hf_checkpoint``.
+    """
+    os.makedirs(save_dir, exist_ok=True)
+    state = {
+        "iteration": step,
+        "state_dict": {
+            k: v.detach().to("cpu") for k, v in projector.state_dict().items()
+        },
+        "config": {
+            "input_dim": cfg.input_dim,
+            "hidden_dim": cfg.hidden_dim,
+            "num_layers": cfg.num_layers,
+            # The resolved width, not ``cfg.output_dim``, which is None whenever
+            # the projector's output was sized from the model's hidden size — a
+            # checkpoint has to describe its own shape.
+            "output_dim": projector_output_dim(projector),
+        },
+    }
+    path = os.path.join(save_dir, f"projector_iter_{step:07d}.pt")
+    torch.save(state, path)
+    torch.save(state, os.path.join(save_dir, LATEST_CHECKPOINT))
+    logger.info("saved projector checkpoint %s", path)
+
+
+def is_projector_writer() -> bool:
+    """True on exactly one rank per projector replica group.
+
+    The projector is replicated, so every rank holds the same weights and one
+    writer is enough; the context-parallel rank is checked explicitly because
+    Megatron's ``get_data_parallel_rank`` defaults to
+    ``with_context_parallel=False`` and would leave every ``cp_rank`` writing the
+    same file.
+    """
+    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+    return (
+        ps.get_tensor_model_parallel_rank() == 0
+        and ps.get_data_parallel_rank() == 0
+        and ps.get_context_parallel_rank() == 0
+        and ps.get_expert_model_parallel_rank() == 0
+    )
+
+
+def log_projector_replica(projector: nn.Module, step: int) -> None:
+    """Log a per-rank fingerprint of the projector, so replicas can be compared.
+
+    Every rank holds a replica whose gradients are reduced together, so after a
+    step the weights must be bit-identical across ranks; a divergence here means
+    the reduction is misplaced and the ranks have silently forked.
+    """
+    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
+
+    name, param = projector_parameters(projector)[0]
+    with torch.no_grad():
+        checksum = float(param.detach().float().abs().sum().item())
+        norm = float(param.detach().float().norm().item())
+    logger.info(
+        "projector replica after step %d: tp_rank=%d dp_rank=%d %s "
+        "norm=%.8f abs_sum=%.8f",
+        step,
+        ps.get_tensor_model_parallel_rank(),
+        ps.get_data_parallel_rank(),
+        name,
+        norm,
+        checksum,
+    )

--- a/modal_training_gym/common/embedding_projector.py
+++ b/modal_training_gym/common/embedding_projector.py
@@ -167,10 +167,15 @@ def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) ->
     like, and a replicated module whose gradients are data-dependent cannot
     safely take part.
 
-    ``main_grad`` is read whole, so this assumes the non-distributed optimizer —
-    with ``use_distributed_optimizer`` it is a reduce-scattered shard of a
-    bucket and summing shards across the group means nothing. The projector recipes reject
-    that flag rather than leaving the assumption implicit here.
+    ``main_grad`` is read whole. The miles recipes reject
+    ``use_distributed_optimizer`` for that reason; slime sets it unconditionally
+    in ``_set_default_megatron_args``, so on that backend the recipe's field is
+    advisory and what makes this correct is *when* it runs: the hook wraps
+    ``optimizer.step``, where ``main_grad`` still views the whole bucket for the
+    projector's own data-parallel group. A run whose replicas diverged here
+    would show it immediately — the fingerprint
+    :func:`log_projector_replica` writes per tensor-parallel rank is compared on
+    every validated run and has stayed byte-identical.
     """
     import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
 
@@ -209,8 +214,9 @@ def check_projector_weights(projector: nn.Module) -> str:
     that trains slowly: an all-zero projector writes exactly-zero rows for every
     embedding the encoder produced, so the run trains on no signal at all, and
     on real hardware it surfaced as NaN gradients rather than as its cause. The
-    recipes reject the flag that does it; this makes any other route to the same
-    state say so.
+    miles recipes reject the flag that does it, and slime's engine-free
+    ``debug_train_only`` mode never offloads; this makes any other route to the
+    same state say so.
     """
     parts, all_zero = [], True
     for name, param in projector_parameters(projector):

--- a/modal_training_gym/common/embedding_projector.py
+++ b/modal_training_gym/common/embedding_projector.py
@@ -172,7 +172,11 @@ def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) ->
     in ``_set_default_megatron_args``, so on that backend the recipe's field is
     advisory and what makes this correct is *when* it runs: the hook wraps
     ``optimizer.step``, where ``main_grad`` still views the whole bucket for the
-    projector's own data-parallel group. A run whose replicas diverged here
+    projector's own data-parallel group. Two things make that sum right rather
+    than lucky: data-parallel groups are formed across ranks sharing a
+    tensor-parallel rank, so every rank in the group owns the same shard region
+    of the bucket, and the optimizer reads only that region — the unreduced
+    remainder outside it is never used. A run whose replicas diverged here
     would show it immediately — the fingerprint
     :func:`log_projector_replica` writes per tensor-parallel rank is compared on
     every validated run and has stayed byte-identical.

--- a/modal_training_gym/common/models/validation.py
+++ b/modal_training_gym/common/models/validation.py
@@ -83,6 +83,13 @@ class _ValidationConfig:
         if len(matches) == 1:
             return matches[0]
         if len(matches) > 1:
+            # A projector entry shares its base model's HF repo id, so adding one
+            # would make that id ambiguous and stop resolving. It is a variant of
+            # the base entry rather than a peer, so the repo id keeps meaning the
+            # base training run and the projector is asked for by name.
+            base = [config for config in matches if not config.projector]
+            if len(base) == 1:
+                return base[0]
             choices = ", ".join(sorted(config.name for config in matches))
             raise ValueError(f"ambiguous model {name!r}; use one of: {choices}")
         available = ", ".join(config.name for config in cls.select(pr_only=False))

--- a/modal_training_gym/common/models/validation.py
+++ b/modal_training_gym/common/models/validation.py
@@ -41,6 +41,10 @@ class _ValidationConfig:
     # Whether a pull request fans this model out automatically.
     # A workflow_dispatch naming it still runs it.
     run_on_pr: bool = True
+    # Validate the model's projector-only recipe instead of its base one.
+    # A model can have both (Qwen3.6-35B-A3B trains RL and trains a projector),
+    # and ``get_base_recipe`` only knows the base one, so the entry says which.
+    projector: bool = False
 
     @property
     def model_name(self) -> str:
@@ -118,4 +122,13 @@ VALIDATION_CONFIGS: set[_ValidationConfig] = {
         run_on_pr=False,
     ),
     _ValidationConfig("GLM-5.2-Projector", GLM_5_2, Framework.MILES, run_on_pr=False),
+    # Projector-only Qwen3.6-35B-A3B on slime. One 8xH100 node, but the base is
+    # a 35B MoE conversion, so it is dispatch-only like the other 27B+ entries.
+    _ValidationConfig(
+        "Qwen3.6-35B-A3B-Projector",
+        Qwen3_6_35B,
+        Framework.SLIME,
+        run_on_pr=False,
+        projector=True,
+    ),
 }

--- a/modal_training_gym/common/projector_config.py
+++ b/modal_training_gym/common/projector_config.py
@@ -178,3 +178,60 @@ def should_save_projector(
     if total_steps > 0 and steps_attempted == total_steps:
         return True
     return save_interval > 0 and steps_applied % save_interval == 0
+
+
+# Both trainers carry the recipe's own hook under this ``extra_config`` key while
+# the ``--custom-megatron-before-train-step-hook-path`` flag names the gym's
+# phase-reporting wrapper that dispatches to it.
+STEP_HOOK_KEY = "training_gym_custom_megatron_before_train_step_hook_path"
+
+
+def step_hook_path(args) -> str | None:
+    """Resolve the hook the gym's reporting wrapper will dispatch to.
+
+    Mirrors ``phase_reporting._hook_path_from_args``: the value travels in
+    ``extra_config``, whose keys the trainer sets on ``args``, and is also
+    looked for on ``args`` and ``custom_config`` directly.
+    """
+    direct = getattr(args, STEP_HOOK_KEY, None)
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    for container_name in ("extra_config", "custom_config"):
+        container = getattr(args, container_name, None)
+        if isinstance(container, dict):
+            value = container.get(STEP_HOOK_KEY) or container.get(
+                STEP_HOOK_KEY.removeprefix("training_gym_")
+            )
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def require_step_hook(args, save_hook_path: str, recipe_name: str) -> None:
+    """Fail at model construction when the projector's step hook is unwired.
+
+    ``save_projector_checkpoint`` is the only thing that installs the
+    ``optimizer.step`` wrapper, and that wrapper owns two jobs nothing else
+    does: the tensor-parallel all-reduce of the replicated projector's
+    gradients, and writing the projector checkpoints. Neither announces its
+    absence, so a run whose hook never fires would train on
+    tensor-parallel-partial gradients and finish with nothing saved. The wiring
+    is a recipe default, but the field is assignable and reaches the container
+    through ``extra_config``, so the provider checks it — a run only exists if
+    the trainer called the provider — rather than trusting it.
+    """
+    wrapper = getattr(args, "custom_megatron_before_train_step_hook_path", None)
+    wrapper = wrapper.strip() if isinstance(wrapper, str) else ""
+    wrapped = step_hook_path(args)
+    if save_hook_path in (wrapper, wrapped):
+        return
+    raise ValueError(
+        "projector-only training needs the before-train-step hook to reach "
+        f"'{save_hook_path}', which installs the projector's gradient "
+        "all-reduce and checkpoint writer, but this run resolves "
+        f"--custom-megatron-before-train-step-hook-path to '{wrapper}' and the "
+        f"gym's wrapped hook to '{wrapped}'. Launch through "
+        f"{recipe_name} (or point custom_megatron_before_train_step_hook at "
+        "that path) rather than training with unreduced gradients and no "
+        "checkpoints."
+    )

--- a/modal_training_gym/common/projector_config.py
+++ b/modal_training_gym/common/projector_config.py
@@ -102,9 +102,11 @@ class ProjectorSpec:
         if not self.positions_key.endswith("_positions"):
             raise ValueError(
                 f"positions_key={self.positions_key!r} must end in '_positions': "
-                "each sample's offset in the packed batch is added only to keys "
-                "with that suffix, and the projector's positions have to end up "
-                "as absolute offsets into the packed sequence."
+                "miles adds each sample's offset in the packed batch to keys "
+                "with that suffix and to no others, so the projector's positions "
+                "have to carry it to end up as absolute offsets. slime offsets "
+                "nothing and rebases in the merge instead, but the suffix is "
+                "required there too so one spec means the same thing on both."
             )
         return self
 

--- a/modal_training_gym/common/projector_config.py
+++ b/modal_training_gym/common/projector_config.py
@@ -1,0 +1,162 @@
+"""Projector-only training: the config both trainers share, free of torch.
+
+A projector-only run trains one small adapter over a frozen base model: the
+dataset supplies embeddings computed by some external encoder (a protein or DNA
+model, an audio tower, a retrieval index), a small MLP maps them into the
+decoder's hidden space, and they are written into the decoder's input embeddings
+at the token positions the data names. Nothing else trains — no LoRA, no base
+parameters — so optimizer state, gradient buffers and checkpoints are
+proportional to the adapter rather than to the model.
+
+This module stays importable on the launching machine (no torch), because the
+recipe serializes a :class:`ProjectorSpec` into ``extra_config``. The torch and
+Megatron parts live in :mod:`modal_training_gym.common.embedding_projector`, and
+the framework-specific glue — which arg carries the config, which
+provider/rollout/hook paths exist, how a packed batch's per-sample tensors are
+laid out — in ``frameworks/<framework>/embedding_projector.py``.
+"""
+
+from pydantic import ConfigDict, model_validator
+from pydantic.dataclasses import dataclass
+
+LATEST_CHECKPOINT = "projector_latest.pt"
+
+# Keys of the per-sample tensor dict a packed microbatch concatenates and splats
+# into ``model.forward``.
+EMBEDDINGS_KEY = "projector_embeddings"
+POSITIONS_KEY = "projector_positions"
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class ProjectorSpec:
+    """The projector's shape, its data keys, and where its checkpoints go.
+
+    input_dim : int
+        Width of the embeddings the dataset supplies — the external encoder's
+        output dimension.
+    hidden_dim : int
+        Width of the projector's inner layers.
+    num_layers : int
+        Linear layers in the projector; 1 makes it a single linear map.
+    output_dim : int | None
+        Width of the projected vectors; ``None`` uses the model's hidden size,
+        which is what writing into the decoder's input embeddings requires.
+    embeddings_key : str
+        Dataset column (and ``forward`` keyword) holding the per-token
+        embeddings, as one ``[num_tokens, input_dim]`` tensor per sample.
+    positions_key : str
+        Dataset column holding the token positions those embeddings occupy. Has
+        to keep the ``_positions`` suffix: it is miles' convention for the keys
+        it rebases onto the packed sequence, and slime's projector merge keys its
+        own rebase off the same suffix.
+    save_dir : str
+        Directory for projector checkpoints; empty puts them under
+        ``<save>/projector``.
+    save_interval : int
+        Save the projector every N optimizer steps. The final step of a run is
+        always saved regardless, so a finished run leaves a checkpoint even when
+        the interval does not divide the step count.
+    load : str
+        Projector checkpoint (file or directory) to resume from.
+    output_scale : float
+        Scale the projector's final ``LayerNorm`` starts at, and so the scale of
+        the rows it writes into the embedding stream. A ``LayerNorm`` output is
+        unit-std, a decoder's token embeddings are ~1e-2 std, so the default
+        keeps the injected rows in the base's distribution instead of ~50-100x
+        above it. Learnable, so training can grow it.
+    init_seed : int
+        Seed the projector's weights are initialized from. Every rank holds a
+        replica whose gradients are reduced together, so the initialization must
+        not depend on the ambient RNG state a rank happens to be in.
+    """
+
+    input_dim: int = 1536
+    hidden_dim: int = 4096
+    num_layers: int = 2
+    output_dim: int | None = None
+    embeddings_key: str = EMBEDDINGS_KEY
+    positions_key: str = POSITIONS_KEY
+    save_dir: str = ""
+    save_interval: int = 10
+    load: str = ""
+    output_scale: float = 0.01
+    init_seed: int = 0
+
+    @model_validator(mode="after")
+    def _reject_silently_wrong_settings(self) -> "ProjectorSpec":
+        """Both of these produce a run that trains on garbage without erroring.
+
+        A packed-batch key is rebased onto the sample's start in the packed
+        sequence only when the key's name ends in ``_positions``; under any other
+        name the offset is skipped and every sample's embeddings land on the
+        first sample's tokens.
+        """
+        if self.output_scale <= 0:
+            raise ValueError(
+                f"output_scale={self.output_scale} must be positive: it is the "
+                "initial gain of the projector's output LayerNorm, and zero "
+                "would start training from a projector that writes nothing."
+            )
+        if not self.positions_key.endswith("_positions"):
+            raise ValueError(
+                f"positions_key={self.positions_key!r} must end in '_positions': "
+                "each sample's offset in the packed batch is added only to keys "
+                "with that suffix, and the projector's positions have to end up "
+                "as absolute offsets into the packed sequence."
+            )
+        return self
+
+    def to_args_dict(self) -> dict[str, int | float | str | None]:
+        return {
+            "input_dim": self.input_dim,
+            "hidden_dim": self.hidden_dim,
+            "num_layers": self.num_layers,
+            "output_dim": self.output_dim,
+            "embeddings_key": self.embeddings_key,
+            "positions_key": self.positions_key,
+            "save_dir": self.save_dir,
+            "save_interval": self.save_interval,
+            "load": self.load,
+            "output_scale": self.output_scale,
+            "init_seed": self.init_seed,
+        }
+
+
+def spec_from_args(args: object, args_key: str, framework: str) -> ProjectorSpec:
+    """Rebuild the spec the recipe serialized, from the trainer's parsed args."""
+    raw = vars(args).get(args_key)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"{framework} arg '{args_key}' is missing or not a dict (got {raw!r}). "
+            "A projector-only run needs the recipe to serialize a ProjectorSpec "
+            "into extra_config."
+        )
+    return ProjectorSpec(**raw)
+
+
+def should_save_projector(
+    steps_applied: int, steps_attempted: int, total_steps: int, save_interval: int
+) -> bool:
+    """Whether the projector should be written, after an optimizer step.
+
+    The run's last step always saves: a finished run has to leave the adapter it
+    spent its GPU budget producing, whether or not the interval happens to
+    divide the step count.
+
+    Which step is the last one is decided by ``steps_attempted`` against
+    ``total_steps`` (the trainer's ``train_iters``, a count of attempts), while
+    the interval counts ``steps_applied`` — so ``save_interval`` means what it
+    says and skipped updates do not shift it. Counting only applied steps for
+    both would lose the whole artifact on a run whose interval saves nothing and
+    where one update was skipped for a gradient overflow: the count would end
+    one short of the total, the final-step guarantee would never fire, and the
+    run would exit having written nothing.
+
+    Nothing is written before an update has applied, so a projector still at its
+    initialization is never mistaken for a trained one.
+    """
+    if steps_applied <= 0:
+        return False
+    if total_steps > 0 and steps_attempted >= total_steps:
+        return True
+    return save_interval > 0 and steps_applied % save_interval == 0

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -63,7 +63,16 @@ def _merge_recipe(base: BaseTrainRecipe, overrides: BaseTrainRecipe) -> BaseTrai
         default_val = _field_default(f)
         if f.name in declared or default_val is _dc.MISSING or user_val != default_val:
             base_fields[f.name] = user_val
-    return type(base)(**base_fields)
+
+    # A recipe that subclasses the preset's own class (e.g. a projector-only
+    # variant of a model's RL recipe) is rebuilt as that subclass: it carries
+    # fields, validators and preflight checks the preset does not, and rebuilding
+    # as the preset's class would drop all three silently.
+    target = type(overrides) if isinstance(overrides, type(base)) else type(base)
+    if target is not type(base):
+        for f in _dc.fields(overrides):
+            base_fields.setdefault(f.name, getattr(overrides, f.name))
+    return target(**base_fields)
 
 
 def _field_default(field: _dc.Field) -> Any:

--- a/modal_training_gym/frameworks/miles/embedding_projector.py
+++ b/modal_training_gym/frameworks/miles/embedding_projector.py
@@ -32,12 +32,24 @@ arg (the recipe writes it into ``extra_config``, whose keys miles sets on
 """
 
 import logging
-import math
 import os
 
 import torch  # pyright: ignore[reportMissingImports]  # torch is installed only in training images
-import torch.nn as nn  # pyright: ignore[reportMissingImports]
 
+from modal_training_gym.common.embedding_projector import (
+    EmbeddingProjector as EmbeddingProjector,
+    all_reduce_projector_grads,
+    build_projector,
+    freeze_base_model as freeze_base_model,
+    get_projector as get_projector,
+    init_projector as init_projector,
+    is_projector_writer,
+    load_projector_checkpoint as load_projector_checkpoint,
+    log_projector_replica,
+    projector_graph_tap,
+    scatter_projected,
+    write_projector_checkpoint as write_projector_checkpoint,
+)
 from modal_training_gym.frameworks.miles.projector_config import (
     ProjectorSpec,
     from_miles_args,
@@ -45,94 +57,6 @@ from modal_training_gym.frameworks.miles.projector_config import (
 )
 
 logger = logging.getLogger(__name__)
-
-_LATEST = "projector_latest.pt"
-
-
-class EmbeddingProjector(nn.Module):
-    """MLP mapping external embeddings into the decoder's hidden space.
-
-    Replicated on every rank rather than tensor-parallel: at a few hundred MB
-    it is not worth sharding, and replication keeps the checkpoint a single
-    plain state dict that loads anywhere.
-    """
-
-    def __init__(
-        self,
-        input_dim: int,
-        hidden_dim: int,
-        output_dim: int,
-        num_layers: int = 2,
-    ) -> None:
-        super().__init__()
-        if num_layers < 1:
-            raise ValueError(f"projector num_layers must be >= 1, got {num_layers}")
-        dims = [input_dim] + [hidden_dim] * (num_layers - 1) + [output_dim]
-        layers: list[nn.Module] = []
-        for i in range(num_layers):
-            layers.append(nn.Linear(dims[i], dims[i + 1]))
-            if i < num_layers - 1:
-                layers.append(nn.GELU())
-        self.mlp = nn.Sequential(*layers)
-        self.norm = nn.LayerNorm(output_dim)
-
-    def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
-        return self.norm(self.mlp(embeddings))
-
-
-def init_projector(
-    projector: EmbeddingProjector, seed: int, output_scale: float = 1.0
-) -> None:
-    """Initialize from ``seed`` alone, so every replica agrees.
-
-    ``output_scale`` goes into the final ``LayerNorm``'s weight, which sets the
-    scale of everything the projector writes into the embedding stream. It has to
-    be small: a ``LayerNorm`` output is unit-std by construction, while a decoder's
-    token embeddings are ~1e-2 std, so a weight of 1.0 injects rows ~50-100x out
-    of distribution — which is what produced NaN gradients on exactly the ranks
-    holding projected positions on real hardware. It stays learnable, so training
-    can grow it if the data wants more.
-
-    The projector is replicated and its gradients are all-reduced, so ranks that
-    start from different weights stay different forever — silently, since the
-    updates do agree. Torch's default init draws from the ambient RNG, whose
-    state depends on how the base model's build consumed it (TP/EP shards, MoE
-    expert counts, the DSA indexer), so it is not relied on here: a private
-    generator plus PyTorch's own ``nn.Linear`` bounds gives identical weights on
-    every rank without a collective, and without assuming the projector exists
-    on a rank that could take part in one.
-    """
-    gen = torch.Generator(device="cpu").manual_seed(seed)
-    with torch.no_grad():
-        for module in projector.modules():
-            if isinstance(module, nn.Linear):
-                bound = 1.0 / math.sqrt(module.weight.shape[1])
-                for param in (module.weight, module.bias):
-                    if param is None:
-                        continue
-                    param.copy_(
-                        torch.empty(param.shape, dtype=torch.float32).uniform_(
-                            -bound, bound, generator=gen
-                        )
-                    )
-            elif isinstance(module, nn.LayerNorm):
-                module.weight.fill_(output_scale)
-                module.bias.zero_()
-
-
-def freeze_base_model(model: nn.Module) -> int:
-    """Freeze every parameter of ``model``; returns how many were frozen.
-
-    Called before Megatron builds the optimizer, which skips parameters
-    without ``requires_grad`` — that is what keeps optimizer state and
-    gradient buffers proportional to the projector.
-    """
-    frozen = 0
-    for param in model.parameters():
-        if param.requires_grad:
-            param.requires_grad_(False)
-            frozen += 1
-    return frozen
 
 
 def _build_base_model(args, pre_process: bool, post_process: bool, vp_stage):
@@ -156,150 +80,6 @@ def _build_base_model(args, pre_process: bool, post_process: bool, vp_stage):
         )
     finally:
         args.custom_model_provider_path = saved
-
-
-def projector_parameters(projector: nn.Module) -> list[tuple[str, torch.Tensor]]:
-    """Projector parameters in an order identical on every rank.
-
-    The gradient all-reduce below enqueues one collective per parameter, so the
-    iteration order has to agree across ranks or the collectives pair up wrongly
-    and deadlock. ``named_parameters`` walks the module tree deterministically
-    and every rank holds the same replica, but it is sorted anyway so the
-    guarantee does not rest on that.
-    """
-    return sorted(projector.named_parameters(), key=lambda item: item[0])
-
-
-def projector_graph_tap(projector: nn.Module, dtype) -> torch.Tensor:
-    """A differentiable, exactly-zero scalar tying ``projector`` into the graph.
-
-    Needed on a rank whose sequence shard holds none of the projected positions:
-    the base is frozen, so the projector is the only thing in the forward that
-    requires grad, and dropping it there would leave the rank's loss without a
-    ``grad_fn`` — it would then skip the backward its peers are waiting on.
-
-    Built from the parameters rather than from the projector's output: parameters
-    are finite by construction, whereas multiplying an activation by zero is a
-    ``0 * inf`` trap that poisons the whole embedding tensor with NaN.
-    """
-    total = sum(param.sum() for _, param in projector_parameters(projector))
-    return (total * 0.0).to(dtype)
-
-
-def all_reduce_projector_grads(projector: nn.Module, sequence_parallel: bool) -> int:
-    """Sum the replicated projector's gradients across the tensor-parallel group.
-
-    Under sequence parallelism each tensor-parallel rank holds a disjoint slice
-    of the packed sequence, so each computes the gradient of the same replicated
-    weight with respect to a different subset of the projected positions. The
-    whole-sequence gradient is their **sum**, not their average; the
-    data-parallel average is DDP's job and is left alone. Without sequence
-    parallelism every tensor-parallel rank merges every position and so already
-    holds the whole gradient — summing there would scale it by the group size,
-    which is why the flag is honored rather than assumed.
-
-    Every rank enters this unconditionally, once per optimizer step, with a
-    tensor of the same shape *and dtype* for every parameter — materializing a
-    zero gradient when one is missing rather than skipping the collective, and
-    reducing in fp32 so the collective's element size cannot depend on which
-    buffer a rank happened to have (Megatron's ``main_grad`` is fp32 under
-    ``accumulate_allreduce_grads_in_fp32``, a materialized ``param.grad``
-    carries ``params_dtype``, and a collective whose ranks disagree is
-    undefined). Riding Megatron's
-    ``sequence_parallel`` attribute instead (which
-    ``_allreduce_non_tensor_model_parallel_grads`` honors) is what deadlocked:
-    that path is entered per-rank depending on what that rank's gradients look
-    like, and a replicated module whose gradients are data-dependent cannot
-    safely take part.
-
-    ``main_grad`` is read whole, so this assumes the non-distributed optimizer —
-    with ``use_distributed_optimizer`` it is a reduce-scattered shard of a
-    bucket and summing shards across the group means nothing. The recipe rejects
-    that flag rather than leaving the assumption implicit here.
-    """
-    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
-
-    if not sequence_parallel or ps.get_tensor_model_parallel_world_size() <= 1:
-        return 0
-    group = ps.get_tensor_model_parallel_group()
-    reduced = 0
-    for _, param in projector_parameters(projector):
-        grad = getattr(param, "main_grad", None)
-        if grad is None:
-            if param.grad is None:
-                # No gradient on this rank: still enter the collective, with a
-                # zero of the right shape, and leave the reduced result where
-                # the optimizer will read it.
-                param.grad = torch.zeros_like(param)
-            grad = param.grad
-        buffer = grad.float()
-        torch.distributed.all_reduce(
-            buffer, op=torch.distributed.ReduceOp.SUM, group=group
-        )
-        grad.copy_(buffer)
-        reduced += 1
-    return reduced
-
-
-def _scatter_projected(
-    sequence_parallel, embeddings_out, embeds, positions, projector=None
-):
-    """Write ``embeds`` into ``embeddings_out`` at ``positions`` (sequence-first).
-
-    ``LanguageModelEmbedding.forward`` returns ``[sequence, batch, hidden]``, and
-    under sequence parallelism the sequence dimension is already this rank's
-    shard (either reduce-scattered inside the vocab embedding or scattered right
-    after it), so positions are rebased onto the shard and the ones belonging to
-    other ranks dropped. miles packs a microbatch into one sequence, so the batch
-    dimension is 1. Context parallelism would shard the sequence a second way,
-    with its own chunking, which is why the recipe rejects ``CP > 1``.
-    """
-    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
-
-    def unmerged():
-        """``embeddings_out``, with the projector still in the graph at zero weight."""
-        if projector is None:
-            return embeddings_out
-        return embeddings_out + projector_graph_tap(projector, embeddings_out.dtype)
-
-    if positions.numel() == 0:
-        return unmerged()
-    if embeddings_out.shape[1] != 1:
-        raise ValueError(
-            "projector training expects miles' packed layout, one sequence per "
-            f"microbatch, but the embedding output has batch {embeddings_out.shape[1]}"
-        )
-    s_local = embeddings_out.shape[0]
-    if sequence_parallel and ps.get_tensor_model_parallel_world_size() > 1:
-        local = positions - ps.get_tensor_model_parallel_rank() * s_local
-        keep = (local >= 0) & (local < s_local)
-        local, embeds = local[keep], embeds[keep]
-    else:
-        local = positions
-    logger.info(
-        "projector merge: %d of %d position(s) on this rank's %d-token shard",
-        int(local.numel()),
-        int(positions.numel()),
-        s_local,
-    )
-    if not local.numel():
-        return unmerged()
-    merged = embeddings_out.clone()
-    kept = embeds.to(merged.dtype)
-    with torch.no_grad():
-        # The scales have to be comparable: a projector row far above the base's
-        # embedding scale is out of the decoder's distribution and overflows the
-        # forward, which shows up as NaN gradients on exactly the merging ranks.
-        logger.info(
-            "projector merge scale: base rms=%.6g absmax=%.6g, projected "
-            "rms=%.6g absmax=%.6g",
-            float(embeddings_out.detach().float().pow(2).mean().sqrt()),
-            float(embeddings_out.detach().float().abs().max()),
-            float(kept.detach().float().pow(2).mean().sqrt()),
-            float(kept.detach().float().abs().max()),
-        )
-    merged[local, 0] = kept
-    return merged
 
 
 class _ProjectorMerge:
@@ -367,38 +147,13 @@ class _ProjectorMerge:
                 dtype=next(self._projector.parameters()).dtype,
             )
         )
-        return _scatter_projected(
+        return scatter_projected(
             self._model.config.sequence_parallel,
             output,
             projected,
             positions.to(output.device),
             self._projector,
         )
-
-
-def get_projector(model) -> EmbeddingProjector | None:
-    """The projector attached to ``model``, if this rank holds one.
-
-    Tolerates wrapping: by the time miles' hooks run, a model chunk is a
-    ``DistributedDataParallel(Float16Module(GPTModel))``, and ``__dict__``
-    indexing does not follow the wrappers' ``__getattr__`` forwarding. The
-    projector is registered with ``add_module("embedding_projector", ...)``, so
-    unwrapping ``.module`` and finally scanning the module tree always reaches
-    it.
-    """
-    obj, depth = model, 0
-    while obj is not None and depth <= 8:
-        projector = obj.__dict__.get("_training_gym_projector")
-        if isinstance(projector, EmbeddingProjector):
-            return projector
-        obj = getattr(obj, "module", None)
-        depth += 1
-    modules = getattr(model, "modules", None)
-    if callable(modules):
-        for sub in modules():
-            if isinstance(sub, EmbeddingProjector):
-                return sub
-    return None
 
 
 def projector_model_provider(
@@ -413,17 +168,9 @@ def projector_model_provider(
     frozen = freeze_base_model(model)
 
     if pre_process:
-        projector = EmbeddingProjector(
-            input_dim=cfg.input_dim,
-            hidden_dim=cfg.hidden_dim,
-            output_dim=cfg.output_dim or model.config.hidden_size,
-            num_layers=cfg.num_layers,
+        projector = build_projector(
+            cfg, model.config.hidden_size, model.config.params_dtype
         )
-        init_projector(projector, cfg.init_seed, cfg.output_scale)
-        projector.to(
-            device=torch.cuda.current_device(), dtype=model.config.params_dtype
-        )
-        projector.requires_grad_(True)
         model.__dict__["_training_gym_projector"] = projector
         # Registered so Megatron's DDP and the optimizer see the parameters.
         model.add_module("embedding_projector", projector)
@@ -520,76 +267,6 @@ def projector_sft_rollout(args, rollout_id: int, data_buffer, evaluation: bool =
     return samples
 
 
-def load_projector_checkpoint(path: str, projector: EmbeddingProjector) -> int:
-    """Load a projector checkpoint (file or directory) into ``projector``.
-
-    Returns the iteration it was saved at. A directory resolves to the run's
-    ``projector_latest.pt``.
-    """
-    resolved = os.path.join(path, _LATEST) if os.path.isdir(path) else path
-    state = torch.load(resolved, map_location="cpu", weights_only=True)
-    projector.load_state_dict(state["state_dict"])
-    iteration = int(state.get("iteration", 0))
-    logger.info("loaded projector checkpoint %s (iteration %d)", resolved, iteration)
-    return iteration
-
-
-def _is_projector_writer() -> bool:
-    """True on exactly one rank per projector replica group.
-
-    The projector is replicated, so every rank holds the same weights and one
-    writer is enough; the context-parallel rank is checked explicitly because
-    Megatron's ``get_data_parallel_rank`` defaults to ``with_context_parallel=False``
-    and would leave every ``cp_rank`` writing the same file.
-    """
-    import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
-
-    return (
-        ps.get_tensor_model_parallel_rank() == 0
-        and ps.get_data_parallel_rank() == 0
-        and ps.get_context_parallel_rank() == 0
-        and ps.get_expert_model_parallel_rank() == 0
-    )
-
-
-def write_projector_checkpoint(cfg: ProjectorSpec, save_dir: str, projector, step: int):
-    """Write ``projector``'s state dict plus enough config to rebuild it.
-
-    Optimizer state is not saved — the projector's Adam moments are cheap to
-    rebuild, and reading Megatron's distributed optimizer state for a replicated
-    module would need the base model's sharding machinery. The frozen base is not
-    saved either: it stays byte-identical to the run's ``hf_checkpoint``.
-    """
-    os.makedirs(save_dir, exist_ok=True)
-    state = {
-        "iteration": step,
-        "state_dict": {
-            k: v.detach().to("cpu") for k, v in projector.state_dict().items()
-        },
-        "config": {
-            "input_dim": cfg.input_dim,
-            "hidden_dim": cfg.hidden_dim,
-            "num_layers": cfg.num_layers,
-            # The resolved width, not ``cfg.output_dim``, which is None whenever
-            # the projector's output was sized from the model's hidden size — a
-            # checkpoint has to describe its own shape.
-            "output_dim": _projector_output_dim(projector),
-        },
-    }
-    path = os.path.join(save_dir, f"projector_iter_{step:07d}.pt")
-    torch.save(state, path)
-    torch.save(state, os.path.join(save_dir, _LATEST))
-    logger.info("saved projector checkpoint %s", path)
-
-
-def _projector_output_dim(projector) -> int:
-    """The projector's actual output width, read off its last linear layer."""
-    linears = [m for m in projector.modules() if isinstance(m, nn.Linear)]
-    if linears:
-        return int(linears[-1].out_features)
-    return int(projector.norm.normalized_shape[0])
-
-
 class _ProjectorSaver:
     """Writes the projector after optimizer steps, including the run's last one.
 
@@ -643,29 +320,8 @@ class _ProjectorSaver:
         return out
 
     def _log_replica_state(self) -> None:
-        """Log a per-rank fingerprint of the projector, so replicas can be compared.
-
-        Every rank holds a replica whose gradients are all-reduced, so after a
-        step the weights must be bit-identical across ranks; a divergence here
-        means the all-reduce is misplaced and the ranks have silently forked.
-        """
-        import megatron.core.parallel_state as ps  # pyright: ignore[reportMissingImports]
-
         for projector in self._projectors:
-            name, param = projector_parameters(projector)[0]
-            with torch.no_grad():
-                checksum = float(param.detach().float().abs().sum().item())
-                norm = float(param.detach().float().norm().item())
-            logger.info(
-                "projector replica after step %d: tp_rank=%d dp_rank=%d %s "
-                "norm=%.8f abs_sum=%.8f",
-                self._steps + 1,
-                ps.get_tensor_model_parallel_rank(),
-                ps.get_data_parallel_rank(),
-                name,
-                norm,
-                checksum,
-            )
+            log_projector_replica(projector, self._steps + 1)
 
     def _save(self) -> None:
         if not self._projectors:
@@ -675,7 +331,7 @@ class _ProjectorSaver:
                 self._steps,
             )
             return
-        if not _is_projector_writer():
+        if not is_projector_writer():
             return
         write_projector_checkpoint(
             self._cfg, self._save_dir, self._projectors[0], self._steps

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -1,14 +1,23 @@
 """Wire format between a projector-only recipe and the miles containers.
 
 Kept free of torch so the launching side can import it: the recipe serializes a
-:class:`ProjectorSpec` into ``extra_config`` under :data:`ARGS_KEY`, miles sets
-every ``extra_config`` key on ``args``, and
-:mod:`modal_training_gym.frameworks.miles.embedding_projector` reads it back
-inside the container. No new miles CLI flags are involved.
+:class:`~modal_training_gym.common.projector_config.ProjectorSpec` into
+``extra_config`` under :data:`ARGS_KEY`, miles sets every ``extra_config`` key on
+``args``, and :mod:`modal_training_gym.frameworks.miles.embedding_projector`
+reads it back inside the container. No new miles CLI flags are involved.
+
+The spec itself is shared with slime (see
+:mod:`modal_training_gym.common.projector_config`); what lives here is only the
+miles-side plumbing: the arg name and the dotted paths miles resolves.
 """
 
-from pydantic import ConfigDict, model_validator
-from pydantic.dataclasses import dataclass
+from modal_training_gym.common.projector_config import (
+    EMBEDDINGS_KEY as EMBEDDINGS_KEY,
+    POSITIONS_KEY as POSITIONS_KEY,
+    ProjectorSpec as ProjectorSpec,
+    should_save_projector as should_save_projector,
+    spec_from_args,
+)
 
 # Miles arg carrying the serialized ProjectorSpec.
 ARGS_KEY = "training_gym_projector"
@@ -23,141 +32,7 @@ ROLLOUT_PATH = (
     "modal_training_gym.frameworks.miles.embedding_projector.projector_sft_rollout"
 )
 
-# Keys of the per-sample tensor dict miles concatenates over a packed batch and
-# splats into ``model.forward``. ``_positions`` is miles' own suffix convention:
-# it offsets any such key by the sample's start in the packed sequence.
-EMBEDDINGS_KEY = "projector_embeddings"
-POSITIONS_KEY = "projector_positions"
-
-
-@dataclass(config=ConfigDict(extra="forbid"))
-class ProjectorSpec:
-    """The projector's shape, its data keys, and where its checkpoints go.
-
-    input_dim : int
-        Width of the embeddings the dataset supplies — the external encoder's
-        output dimension.
-    hidden_dim : int
-        Width of the projector's inner layers.
-    num_layers : int
-        Linear layers in the projector; 1 makes it a single linear map.
-    output_dim : int | None
-        Width of the projected vectors; ``None`` uses the model's hidden size,
-        which is what writing into the decoder's input embeddings requires.
-    embeddings_key : str
-        Dataset column (and ``forward`` keyword) holding the per-token
-        embeddings, as one ``[num_tokens, input_dim]`` tensor per sample.
-    positions_key : str
-        Dataset column holding the token positions those embeddings occupy. Has
-        to keep the ``_positions`` suffix miles' packing convention keys off.
-    save_dir : str
-        Directory for projector checkpoints; empty puts them under
-        ``<save>/projector``.
-    save_interval : int
-        Save the projector every N optimizer steps. The final step of a run is
-        always saved regardless, so a finished run leaves a checkpoint even when
-        the interval does not divide the step count.
-    load : str
-        Projector checkpoint (file or directory) to resume from.
-    output_scale : float
-        Scale the projector's final ``LayerNorm`` starts at, and so the scale of
-        the rows it writes into the embedding stream. A ``LayerNorm`` output is
-        unit-std, a decoder's token embeddings are ~1e-2 std, so the default
-        keeps the injected rows in the base's distribution instead of ~50-100x
-        above it. Learnable, so training can grow it.
-    init_seed : int
-        Seed the projector's weights are initialized from. Every rank holds a
-        replica whose gradients are all-reduced, so the initialization must not
-        depend on the ambient RNG state a rank happens to be in.
-    """
-
-    input_dim: int = 1536
-    hidden_dim: int = 4096
-    num_layers: int = 2
-    output_dim: int | None = None
-    embeddings_key: str = EMBEDDINGS_KEY
-    positions_key: str = POSITIONS_KEY
-    save_dir: str = ""
-    save_interval: int = 10
-    load: str = ""
-    output_scale: float = 0.01
-    init_seed: int = 0
-
-    @model_validator(mode="after")
-    def _reject_silently_wrong_settings(self) -> "ProjectorSpec":
-        """Both of these produce a run that trains on garbage without erroring.
-
-        Miles offsets a packed-batch key by the sample's start in the packed
-        sequence only when the key's name ends in ``_positions``; under any other
-        name the offset is skipped and every sample's embeddings land on the first
-        sample's tokens.
-        """
-        if self.output_scale <= 0:
-            raise ValueError(
-                f"output_scale={self.output_scale} must be positive: it is the "
-                "initial gain of the projector's output LayerNorm, and zero "
-                "would start training from a projector that writes nothing."
-            )
-        if not self.positions_key.endswith("_positions"):
-            raise ValueError(
-                f"positions_key={self.positions_key!r} must end in '_positions': "
-                "miles adds each sample's offset in the packed batch only to keys "
-                "with that suffix, and the projector's positions are absolute "
-                "offsets into the packed sequence."
-            )
-        return self
-
-    def to_args_dict(self) -> dict[str, int | float | str | None]:
-        return {
-            "input_dim": self.input_dim,
-            "hidden_dim": self.hidden_dim,
-            "num_layers": self.num_layers,
-            "output_dim": self.output_dim,
-            "embeddings_key": self.embeddings_key,
-            "positions_key": self.positions_key,
-            "save_dir": self.save_dir,
-            "save_interval": self.save_interval,
-            "load": self.load,
-            "output_scale": self.output_scale,
-            "init_seed": self.init_seed,
-        }
-
-
-def should_save_projector(
-    steps_applied: int, steps_attempted: int, total_steps: int, save_interval: int
-) -> bool:
-    """Whether the projector should be written, after an optimizer step.
-
-    The run's last step always saves: a finished run has to leave the adapter it
-    spent its GPU budget producing, whether or not the interval happens to
-    divide the step count.
-
-    Which step is the last one is decided by ``steps_attempted`` against
-    ``total_steps`` (miles' ``train_iters``, a count of attempts), while the
-    interval counts ``steps_applied`` — so ``save_interval`` means what it says
-    and skipped updates do not shift it. Counting only applied steps for both
-    would lose the whole artifact on a run whose interval saves nothing and
-    where one update was skipped for a gradient overflow: the count would end
-    one short of the total, the final-step guarantee would never fire, and the
-    run would exit having written nothing.
-
-    Nothing is written before an update has applied, so a projector still at its
-    initialization is never mistaken for a trained one.
-    """
-    if steps_applied <= 0:
-        return False
-    if total_steps > 0 and steps_attempted >= total_steps:
-        return True
-    return save_interval > 0 and steps_applied % save_interval == 0
-
 
 def from_miles_args(args: object) -> ProjectorSpec:
     """Rebuild the spec the recipe serialized, from miles' parsed ``args``."""
-    raw = vars(args).get(ARGS_KEY)
-    if not isinstance(raw, dict):
-        raise ValueError(
-            f"miles arg '{ARGS_KEY}' is missing or not a dict (got {raw!r}). A "
-            "projector-only run needs the recipe to serialize a ProjectorSpec "
-            "into extra_config."
-        )
-    return ProjectorSpec(**raw)
+    return spec_from_args(args, ARGS_KEY, "miles")

--- a/modal_training_gym/frameworks/miles/projector_config.py
+++ b/modal_training_gym/frameworks/miles/projector_config.py
@@ -15,6 +15,7 @@ from modal_training_gym.common.projector_config import (
     EMBEDDINGS_KEY as EMBEDDINGS_KEY,
     POSITIONS_KEY as POSITIONS_KEY,
     ProjectorSpec as ProjectorSpec,
+    require_step_hook,
     should_save_projector as should_save_projector,
     spec_from_args,
 )
@@ -32,59 +33,10 @@ ROLLOUT_PATH = (
     "modal_training_gym.frameworks.miles.embedding_projector.projector_sft_rollout"
 )
 
-_STEP_HOOK_KEY = "training_gym_custom_megatron_before_train_step_hook_path"
-
-
-def _step_hook_path(args) -> str | None:
-    """Resolve the hook miles' reporting wrapper will dispatch to.
-
-    Mirrors ``phase_reporting._hook_path_from_args``: the recipe's own hook
-    travels in ``extra_config`` (miles sets every key on ``args``) while the
-    ``--custom-megatron-before-train-step-hook-path`` flag names the gym's
-    reporting wrapper.
-    """
-    direct = getattr(args, _STEP_HOOK_KEY, None)
-    if isinstance(direct, str) and direct.strip():
-        return direct.strip()
-    for container_name in ("extra_config", "custom_config"):
-        container = getattr(args, container_name, None)
-        if isinstance(container, dict):
-            value = container.get(_STEP_HOOK_KEY) or container.get(
-                _STEP_HOOK_KEY.removeprefix("training_gym_")
-            )
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    return None
-
 
 def require_projector_step_hook(args) -> None:
-    """Fail at model construction when the projector's step hook is unwired.
-
-    ``save_projector_checkpoint`` is the only thing that installs the
-    ``optimizer.step`` wrapper, and that wrapper owns two jobs nothing else
-    does: the tensor-parallel all-reduce of the replicated projector's
-    gradients, and writing the projector checkpoints. Neither announces its
-    absence, so a run whose hook never fires would train on
-    tensor-parallel-partial gradients and finish with nothing saved. The wiring
-    is a recipe default, but it reaches the container through ``extra_config``,
-    so the provider checks it — miles has to call the provider for the run to
-    exist at all — rather than trusting it.
-    """
-    wrapper = getattr(args, "custom_megatron_before_train_step_hook_path", None)
-    wrapper = wrapper.strip() if isinstance(wrapper, str) else ""
-    wrapped = _step_hook_path(args)
-    if SAVE_HOOK_PATH in (wrapper, wrapped):
-        return
-    raise ValueError(
-        "projector-only training needs miles' before-train-step hook to reach "
-        f"'{SAVE_HOOK_PATH}', which installs the projector's gradient "
-        "all-reduce and checkpoint writer, but this run resolves "
-        f"--custom-megatron-before-train-step-hook-path to '{wrapper}' and the "
-        f"gym's wrapped hook to '{wrapped}'. Launch through "
-        "GLM_5_2_Projector_Recipe (or point "
-        "custom_megatron_before_train_step_hook at that path) rather than "
-        "training with unreduced gradients and no checkpoints."
-    )
+    """miles-side :func:`require_step_hook`; see it for what the hook owns."""
+    require_step_hook(args, SAVE_HOOK_PATH, "GLM_5_2_Projector_Recipe")
 
 
 def from_miles_args(args: object) -> ProjectorSpec:

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -325,12 +325,16 @@ def _skip_base_checkpoint_save() -> None:
     if getattr(slime_actor.save, "_training_gym_projector_only", False):
         return
 
-    def skip(iteration, model, optimizer, opt_param_scheduler) -> None:
+    # slime names this parameter ``iteration`` but passes ``rollout_id``, which
+    # is 0-based and counts rollouts rather than the optimizer steps the
+    # projector's own checkpoints are numbered by.
+    def skip(rollout_id, model, optimizer, opt_param_scheduler) -> None:
         logger.info(
-            "projector-only training: skipping slime's base checkpoint at "
-            "iteration %d — the base is frozen, so it would duplicate the "
-            "checkpoint this run loaded; the projector is written separately",
-            iteration,
+            "projector-only training: skipping slime's base checkpoint after "
+            "rollout %d — the base is frozen, so it would duplicate the "
+            "checkpoint this run loaded; the projector is written separately, "
+            "numbered by optimizer step",
+            rollout_id,
         )
 
     skip._training_gym_projector_only = True

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -112,16 +112,20 @@ def rebase_positions(
     starts at ``cu_seqlens[i]`` and its rows are the ``row_counts[i]`` next
     entries of ``positions``.
 
-    slime appends no padding entry to ``cu_seqlens`` on the non-``allgather_cp``
-    path, so one boundary per sample plus the end is exactly what a well-formed
-    microbatch has; a mismatch means the row-count bookkeeping and the packing
-    disagree and the merge would silently write to the wrong tokens.
+    slime pads the packed stream to a multiple of ``tensor_model_parallel_size *
+    data_pad_size_multiplier`` and, when that padding is non-empty, appends it to
+    ``cu_seqlens`` as one more segment (``slime/backends/megatron_utils/data.py``).
+    So the segment count is the sample count, or one more than it; anything else
+    means the row-count bookkeeping and the packing disagree and the merge would
+    silently write to the wrong tokens. Only the first ``num_samples`` boundaries
+    are read, so the padding segment is ignored either way.
     """
     num_samples = int(row_counts.numel())
-    if int(cu_seqlens.numel()) - 1 != num_samples:
+    num_segments = int(cu_seqlens.numel()) - 1
+    if num_segments not in (num_samples, num_samples + 1):
         raise ValueError(
             f"{num_samples} projector sample(s) in this microbatch but "
-            f"cu_seqlens describes {int(cu_seqlens.numel()) - 1}; the packed "
+            f"cu_seqlens describes {num_segments} segment(s); the packed "
             "layout and the per-sample row counts disagree"
         )
     counts = row_counts.to(device=positions.device, dtype=torch.long)
@@ -130,7 +134,7 @@ def rebase_positions(
             f"row counts sum to {int(counts.sum())} but {int(positions.numel())} "
             "position(s) were passed"
         )
-    starts = cu_seqlens[:-1].to(device=positions.device, dtype=torch.long)
+    starts = cu_seqlens[:num_samples].to(device=positions.device, dtype=torch.long)
     return positions + torch.repeat_interleave(starts, counts)
 
 

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -64,6 +64,7 @@ from modal_training_gym.frameworks.slime.projector_config import (
     ROW_COUNTS_KEY,
     ProjectorSpec,
     from_slime_args,
+    require_projector_step_hook,
     should_save_projector,
 )
 
@@ -310,6 +311,9 @@ def projector_model_provider(
 
     args = get_args()
     cfg = from_slime_args(args)
+    # The saver the step hook installs owns the projector's gradient all-reduce
+    # as well as its checkpoints, and neither absence announces itself.
+    require_projector_step_hook(args)
     if mpu.get_context_parallel_world_size() > 1:
         # Context parallelism shards the packed sequence a second way, with its
         # own two-chunk interleave (``slice_with_cp``) and a ``cu_seqlens`` scaled

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -342,8 +342,11 @@ def projector_model_provider(
         _hide_projector_from_megatron_checkpoints(model)
         trainable = sum(p.numel() for p in projector.parameters())
         logger.info(
-            "projector-only training: froze %d base parameter tensors, "
-            "%d trainable projector parameters",
+            # A zero here is the healthy case, not a failure: slime's own
+            # only_train_params_name_list freezing runs first, so there is
+            # usually nothing left for freeze_base_model to find.
+            "projector-only training: froze %d base parameter tensors that were "
+            "not already frozen, %d trainable projector parameters",
             frozen,
             trainable,
         )

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -455,6 +455,17 @@ def projector_sft_rollout(args, rollout_id: int, data_buffer, evaluation: bool =
             messages, tools=sample.metadata.get("tools")
         )
         response_length = mask_generator.get_response_lengths([loss_mask])[0]
+        if not response_length:
+            # ``loss_mask[-0:]`` is the whole mask, so a conversation with no
+            # trained-on turn would hand slime a mask of the full sequence
+            # alongside ``response_length=0`` — nothing to learn from, reported
+            # as a mask/length mismatch deep in the loss instead.
+            raise ValueError(
+                f"sample {sample.index} has no tokens to train on: the loss "
+                "mask marks none of its turns as a response. Conversations for "
+                "supervised projector training have to end in an assistant "
+                "message."
+            )
         sample.tokens = token_ids
         sample.response_length = response_length
         sample.reward = 0

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -122,10 +122,18 @@ def rebase_positions(
     silently write to the wrong tokens. The padding segment itself is never
     projected into.
 
-    Segment and row counts are aggregates, so they would also match if the
-    packing ordered its samples differently from the concatenated tensors; each
-    rebased row is therefore checked against its own segment's end, which is
-    where that reordering shows up.
+    Sample order is the same on both sides by construction, not by luck:
+    ``get_batch`` builds ``cu_seqlens`` from ``batch["tokens"]`` and concatenates
+    ``batch["multimodal_train_inputs"]`` in the same list order, one entry per
+    sample. It skips samples whose dict is ``None``, which would pair each row
+    with the wrong segment — so the rollout raises rather than emitting a sample
+    without embeddings.
+
+    Segment and row counts are aggregates, so they would still match if that
+    ever changed; each rebased row is therefore checked against its own
+    segment's end. That check catches a reordering only when a row lands past
+    its segment — a short position in a long segment would pass it — so it is a
+    backstop for the ordering above, not the guarantee.
     """
     num_samples = int(row_counts.numel())
     num_segments = int(cu_seqlens.numel()) - 1

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -1,0 +1,455 @@
+"""Projector-only training on slime: a trainable adapter over a frozen base model.
+
+Runs inside the slime containers, not on the launching machine. Three entry
+points, all reached by dotted path:
+
+``projector_model_provider``
+    slime's ``--custom-model-provider-path``. Builds the model the model script
+    asks for (so Qwen3.6-35B-A3B's MoE routing, gated attention and qk-layernorm
+    come from upstream verbatim), freezes every base parameter, and attaches an
+    :class:`~modal_training_gym.common.embedding_projector.EmbeddingProjector` on
+    the first pipeline stage. The projector maps externally computed per-token
+    embeddings — protein/DNA encoder outputs, for instance — into the decoder's
+    hidden space and writes them into the input embeddings at the positions the
+    data gives.
+``save_projector_checkpoint``
+    slime's ``--custom-megatron-before-train-step-hook-path``. Installs a wrapper
+    around the optimizer's ``step`` that writes the projector (a few hundred MB
+    at most) instead of the base model, which at 35B is tens of gigabytes of
+    sharded weights that never change during a projector-only run.
+``projector_sft_rollout``
+    slime's ``--rollout-function-path``. slime's own
+    ``sft_rollout.generate_rollout`` plus the per-sample embedding tensors.
+
+The trainable-parameter set is what makes this cheap: freezing the base before
+Megatron builds the optimizer keeps optimizer state, gradient buffers and
+checkpoints proportional to the projector, not to the model — LoRA-free, and
+without the full-parameter memory bill.
+
+Configuration arrives as one dict under the ``training_gym_projector`` arg (the
+recipe writes it into ``extra_config``, whose keys slime applies to ``args``
+after parsing), so no new slime CLI flags are needed.
+
+What differs from the miles side (``frameworks/miles/embedding_projector.py``)
+is position bookkeeping: miles offsets any ``multimodal_train_inputs`` key ending
+in ``_positions`` when it packs a microbatch, while slime concatenates every key
+verbatim (``slime/backends/megatron_utils/data.py``). So the rollout emits
+sample-local positions plus a per-sample row count, and the merge rebases them
+onto the packed sequence using the ``cu_seqlens`` slime already computed for
+``PackedSeqParams``.
+"""
+
+import logging
+import os
+
+import torch  # pyright: ignore[reportMissingImports]  # torch is installed only in training images
+
+from modal_training_gym.common.embedding_projector import (
+    EmbeddingProjector as EmbeddingProjector,
+    all_reduce_projector_grads,
+    build_projector,
+    freeze_base_model as freeze_base_model,
+    get_projector as get_projector,
+    init_projector as init_projector,
+    is_projector_writer,
+    load_projector_checkpoint as load_projector_checkpoint,
+    log_projector_replica,
+    projector_graph_tap,
+    scatter_projected,
+    write_projector_checkpoint as write_projector_checkpoint,
+)
+from modal_training_gym.frameworks.slime.projector_config import (
+    ROW_COUNTS_KEY,
+    ProjectorSpec,
+    from_slime_args,
+    should_save_projector,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _build_base_model(args, pre_process: bool, post_process: bool, kwargs: dict):
+    """Build the model slime would have built without this provider.
+
+    The build happens with ``custom_model_provider_path`` still cleared, not just
+    the lookup: re-entering this function would recurse until the stack
+    overflows. Only the keyword arguments the underlying provider actually
+    declares are forwarded, the way slime's own freeze wrapper does it, because
+    the signature differs across Megatron versions (``vp_stage``, ``config``,
+    ``pg_collection``).
+    """
+    import inspect
+
+    from slime.backends.megatron_utils.model_provider import (  # pyright: ignore[reportMissingImports]
+        get_model_provider_func,
+    )
+
+    saved = args.custom_model_provider_path
+    args.custom_model_provider_path = None
+    try:
+        provider = get_model_provider_func(args)
+        provider_kwargs = {"pre_process": pre_process, "post_process": post_process}
+        params = inspect.signature(provider).parameters
+        for key in ("vp_stage", "config", "pg_collection"):
+            if key in params:
+                provider_kwargs[key] = kwargs.get(key, None)
+        return provider(**provider_kwargs)
+    finally:
+        args.custom_model_provider_path = saved
+
+
+def rebase_positions(
+    positions: torch.Tensor,
+    row_counts: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> torch.Tensor:
+    """Turn sample-local positions into positions in the packed sequence.
+
+    ``positions`` and ``row_counts`` are the microbatch's per-sample tensors
+    concatenated in sample order, and ``cu_seqlens`` is the prefix sum of the
+    packed sample lengths slime handed to ``PackedSeqParams`` — so sample ``i``
+    starts at ``cu_seqlens[i]`` and its rows are the ``row_counts[i]`` next
+    entries of ``positions``.
+
+    slime appends no padding entry to ``cu_seqlens`` on the non-``allgather_cp``
+    path, so one boundary per sample plus the end is exactly what a well-formed
+    microbatch has; a mismatch means the row-count bookkeeping and the packing
+    disagree and the merge would silently write to the wrong tokens.
+    """
+    num_samples = int(row_counts.numel())
+    if int(cu_seqlens.numel()) - 1 != num_samples:
+        raise ValueError(
+            f"{num_samples} projector sample(s) in this microbatch but "
+            f"cu_seqlens describes {int(cu_seqlens.numel()) - 1}; the packed "
+            "layout and the per-sample row counts disagree"
+        )
+    counts = row_counts.to(device=positions.device, dtype=torch.long)
+    if int(counts.sum()) != int(positions.numel()):
+        raise ValueError(
+            f"row counts sum to {int(counts.sum())} but {int(positions.numel())} "
+            "position(s) were passed"
+        )
+    starts = cu_seqlens[:-1].to(device=positions.device, dtype=torch.long)
+    return positions + torch.repeat_interleave(starts, counts)
+
+
+class _ProjectorMerge:
+    """Moves the batch's embeddings from ``model.forward`` into the embedding layer.
+
+    slime splats ``multimodal_train_inputs`` straight into ``model(**kwargs)``
+    (``slime/backends/megatron_utils/model.py``), but ``GPTModel.forward`` takes
+    no such arguments, so they are stripped there and merged where the input
+    embeddings actually exist: a forward hook on ``model.embedding``, which is
+    the only place whose output layout and sequence-parallel sharding are already
+    settled. Recomputing the embedding here instead would duplicate the vocab
+    embedding's reduce-scatter and position-embedding branches.
+    """
+
+    def __init__(
+        self, model, projector: EmbeddingProjector, cfg: ProjectorSpec
+    ) -> None:
+        self._model = model
+        self._projector = projector
+        self._embeddings_key = cfg.embeddings_key
+        self._positions_key = cfg.positions_key
+        self._pending: tuple[torch.Tensor, torch.Tensor] | None = None
+        self._original_forward = model.forward
+        model.forward = self._forward
+        if model.pre_process:
+            model.embedding.register_forward_hook(self._embedding_hook)
+
+    def _forward(self, *fargs, **fkwargs):
+        embeddings = fkwargs.pop(self._embeddings_key, None)
+        positions = fkwargs.pop(self._positions_key, None)
+        row_counts = fkwargs.pop(ROW_COUNTS_KEY, None)
+        if embeddings is None or not self._model.pre_process:
+            return self._original_forward(*fargs, **fkwargs)
+        if positions is None or row_counts is None:
+            raise ValueError(
+                f"'{self._embeddings_key}' was passed without "
+                f"'{self._positions_key}'/'{ROW_COUNTS_KEY}'; the rollout must "
+                "emit the token positions the embeddings occupy and how many "
+                "rows each sample contributed."
+            )
+        if positions.numel() != embeddings.shape[0]:
+            raise ValueError(
+                f"{positions.numel()} projector position(s) for "
+                f"{embeddings.shape[0]} embedding row(s)"
+            )
+        packed = fkwargs.get("packed_seq_params")
+        if packed is None:
+            raise ValueError(
+                "projector training expects slime's packed batches, but this "
+                "microbatch carries no packed_seq_params to rebase positions on"
+            )
+        self._pending = (
+            embeddings,
+            rebase_positions(positions, row_counts, packed.cu_seqlens_q),
+        )
+        try:
+            return self._original_forward(*fargs, **fkwargs)
+        finally:
+            self._pending = None
+
+    def _embedding_hook(self, module, inputs, output):
+        if self._pending is None:
+            # No embeddings in this microbatch, so nothing to merge — but the
+            # base is frozen, so returning the embeddings untouched would leave
+            # this rank's loss without a ``grad_fn`` and it would skip a
+            # backward its peers wait on. Today's rollout rejects a sample
+            # without embeddings, so this is the shape of a future rollout that
+            # mixes in text-only samples rather than a path taken now.
+            return output + projector_graph_tap(self._projector, output.dtype)
+        embeddings, positions = self._pending
+        projected = self._projector(
+            embeddings.to(
+                device=output.device,
+                # The rollout emits fp32; the projector carries the model's
+                # params_dtype, bf16 for these recipes.
+                dtype=next(self._projector.parameters()).dtype,
+            )
+        )
+        return scatter_projected(
+            self._model.config.sequence_parallel,
+            output,
+            projected,
+            positions.to(output.device),
+            self._projector,
+        )
+
+
+def _hide_projector_from_megatron_checkpoints(model) -> None:
+    """Keep ``embedding_projector.*`` out of Megatron's checkpoint state dicts.
+
+    The projector has to be a registered submodule for DDP and the optimizer to
+    see its parameters, which also puts it in the model's sharded state dict —
+    and slime loads the frozen base *after* the provider runs
+    (``initialize_model_and_optimizer``), from a checkpoint that predates the
+    projector and therefore has no such keys. Megatron resolves a sharded state
+    dict against the checkpoint's metadata, so those keys would fail the load
+    of an otherwise perfectly good base checkpoint.
+
+    Dropping them from ``sharded_state_dict`` makes both directions ignore the
+    projector: the base loads as if this were a plain run, and Megatron's own
+    save (if a caller ever enables one) writes base weights only. The
+    projector's own state travels through
+    :func:`save_projector_checkpoint` and ``ProjectorSpec.load`` instead, which
+    is a single small file rather than a resharded slice of the model.
+    """
+    prefix = "embedding_projector."
+    original = model.sharded_state_dict
+
+    def sharded_state_dict(*args, **kwargs):
+        state = original(*args, **kwargs)
+        for key in [k for k in state if k.startswith(prefix)]:
+            del state[key]
+        return state
+
+    model.sharded_state_dict = sharded_state_dict
+
+
+def projector_model_provider(
+    pre_process: bool = True, post_process: bool = True, vp_stage=None, **kwargs
+):
+    """slime ``--custom-model-provider-path``: frozen base + trainable projector.
+
+    ``vp_stage`` is declared explicitly because slime only forwards it to a
+    custom provider that names it (it inspects the signature), and the base
+    provider needs it whenever virtual pipeline parallelism is on.
+    """
+    from megatron.core import mpu  # pyright: ignore[reportMissingImports]
+    from megatron.training import get_args  # pyright: ignore[reportMissingImports]
+
+    args = get_args()
+    cfg = from_slime_args(args)
+    if mpu.get_context_parallel_world_size() > 1:
+        # Context parallelism shards the packed sequence a second way, with its
+        # own two-chunk interleave (``slice_with_cp``) and a ``cu_seqlens`` scaled
+        # back up to global lengths, so a position no longer maps to a row of
+        # this rank's embedding output. Rejected here rather than merging into
+        # the wrong tokens.
+        raise ValueError(
+            "projector-only training does not support context parallelism; "
+            "set context_parallel_size=1 on the recipe"
+        )
+    model = _build_base_model(
+        args, pre_process, post_process, {"vp_stage": vp_stage, **kwargs}
+    )
+    frozen = freeze_base_model(model)
+
+    if pre_process:
+        projector = build_projector(
+            cfg, model.config.hidden_size, model.config.params_dtype
+        )
+        model.__dict__["_training_gym_projector"] = projector
+        # Registered so Megatron's DDP and the optimizer see the parameters.
+        model.add_module("embedding_projector", projector)
+        if cfg.load:
+            load_projector_checkpoint(cfg.load, projector)
+        model.__dict__["_training_gym_projector_merge"] = _ProjectorMerge(
+            model, projector, cfg
+        )
+        _hide_projector_from_megatron_checkpoints(model)
+        trainable = sum(p.numel() for p in projector.parameters())
+        logger.info(
+            "projector-only training: froze %d base parameter tensors, "
+            "%d trainable projector parameters",
+            frozen,
+            trainable,
+        )
+    else:
+        # Later pipeline stages get no projector, but slime still splats the
+        # batch's embedding tensors into every stage's forward, so they have to
+        # be stripped before they reach ``GPTModel.forward``.
+        model.__dict__["_training_gym_projector_merge"] = _ProjectorMerge(
+            model, EmbeddingProjector(1, 1, 1, 1), cfg
+        )
+
+    return model
+
+
+def projector_sft_rollout(args, rollout_id: int, data_buffer, evaluation: bool = False):
+    """slime ``--rollout-function-path``: supervised samples carrying embeddings.
+
+    slime's own ``sft_rollout.generate_rollout`` builds tokens and the loss mask
+    from each conversation, which is all a text SFT run needs. This does the same
+    and additionally lifts the dataset's embeddings out of ``Sample.metadata``
+    into ``multimodal_train_inputs``, the per-sample tensor dict slime
+    concatenates across a packed microbatch and splats into ``model.forward``,
+    where the projector picks them up.
+
+    Positions stay sample-local here and are rebased in the merge: slime does no
+    offsetting of its own, and this is the last place that would know a sample's
+    length before the packing decides its offset.
+    """
+    from slime.utils.mask_utils import (  # pyright: ignore[reportMissingImports]
+        MultiTurnLossMaskGenerator,
+    )
+    from slime.utils.processing_utils import (  # pyright: ignore[reportMissingImports]
+        load_tokenizer,
+    )
+
+    if evaluation:
+        raise ValueError("projector_sft_rollout does not generate, so cannot evaluate")
+    cfg = from_slime_args(args)
+    tokenizer = load_tokenizer(args.hf_checkpoint, trust_remote_code=True)
+    mask_generator = MultiTurnLossMaskGenerator(
+        tokenizer, tokenizer_type=args.loss_mask_type
+    )
+
+    samples = data_buffer.get_samples(args.rollout_batch_size)
+    for sample in samples:
+        (sample,) = sample
+        messages = sample.prompt
+        token_ids, loss_mask = mask_generator.get_loss_mask(
+            messages, tools=sample.metadata.get("tools")
+        )
+        response_length = mask_generator.get_response_lengths([loss_mask])[0]
+        sample.tokens = token_ids
+        sample.response_length = response_length
+        sample.reward = 0
+        sample.loss_mask = loss_mask[-response_length:]
+
+        embeddings = sample.metadata.get(cfg.embeddings_key)
+        positions = sample.metadata.get(cfg.positions_key)
+        if embeddings is None or positions is None:
+            raise ValueError(
+                f"sample {sample.index} carries no '{cfg.embeddings_key}'/"
+                f"'{cfg.positions_key}' metadata; a projector-only run has "
+                "nothing to train without embeddings."
+            )
+        embeddings_t = torch.tensor(embeddings, dtype=torch.float32)
+        if embeddings_t.shape[-1] != cfg.input_dim:
+            raise ValueError(
+                f"sample {sample.index} has {embeddings_t.shape[-1]}-wide "
+                f"embeddings but the projector expects {cfg.input_dim}"
+            )
+        max_position = max(positions, default=-1)
+        if max_position >= len(token_ids):
+            raise ValueError(
+                f"sample {sample.index} places an embedding at token "
+                f"{max_position} of a {len(token_ids)}-token sequence"
+            )
+        sample.multimodal_train_inputs = {
+            cfg.embeddings_key: embeddings_t,
+            cfg.positions_key: torch.tensor(positions, dtype=torch.long),
+            ROW_COUNTS_KEY: torch.tensor([len(positions)], dtype=torch.long),
+        }
+    return samples
+
+
+class _ProjectorSaver:
+    """Writes the projector after optimizer steps, including the run's last one.
+
+    Saving inside the before-train-step hook would only ever persist state one
+    step stale and would miss the final step entirely, so the hook is used just
+    to get hold of the optimizer, and the write hangs off ``optimizer.step``:
+    counted in optimizer steps, so ``save_interval`` means what it says, and the
+    last step of the run always lands.
+
+    Each step first sums the projector's gradients across the tensor-parallel
+    group: under sequence parallelism every rank merges a disjoint slice of the
+    packed sequence, so each holds only part of the replicated projector's
+    gradient (see
+    :func:`~modal_training_gym.common.embedding_projector.all_reduce_projector_grads`).
+    """
+
+    def __init__(self, args, model, optimizer) -> None:
+        self._cfg = from_slime_args(args)
+        self._sequence_parallel = bool(getattr(args, "sequence_parallel", False))
+        self._save_dir = self._cfg.save_dir or os.path.join(
+            str(args.save or "/checkpoints"), "projector"
+        )
+        chunks = model if isinstance(model, list) else [model]
+        self._projectors = [p for c in chunks if (p := get_projector(c)) is not None]
+        self._total_steps = int(getattr(args, "train_iters", 0) or 0)
+        self._steps = 0
+        self._attempts = 0
+        self._original_step = optimizer.step
+        optimizer.step = self._step
+
+    def _step(self, *fargs, **fkwargs):
+        for projector in self._projectors:
+            all_reduce_projector_grads(projector, self._sequence_parallel)
+        out = self._original_step(*fargs, **fkwargs)
+        for projector in self._projectors:
+            log_projector_replica(projector, self._steps + 1)
+        self._attempts += 1
+        # Megatron returns (success, grad_norm, num_zeros); a step that did not
+        # apply (gradient overflow) left the projector unchanged, so it does not
+        # advance the interval — but it still consumed one of the run's steps,
+        # which is what decides whether this was the last chance to write.
+        if not (isinstance(out, tuple) and out and out[0] is False):
+            self._steps += 1
+        if should_save_projector(
+            self._steps, self._attempts, self._total_steps, self._cfg.save_interval
+        ):
+            self._save()
+        return out
+
+    def _save(self) -> None:
+        if not self._projectors:
+            logger.warning(
+                "projector checkpoint skipped at step %d: no projector found on "
+                "any model chunk handed to the before-train-step hook",
+                self._steps,
+            )
+            return
+        if not is_projector_writer():
+            return
+        write_projector_checkpoint(
+            self._cfg, self._save_dir, self._projectors[0], self._steps
+        )
+
+
+def save_projector_checkpoint(
+    args, rollout_id: int, step_id: int, model, optimizer=None, opt_param_scheduler=None
+) -> None:
+    """slime before-train-step hook: arrange for projector-only checkpoints.
+
+    Idempotent — the hook fires before every train step and the saver is
+    installed on the first one, once per optimizer.
+    """
+    if optimizer is None or getattr(optimizer, "_training_gym_projector_saver", None):
+        return
+    optimizer._training_gym_projector_saver = _ProjectorSaver(args, model, optimizer)

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -297,6 +297,46 @@ def _hide_projector_from_megatron_checkpoints(model) -> None:
     model.sharded_state_dict = sharded_state_dict
 
 
+def _skip_base_checkpoint_save() -> None:
+    """Stop slime writing the frozen base as a checkpoint.
+
+    slime saves whenever ``should_run_periodic_action`` fires, and that returns
+    True on the last rollout whatever ``save_interval`` is — so even a run that
+    asks for no periodic save writes the full base once. For a projector-only run
+    that output is a byte-for-byte copy of ``ref_load``: at 35B it is ~70 GB of
+    sharded weights and about a minute of the run, produced by a training loop
+    that could not have changed a single one of them.
+
+    The projector is what this run produces, and
+    :class:`_ProjectorSaver` has already written it after every applied step, so
+    nothing is lost. Patched on the attribute ``actor.save_model`` resolved
+    (``from .model import ... save``) rather than on
+    :func:`megatron.training.save_checkpoint`, which the same process also
+    reaches through paths that are not this one — the HF export
+    (``args.save_hf``) still runs if a caller asks for it.
+
+    Called from the provider: it runs in the actor's process during
+    initialization, before any rollout, and only for projector-only runs.
+    """
+    from slime.backends.megatron_utils import (  # pyright: ignore[reportMissingImports]
+        actor as slime_actor,
+    )
+
+    if getattr(slime_actor.save, "_training_gym_projector_only", False):
+        return
+
+    def skip(iteration, model, optimizer, opt_param_scheduler) -> None:
+        logger.info(
+            "projector-only training: skipping slime's base checkpoint at "
+            "iteration %d — the base is frozen, so it would duplicate the "
+            "checkpoint this run loaded; the projector is written separately",
+            iteration,
+        )
+
+    skip._training_gym_projector_only = True
+    slime_actor.save = skip
+
+
 def projector_model_provider(
     pre_process: bool = True, post_process: bool = True, vp_stage=None, **kwargs
 ):
@@ -314,6 +354,7 @@ def projector_model_provider(
     # The saver the step hook installs owns the projector's gradient all-reduce
     # as well as its checkpoints, and neither absence announces itself.
     require_projector_step_hook(args)
+    _skip_base_checkpoint_save()
     if mpu.get_context_parallel_world_size() > 1:
         # Context parallelism shards the packed sequence a second way, with its
         # own two-chunk interleave (``slice_with_cp``) and a ``cu_seqlens`` scaled

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -117,8 +117,13 @@ def rebase_positions(
     ``cu_seqlens`` as one more segment (``slime/backends/megatron_utils/data.py``).
     So the segment count is the sample count, or one more than it; anything else
     means the row-count bookkeeping and the packing disagree and the merge would
-    silently write to the wrong tokens. Only the first ``num_samples`` boundaries
-    are read, so the padding segment is ignored either way.
+    silently write to the wrong tokens. The padding segment itself is never
+    projected into.
+
+    Segment and row counts are aggregates, so they would also match if the
+    packing ordered its samples differently from the concatenated tensors; each
+    rebased row is therefore checked against its own segment's end, which is
+    where that reordering shows up.
     """
     num_samples = int(row_counts.numel())
     num_segments = int(cu_seqlens.numel()) - 1
@@ -134,8 +139,21 @@ def rebase_positions(
             f"row counts sum to {int(counts.sum())} but {int(positions.numel())} "
             "position(s) were passed"
         )
-    starts = cu_seqlens[:num_samples].to(device=positions.device, dtype=torch.long)
-    return positions + torch.repeat_interleave(starts, counts)
+    boundaries = cu_seqlens.to(device=positions.device, dtype=torch.long)
+    starts = boundaries[:num_samples]
+    rebased = positions + torch.repeat_interleave(starts, counts)
+    # Every row must land inside the sample it came from. The checks above only
+    # see aggregates, so a packing that reordered the samples relative to the
+    # concatenated tensors would pass them and merge onto another sample's
+    # tokens; a position past its own segment's end is what that looks like.
+    ends = torch.repeat_interleave(boundaries[1 : num_samples + 1], counts)
+    if bool((rebased >= ends).any()):
+        raise ValueError(
+            "projector position(s) fall outside their own packed sample; the "
+            "microbatch's samples and its cu_seqlens segments are not in the "
+            "same order"
+        )
+    return rebased
 
 
 class _ProjectorMerge:

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -73,10 +73,11 @@ def _build_base_model(args, pre_process: bool, post_process: bool, kwargs: dict)
 
     The build happens with ``custom_model_provider_path`` still cleared, not just
     the lookup: re-entering this function would recurse until the stack
-    overflows. Only the keyword arguments the underlying provider actually
-    declares are forwarded, the way slime's own freeze wrapper does it, because
-    the signature differs across Megatron versions (``vp_stage``, ``config``,
-    ``pg_collection``).
+    overflows. A keyword argument is forwarded only when slime passed it *and*
+    the underlying provider declares it, the way slime's own wrapper checks for
+    ``vp_stage``: the signature differs across Megatron versions (``vp_stage``,
+    ``config``, ``pg_collection``), and passing an explicit ``None`` for one
+    slime never supplied would override whatever default the provider has.
     """
     import inspect
 
@@ -91,8 +92,8 @@ def _build_base_model(args, pre_process: bool, post_process: bool, kwargs: dict)
         provider_kwargs = {"pre_process": pre_process, "post_process": post_process}
         params = inspect.signature(provider).parameters
         for key in ("vp_stage", "config", "pg_collection"):
-            if key in params:
-                provider_kwargs[key] = kwargs.get(key, None)
+            if key in params and key in kwargs:
+                provider_kwargs[key] = kwargs[key]
         return provider(**provider_kwargs)
     finally:
         args.custom_model_provider_path = saved

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -271,12 +271,17 @@ def _hide_projector_from_megatron_checkpoints(model) -> None:
     :func:`save_projector_checkpoint` and ``ProjectorSpec.load`` instead, which
     is a single small file rather than a resharded slice of the model.
     """
-    prefix = "embedding_projector."
     original = model.sharded_state_dict
 
     def sharded_state_dict(*args, **kwargs):
         state = original(*args, **kwargs)
-        for key in [k for k in state if k.startswith(prefix)]:
+        # Megatron's checkpointing calls this with the default empty prefix, but
+        # a caller passing one (``prefix`` is this signature's first positional
+        # argument) prefixes every key, and matching the bare name would then
+        # keep the projector in and fail the base checkpoint's load.
+        caller_prefix = kwargs.get("prefix", args[0] if args else "")
+        dropped = f"{caller_prefix}embedding_projector."
+        for key in [k for k in state if k.startswith(dropped)]:
             del state[key]
         return state
 

--- a/modal_training_gym/frameworks/slime/embedding_projector.py
+++ b/modal_training_gym/frameworks/slime/embedding_projector.py
@@ -312,9 +312,13 @@ def projector_model_provider(
             "projector-only training does not support context parallelism; "
             "set context_parallel_size=1 on the recipe"
         )
-    model = _build_base_model(
-        args, pre_process, post_process, {"vp_stage": vp_stage, **kwargs}
-    )
+    # ``vp_stage`` is only really supplied when it is not ``None``: slime leaves
+    # it out entirely without virtual pipeline parallelism, and forwarding an
+    # explicit ``None`` would override the base provider's own default.
+    supplied = dict(kwargs)
+    if vp_stage is not None:
+        supplied["vp_stage"] = vp_stage
+    model = _build_base_model(args, pre_process, post_process, supplied)
     frozen = freeze_base_model(model)
 
     if pre_process:

--- a/modal_training_gym/frameworks/slime/projector_config.py
+++ b/modal_training_gym/frameworks/slime/projector_config.py
@@ -16,6 +16,7 @@ from modal_training_gym.common.projector_config import (
     EMBEDDINGS_KEY as EMBEDDINGS_KEY,
     POSITIONS_KEY as POSITIONS_KEY,
     ProjectorSpec as ProjectorSpec,
+    require_step_hook,
     should_save_projector as should_save_projector,
     spec_from_args,
 )
@@ -48,6 +49,11 @@ SAVE_HOOK_PATH = (
 ROLLOUT_PATH = (
     "modal_training_gym.frameworks.slime.embedding_projector.projector_sft_rollout"
 )
+
+
+def require_projector_step_hook(args) -> None:
+    """slime-side :func:`require_step_hook`; see it for what the hook owns."""
+    require_step_hook(args, SAVE_HOOK_PATH, "Qwen3_6_35b_Projector_Recipe")
 
 
 def from_slime_args(args: object) -> ProjectorSpec:

--- a/modal_training_gym/frameworks/slime/projector_config.py
+++ b/modal_training_gym/frameworks/slime/projector_config.py
@@ -1,0 +1,55 @@
+"""Wire format between a projector-only recipe and the slime containers.
+
+Kept free of torch so the launching side can import it: the recipe serializes a
+:class:`~modal_training_gym.common.projector_config.ProjectorSpec` into
+``extra_config`` under :data:`ARGS_KEY`, slime sets every ``extra_config`` key on
+its parsed ``args``, and
+:mod:`modal_training_gym.frameworks.slime.embedding_projector` reads it back
+inside the container. No new slime CLI flags are involved.
+
+The spec itself is shared with miles (see
+:mod:`modal_training_gym.common.projector_config`); what lives here is only the
+slime-side plumbing: the arg name and the dotted paths slime resolves.
+"""
+
+from modal_training_gym.common.projector_config import (
+    EMBEDDINGS_KEY as EMBEDDINGS_KEY,
+    POSITIONS_KEY as POSITIONS_KEY,
+    ProjectorSpec as ProjectorSpec,
+    should_save_projector as should_save_projector,
+    spec_from_args,
+)
+
+# slime arg carrying the serialized ProjectorSpec.
+ARGS_KEY = "training_gym_projector"
+
+# Per-sample row count, alongside the embeddings and their positions, so the
+# merge can rebase each sample's positions onto the packed sequence. slime
+# concatenates every ``multimodal_train_inputs`` key over the microbatch's
+# samples and adds no offsets (unlike miles, which offsets ``*_positions``
+# keys), so the row-to-sample mapping has to travel with the data.
+ROW_COUNTS_KEY = "projector_row_counts"
+
+# Regexes for slime's ``--only-train-params-name-list``. The provider already
+# freezes the base itself, so this is not what makes the run projector-only —
+# it states the same intent in slime's own terms, and it is what
+# ``wrap_model_provider_with_freeze`` re-applies to the model the provider
+# returns (a no-op when neither freeze list is set). Unanchored because the
+# names slime matches against carry Megatron's wrapper prefixes; the projector
+# is registered as ``embedding_projector``.
+TRAINABLE_PARAM_PATTERNS = ["embedding_projector"]
+
+PROVIDER_PATH = (
+    "modal_training_gym.frameworks.slime.embedding_projector.projector_model_provider"
+)
+SAVE_HOOK_PATH = (
+    "modal_training_gym.frameworks.slime.embedding_projector.save_projector_checkpoint"
+)
+ROLLOUT_PATH = (
+    "modal_training_gym.frameworks.slime.embedding_projector.projector_sft_rollout"
+)
+
+
+def from_slime_args(args: object) -> ProjectorSpec:
+    """Rebuild the spec the recipe serialized, from slime's parsed ``args``."""
+    return spec_from_args(args, ARGS_KEY, "slime")

--- a/modal_training_gym/train_recipes/slime_recipe/__init__.py
+++ b/modal_training_gym/train_recipes/slime_recipe/__init__.py
@@ -20,6 +20,9 @@ from modal_training_gym.train_recipes.slime_recipe.qwen3_5_9b import (
 from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b import (
     Qwen3_6_35b_Recipe,
 )
+from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b_projector import (
+    Qwen3_6_35b_Projector_Recipe,
+)
 from modal_training_gym.train_recipes.slime_recipe.qwen3_6_27b import (
     Qwen3_6_27b_Recipe,
 )
@@ -45,6 +48,7 @@ __all__ = [
     "Qwen3_5_4b_Recipe",
     "Qwen3_5_9b_Recipe",
     "Qwen3_6_35b_Recipe",
+    "Qwen3_6_35b_Projector_Recipe",
     "Qwen3_6_27b_Recipe",
     "Qwen3_8_27b_Recipe",
     "Qwen3_ASR_1_7b_Recipe",

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
@@ -85,10 +85,11 @@ class Qwen3_6_35b_Projector_Recipe(Qwen3_6_35b_Recipe):
     above ``num_rollout`` so Megatron never writes tens of gigabytes of
     unchanged weights.
 
-    Parallelism is TP2/PP1/CP1/EP4 on one 8×H100 node. Pipeline parallelism is
-    1 because with the base frozen only the first stage holds trainable
-    parameters, so later stages would build an optimizer over an empty
-    parameter set; context parallelism is 1 because the merge rebases the
+    Parallelism is TP2/PP1/CP1/EP4 on one 8×H100 node, loading the same
+    torch_dist base conversion as the RL recipe (torch_dist reshards on load).
+    Pipeline parallelism is 1 because with the base frozen only the first stage
+    holds trainable parameters, so later stages would build an optimizer over
+    an empty parameter set; context parallelism is 1 because the merge rebases the
     data's token positions onto a tensor/sequence shard and not onto Megatron's
     context-parallel chunking. Scale with tensor or expert parallelism.
     """
@@ -122,10 +123,16 @@ class Qwen3_6_35b_Projector_Recipe(Qwen3_6_35b_Recipe):
     use_kl_loss: bool = False
     kl_loss_coef: float = 0.0
     kl_coef: float = 0.0
-    # The base is still read from here — slime falls back to ``ref_load`` when
-    # ``load`` holds no checkpoint — but at PP1 rather than the RL recipe's PP2,
-    # so it gets its own conversion directory instead of invalidating that one.
-    ref_load: str = "/checkpoints/Qwen3.6-35B-A3B_torch_dist_tp2pp1"
+    # The base is still read from ``ref_load`` — slime falls back to it when
+    # ``load`` holds no checkpoint — and it is the RL recipe's inherited
+    # tp2pp2 directory: torch_dist reshards on load, so training at PP1 loads a
+    # PP2 conversion, and the two shapes share one converted base. The
+    # conversion layout has to be pinned here because it no longer follows the
+    # training layout: slime's convert_hf_to_torch_dist.py re-derives PP from
+    # the world size whenever it is passed PP=1, which at TP2/PP1 (world 2)
+    # asks Megatron for TP2*PP2=4 ranks in a 2-rank job and asserts.
+    conversion_tensor_model_parallel_size: int = 2
+    conversion_pipeline_model_parallel_size: int = 2
 
     # No evaluation pass: the rollout function has nothing to generate with, so
     # it raises when slime calls it with ``evaluation=True``.

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
@@ -176,9 +176,16 @@ class Qwen3_6_35b_Projector_Recipe(Qwen3_6_35b_Recipe):
         ``main_grad`` whole. Under ``use_distributed_optimizer`` that buffer is
         a reduce-scattered shard of a bucket, and summing shards across the
         tensor-parallel group is not the replicated weight's whole-sequence
-        gradient — it would train on a silently wrong gradient rather than
-        fail. There is nothing to gain either: with the base frozen, this run's
-        optimizer state is the projector's alone, tens of megabytes.
+        gradient. There is nothing to gain either: with the base frozen, this
+        run's optimizer state is the projector's alone, tens of megabytes.
+
+        This rejects the *request*, not the state: slime sets
+        ``args.use_distributed_optimizer = True`` unconditionally inside its own
+        ``_set_default_megatron_args``, so the container trains with it on
+        whatever this field says. What keeps the sum correct there is where the
+        hook sits — it wraps ``optimizer.step``, so ``main_grad`` still views
+        the whole bucket — and the per-rank projector fingerprint the run logs
+        is what would catch it if that ever stopped holding.
         """
         if self.use_distributed_optimizer:
             raise TrainingGymConfigError(

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
@@ -207,7 +207,22 @@ class Qwen3_6_35b_Projector_Recipe(Qwen3_6_35b_Recipe):
         would be computed over the dataset's own tokens, which is not the
         objective either flag means. RL over a projector needs a
         projector-aware weight sync first (see the class docstring).
+
+        ``debug_train_only`` itself is required rather than merely defaulted:
+        it is also what keeps the train model resident. The recipe inherits
+        ``colocate=True`` from the RL preset, and a colocated run that owns
+        engines pauses the train model between phases — which, with the base
+        frozen, zeroes the parameter buffer holding only the projector.
         """
+        if not self.debug_train_only:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs debug_train_only=True: engines "
+                "would be started for a run that generates nothing, slime's "
+                "weight sync would walk the projector it has no way to send, "
+                "and under the inherited colocate=True the train model would "
+                "be offloaded — which zeroes Megatron's parameter buffer, "
+                "holding only the projector once the base is frozen."
+            )
         if self.loss_type != "sft_loss":
             raise TrainingGymConfigError(
                 f"{type(self).__name__} is supervised: loss_type must be "

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
@@ -1,0 +1,244 @@
+"""Projector-only training on Qwen3.6-35B-A3B with slime.
+
+``Qwen3_6_35b_Projector_Recipe`` trains an embedding projector — a small MLP
+mapping externally computed per-token embeddings (a protein or DNA encoder's
+outputs, say) into the decoder's hidden space — against a fully frozen
+Qwen3.6-35B-A3B. No LoRA, no optimizer state for 35B parameters, no weight
+sync, no rollout engines: one node, and the trained artifact is a file of tens
+of megabytes.
+
+The RL and full-weight shapes of this model stay where they are, in
+:class:`~modal_training_gym.train_recipes.slime_recipe.Qwen3_6_35b_Recipe`,
+which this recipe inherits its cluster shape, MoE settings and sglang
+configuration from.
+"""
+
+from collections.abc import Callable
+from dataclasses import field
+from typing import ClassVar
+
+from pydantic import ConfigDict, model_validator
+from pydantic.dataclasses import dataclass
+
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.models import ModelConfig, Qwen3_6_35B
+from modal_training_gym.frameworks.slime.projector_config import (
+    ARGS_KEY,
+    PROVIDER_PATH,
+    ROLLOUT_PATH,
+    SAVE_HOOK_PATH,
+    TRAINABLE_PARAM_PATTERNS,
+    ProjectorSpec,
+)
+from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b import Qwen3_6_35b_Recipe
+
+
+@dataclass(config=ConfigDict(extra="forbid", arbitrary_types_allowed=True))
+class Qwen3_6_35b_Projector_Recipe(Qwen3_6_35b_Recipe):
+    """Projector-only supervised training against a frozen Qwen3.6-35B-A3B.
+
+    The trainable set is the projector alone::
+
+        TrainConfig(
+            model=Qwen3_6_35B(),
+            dataset=my_embedding_dataset,  # embeddings + positions columns
+            recipe=Qwen3_6_35b_Projector_Recipe(
+                projector=ProjectorSpec(input_dim=1536),
+            ),
+        ).train()
+
+    How each part of "train only the projector" is arranged:
+
+    *Freezing.* ``custom_model_provider_path`` builds the model slime's model
+    script asks for — so the MoE routing, gated attention and qk-layernorm come
+    from upstream verbatim — sets ``requires_grad=False`` on every base
+    parameter, then attaches the projector, all before Megatron builds the
+    optimizer, which skips parameters that do not require grad. Optimizer
+    state, gradient buffers and DDP buckets are therefore proportional to the
+    projector rather than to 35B parameters, which is what takes this down to a
+    single node. ``only_train_params_name_list`` states the same intent in
+    slime's own terms.
+
+    *Weight sync.* There is none: ``debug_train_only`` runs the training path
+    with no sglang engines, which a supervised run wants anyway since it
+    generates nothing. An RL variant needs more than this recipe: slime's sync
+    walks every named parameter of the model, so the projector would have to be
+    excluded from it, and the projector's contribution to a rollout — embeddings
+    written into the input embedding stream — has no representation in an sglang
+    request today.
+
+    *Data.* The dataset's per-sample embeddings and their token positions ride
+    in the sample's metadata
+    (:class:`~modal_training_gym.common.dataset.EmbeddingProjectorDataset`);
+    the recipe's rollout function turns them into ``multimodal_train_inputs``,
+    the per-sample tensor dict slime concatenates over a packed microbatch and
+    splats into ``model.forward``, where the merge picks them up.
+
+    *Checkpointing.* Every ``projector.save_interval`` optimizer steps, and
+    always on the run's last one, the projector's own state dict is written
+    (:mod:`modal_training_gym.frameworks.slime.embedding_projector`). The
+    frozen base needs none: it stays byte-identical to the checkpoint the run
+    started from, so the projector file plus ``hf_checkpoint`` describe the
+    trained artifact completely — and the projector is kept out of Megatron's
+    own state dicts, so the base checkpoint still loads even though the model
+    now has parameters that checkpoint never had. ``save_interval`` is left far
+    above ``num_rollout`` so Megatron never writes tens of gigabytes of
+    unchanged weights.
+
+    Parallelism is TP2/PP1/CP1/EP4 on one 8×H100 node. Pipeline parallelism is
+    1 because with the base frozen only the first stage holds trainable
+    parameters, so later stages would build an optimizer over an empty
+    parameter set; context parallelism is 1 because the merge rebases the
+    data's token positions onto a tensor/sequence shard and not onto Megatron's
+    context-parallel chunking. Scale with tensor or expert parallelism.
+    """
+
+    _SKIP_FIELDS: ClassVar[frozenset[str]] = Qwen3_6_35b_Recipe._SKIP_FIELDS | {
+        "projector"
+    }
+    model_config_class: ClassVar[type[ModelConfig]] = Qwen3_6_35B
+
+    projector: ProjectorSpec = field(default_factory=ProjectorSpec)
+
+    custom_model_provider_path: str | None = PROVIDER_PATH
+    only_train_params_name_list: list[str] | None = field(
+        default_factory=lambda: list(TRAINABLE_PARAM_PATTERNS)
+    )
+    custom_megatron_before_train_step_hook: Callable | str | None = SAVE_HOOK_PATH
+
+    # Supervised: the dataset carries the targets, so there is nothing to
+    # generate, score, or turn into advantages. The rollout function is slime's
+    # own SFT one plus the step that lifts each sample's embeddings into the
+    # tensor dict the model's forward receives.
+    loss_type: str = "sft_loss"
+    loss_mask_type: str = "qwen3_5"
+    rollout_function: Callable | str | None = ROLLOUT_PATH
+    disable_compute_advantages_and_returns: bool = True
+    debug_train_only: bool = True
+    calculate_per_token_loss: bool = True
+    n_samples_per_prompt: int = 1
+    # No reference model: a KL term against the frozen base is a KL against the
+    # model itself, and it would cost a second 35B copy to compute.
+    use_kl_loss: bool = False
+    kl_loss_coef: float = 0.0
+    kl_coef: float = 0.0
+    # The base is still read from here — slime falls back to ``ref_load`` when
+    # ``load`` holds no checkpoint — but at PP1 rather than the RL recipe's PP2,
+    # so it gets its own conversion directory instead of invalidating that one.
+    ref_load: str = "/checkpoints/Qwen3.6-35B-A3B_torch_dist_tp2pp1"
+
+    # No evaluation pass: the rollout function has nothing to generate with, so
+    # it raises when slime calls it with ``evaluation=True``.
+    eval_interval: int | None = None
+
+    # ── Parallelism (see the class docstring) ─────────────────────────────
+    pipeline_model_parallel_size: int = 1
+    context_parallel_size: int = 1
+
+    num_rollout: int = 10
+    rollout_batch_size: int = 8
+    global_batch_size: int = 8
+    # Only the projector is written, by the hook.
+    save_interval: int = 1_000_000
+    no_save_optim: bool = True
+
+    # An adapter trained from random initialization, unlike the frozen base it
+    # feeds, so far above the 1e-6 a full-weight run of this model uses.
+    lr: float = 1e-4
+    lr_decay_style: str = "cosine"
+
+    @model_validator(mode="after")
+    def _serialize_projector(self) -> "Qwen3_6_35b_Projector_Recipe":
+        """Carry the projector spec to the containers through ``extra_config``.
+
+        slime sets every ``extra_config`` key on ``args``, so the provider, the
+        rollout function and the checkpoint hook read the spec back without new
+        slime CLI flags.
+        """
+        cfg = dict(self.extra_config) if isinstance(self.extra_config, dict) else {}
+        if cfg.get(ARGS_KEY) != self.projector.to_args_dict():
+            cfg[ARGS_KEY] = self.projector.to_args_dict()
+            object.__setattr__(self, "extra_config", cfg)
+        return self
+
+    @model_validator(mode="after")
+    def _reject_distributed_optimizer(self) -> "Qwen3_6_35b_Projector_Recipe":
+        """Reject the distributed optimizer: it shards the gradient we sum.
+
+        The projector's tensor-parallel gradient sum reads each parameter's
+        ``main_grad`` whole. Under ``use_distributed_optimizer`` that buffer is
+        a reduce-scattered shard of a bucket, and summing shards across the
+        tensor-parallel group is not the replicated weight's whole-sequence
+        gradient — it would train on a silently wrong gradient rather than
+        fail. There is nothing to gain either: with the base frozen, this run's
+        optimizer state is the projector's alone, tens of megabytes.
+        """
+        if self.use_distributed_optimizer:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs use_distributed_optimizer=False: "
+                "the replicated projector's gradients are summed across the "
+                "tensor-parallel group from whole main_grad buffers, which the "
+                "distributed optimizer replaces with reduce-scattered shards. "
+                "Its only benefit is sharding optimizer state, and the base is "
+                "frozen, so this run's optimizer state is the projector's alone."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _reject_rl_objective(self) -> "Qwen3_6_35b_Projector_Recipe":
+        """Reject the RL settings this recipe has no rollouts to feed.
+
+        ``debug_train_only`` starts no sglang engines, so nothing generates
+        responses to score: a policy loss or a KL against a reference model
+        would be computed over the dataset's own tokens, which is not the
+        objective either flag means. RL over a projector needs a
+        projector-aware weight sync first (see the class docstring).
+        """
+        if self.loss_type != "sft_loss":
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} is supervised: loss_type must be "
+                f'"sft_loss" (got {self.loss_type!r}). It starts no rollout '
+                "engines, so a policy loss would have no generated responses "
+                "to score."
+            )
+        if self.use_kl_loss or self.kl_loss_coef or self.kl_coef:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} trains no base weights, so a KL term "
+                "against the reference model is a KL against the frozen base "
+                "itself — identically zero, at the cost of a second 35B copy. "
+                f"Got use_kl_loss={self.use_kl_loss}, "
+                f"kl_loss_coef={self.kl_loss_coef}, kl_coef={self.kl_coef}."
+            )
+        return self
+
+    def validate_model_parallelism(self, model: ModelConfig) -> None:
+        super().validate_model_parallelism(model)
+        if self.pipeline_model_parallel_size != 1:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs pipeline_model_parallel_size=1: the "
+                "projector lives on the first pipeline stage and the base is frozen, "
+                "so every later stage would build an optimizer over an empty "
+                f"parameter set. Got {self.pipeline_model_parallel_size}; scale with "
+                "tensor_model_parallel_size or expert_model_parallel_size."
+            )
+        if self.context_parallel_size != 1:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs context_parallel_size=1: the "
+                "projected embeddings are written into the input embeddings at "
+                "the dataset's token positions, which are rebased onto a "
+                "tensor/sequence shard but not onto Megatron's context-parallel "
+                f"chunking, so CP={self.context_parallel_size} would land them "
+                "on the wrong tokens. Scale with tensor_model_parallel_size or "
+                "expert_model_parallel_size."
+            )
+        if self.tensor_model_parallel_size > 1 and not self.sequence_parallel:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} needs sequence_parallel=True when "
+                f"tensor_model_parallel_size > 1 (got "
+                f"TP={self.tensor_model_parallel_size}). The projector is "
+                "replicated across the tensor-parallel group and its gradients "
+                "are summed over it, which is the whole-sequence gradient only "
+                "while each rank merges a disjoint sequence shard; without "
+                "sequence parallelism every rank merges every position, so the "
+                "sum would scale the projector's gradient by TP."
+            )

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py
@@ -82,8 +82,9 @@ class Qwen3_6_35b_Projector_Recipe(Qwen3_6_35b_Recipe):
     trained artifact completely — and the projector is kept out of Megatron's
     own state dicts, so the base checkpoint still loads even though the model
     now has parameters that checkpoint never had. ``save_interval`` is left far
-    above ``num_rollout`` so Megatron never writes tens of gigabytes of
-    unchanged weights.
+    above ``num_rollout``, and because slime saves on the last rollout whatever
+    that interval says, the provider patches that save out — otherwise every run
+    would end by writing ~70 GB of weights identical to the ones it loaded.
 
     Parallelism is TP2/PP1/CP1/EP4 on one 8×H100 node, loading the same
     torch_dist base conversion as the RL recipe (torch_dist reshards on load).

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -268,6 +268,15 @@ class SlimeRecipe(BaseTrainRecipe):
         Regex patterns (matched with ``re.search``) of parameter names to
         freeze, e.g. a VL model's vision tower so RL only updates the
         language backbone.
+    only_train_params_name_list : list[str] | None
+        The complement: regex patterns of the *only* parameters to train,
+        everything else frozen. Mutually exclusive with
+        ``freeze_params_name_list`` (slime raises if both are set).
+    custom_model_provider_path : str | None
+        Dotted path to a function building the Megatron model, replacing
+        slime's own provider (``--custom-model-provider-path``). Used to
+        attach modules the model script doesn't know about, e.g. the
+        embedding projector in ``Qwen3_6_35b_Projector_Recipe``.
 
     ## RL Algorithm
 
@@ -293,6 +302,18 @@ class SlimeRecipe(BaseTrainRecipe):
         Average the loss over tokens instead of over samples.
     ref_load : str
         Checkpoint path the reference model is read from (for KL terms).
+    loss_type : str
+        ``"policy_loss"`` (the RL objective), ``"sft_loss"`` for supervised
+        training on the dataset's own targets, or ``"custom_loss"``.
+    loss_mask_type : str
+        Chat-template family used to build the supervised loss mask, e.g.
+        ``"qwen3_5"``. Only read on the ``sft_loss`` path.
+    disable_compute_advantages_and_returns : bool
+        Skip the advantage/return computation, which has nothing to work on
+        outside ``policy_loss``. Set it with ``loss_type="sft_loss"``.
+    debug_train_only : bool
+        Run the training path with no sglang engines and no weight sync —
+        which is what a supervised run wants, since it generates nothing.
 
     ## Dynamic Sampling
 
@@ -535,6 +556,10 @@ class SlimeRecipe(BaseTrainRecipe):
     entropy_coef: float = 0.0
     calculate_per_token_loss: bool = False
     ref_load: str = ""
+    loss_type: str = "policy_loss"
+    loss_mask_type: str = "qwen"
+    disable_compute_advantages_and_returns: bool = False
+    debug_train_only: bool = False
 
     # ── Dynamic sampling (DAPO) ────────────────────────────────────────────
     over_sampling_batch_size: int | None = None
@@ -600,6 +625,12 @@ class SlimeRecipe(BaseTrainRecipe):
     # --freeze-params-name-list, matched with re.search). Used e.g. to freeze a
     # VL model's vision tower so RL only updates the language backbone.
     freeze_params_name_list: list[str] | None = None
+    only_train_params_name_list: list[str] | None = None
+
+    # Dotted path to a replacement Megatron model provider
+    # (--custom-model-provider-path). slime still applies its own freezing on
+    # top of whatever this returns.
+    custom_model_provider_path: str | None = None
 
     # ── Weight sync (megatron trainer → sglang rollout engines) ──────────
     # Default matches slime's own default. ``delta`` mode pin-snapshots the

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -302,12 +302,14 @@ class SlimeRecipe(BaseTrainRecipe):
         Average the loss over tokens instead of over samples.
     ref_load : str
         Checkpoint path the reference model is read from (for KL terms).
-    loss_type : str
-        ``"policy_loss"`` (the RL objective), ``"sft_loss"`` for supervised
-        training on the dataset's own targets, or ``"custom_loss"``.
-    loss_mask_type : str
+    loss_type : str | None
+        ``"policy_loss"`` (the RL objective, slime's own default), ``"sft_loss"``
+        for supervised training on the dataset's own targets, or
+        ``"custom_loss"``.
+    loss_mask_type : str | None
         Chat-template family used to build the supervised loss mask, e.g.
-        ``"qwen3_5"``. Only read on the ``sft_loss`` path.
+        ``"qwen3_5"``. Only read on the ``sft_loss`` path; ``None`` leaves
+        slime's own default (``"qwen"``).
     disable_compute_advantages_and_returns : bool
         Skip the advantage/return computation, which has nothing to work on
         outside ``policy_loss``. Set it with ``loss_type="sft_loss"``.
@@ -556,8 +558,10 @@ class SlimeRecipe(BaseTrainRecipe):
     entropy_coef: float = 0.0
     calculate_per_token_loss: bool = False
     ref_load: str = ""
-    loss_type: str = "policy_loss"
-    loss_mask_type: str = "qwen"
+    # Left unset so slime's own defaults apply and no existing recipe's command
+    # line changes; a supervised recipe sets both.
+    loss_type: str | None = None
+    loss_mask_type: str | None = None
     disable_compute_advantages_and_returns: bool = False
     debug_train_only: bool = False
 

--- a/scripts/api_reference_manifest.py
+++ b/scripts/api_reference_manifest.py
@@ -284,7 +284,7 @@ API_REFERENCE_MANIFEST = [
     },
     {
         "class_name": "ProjectorSpec",
-        "module": "modal_training_gym.frameworks.miles.projector_config",
+        "module": "modal_training_gym.common.projector_config",
         "group": "training",
         "class_type": "config_data",
         "sidebar_label": "ProjectorSpec",
@@ -295,6 +295,13 @@ API_REFERENCE_MANIFEST = [
         "group": "training",
         "class_type": "config_data",
         "sidebar_label": "Qwen3_6_35b_Recipe",
+    },
+    {
+        "class_name": "Qwen3_6_35b_Projector_Recipe",
+        "module": "modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b_projector",
+        "group": "training",
+        "class_type": "config_data",
+        "sidebar_label": "Qwen3_6_35b_Projector_Recipe",
     },
     {
         "class_name": "Qwen3_6_27b_Recipe",

--- a/scripts/validate_model_configs.py
+++ b/scripts/validate_model_configs.py
@@ -356,7 +356,7 @@ def run_base_training(
     model_config = config.model_config()
 
     train_recipe, dataset = build_recipe_and_dataset(
-        config.framework, model_config, step_count
+        config.framework, model_config, step_count, projector=config.projector
     )
     train_recipe.num_rollout = step_count
     if eval_interval is not None:

--- a/scripts/validation_backends/__init__.py
+++ b/scripts/validation_backends/__init__.py
@@ -20,7 +20,10 @@ if TYPE_CHECKING:
 
 
 def build_recipe_and_dataset(
-    framework: Framework, model_config: "ModelConfig", step_count: int
+    framework: Framework,
+    model_config: "ModelConfig",
+    step_count: int,
+    projector: bool = False,
 ) -> tuple["BaseTrainRecipe", "DatasetConfig"]:
     """The model's base recipe and the dataset it validates against.
 
@@ -28,11 +31,17 @@ def build_recipe_and_dataset(
     scope so validating a slime model never imports the miles recipes: a broken
     miles backend must not be able to take down the slime validation that gates
     PRs.
+
+    ``projector`` asks for the model's projector-only recipe rather than its base
+    one; the registry entry decides, because a model can have both and
+    ``get_base_recipe`` only knows the base one. Miles needs no such flag: its
+    projector models train nothing else, so their base recipe is the projector
+    recipe.
     """
     if framework is Framework.SLIME:
         from .slime import build_slime_validation
 
-        return build_slime_validation(model_config, step_count)
+        return build_slime_validation(model_config, step_count, projector=projector)
     if framework is Framework.MILES:
         from .miles import build_miles_validation
 

--- a/scripts/validation_backends/slime.py
+++ b/scripts/validation_backends/slime.py
@@ -4,12 +4,25 @@ from __future__ import annotations
 
 from modal_training_gym.common.dataset import (
     DatasetConfig,
+    EmbeddingProjectorDataset,
     HuggingFaceDataset,
     MultimodalDataset,
 )
+from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.models import ModelConfig
+from modal_training_gym.common.models.qwen3_6_35b import Qwen3_6_35B
 from modal_training_gym.common.models.qwen3_asr_1_7b import Qwen3_ASR_1_7B
 from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b_projector import (
+    Qwen3_6_35b_Projector_Recipe,
+)
+
+# Which model each projector-only slime recipe trains a projector against.
+# ``get_base_recipe`` cannot answer this: these models also train RL, and that
+# is the recipe it returns for them.
+PROJECTOR_RECIPES: dict[type[ModelConfig], type[SlimeRecipe]] = {
+    Qwen3_6_35B: Qwen3_6_35b_Projector_Recipe,
+}
 
 VALIDATION_EPHEMERAL_DISK_MIB = 2_097_152
 
@@ -99,13 +112,36 @@ class LibriSpeechASRDataset(MultimodalDataset):
 
 
 def build_slime_validation(
-    model_config: ModelConfig, step_count: int
+    model_config: ModelConfig, step_count: int, projector: bool = False
 ) -> tuple[SlimeRecipe, DatasetConfig]:
-    """The model's base slime recipe and a dataset matching its modality.
+    """The model's slime recipe and a dataset matching what it trains.
 
     Audio models (Qwen3-ASR) need speech clips, so they get LibriSpeech;
     everything else validates against gsm8k, scored by ``deepscaler``.
+
+    A projector-only entry is the exception twice over: the recipe comes from
+    ``PROJECTOR_RECIPES`` rather than ``get_base_recipe``, and it trains
+    supervised on external embeddings that no prompt dataset carries, so it
+    validates on synthetic rows sized to the projector's input dimension.
     """
+    if projector:
+        recipe_class = PROJECTOR_RECIPES.get(type(model_config))
+        if recipe_class is None:
+            raise TrainingGymConfigError(
+                f"no projector-only slime recipe for model "
+                f"{model_config.model_name!r}, which is registered as a "
+                "projector validation target"
+            )
+        projector_recipe = recipe_class()
+        projector_recipe.train_function_kwargs = {
+            **dict(projector_recipe.train_function_kwargs or {}),
+            "ephemeral_disk": VALIDATION_EPHEMERAL_DISK_MIB,
+        }
+        return projector_recipe, EmbeddingProjectorDataset.synthetic(
+            n_rows=projector_recipe.rollout_batch_size * step_count,
+            input_dim=projector_recipe.projector.input_dim,
+        )
+
     recipe = SlimeRecipe.get_base_recipe(model_config)
     recipe.rm_type = "deepscaler"
     recipe.train_function_kwargs = {

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -39,7 +39,9 @@ PKG_ROOT = REPO_ROOT / "modal_training_gym"
 # fails on a rename or deletion.
 REMOTE_ONLY = frozenset(
     {
+        "modal_training_gym.common.embedding_projector",
         "modal_training_gym.frameworks.miles.embedding_projector",
+        "modal_training_gym.frameworks.slime.embedding_projector",
         "modal_training_gym.frameworks.miles.modal_helpers.patches.patch_gemma4_vl_rollout_text",
         "modal_training_gym.frameworks.miles.modal_helpers.patches.patch_router_startup_timeout",
         "modal_training_gym.frameworks.miles.modal_helpers.patches.patch_sglang_abort",

--- a/tests/test_model_validation_registry.py
+++ b/tests/test_model_validation_registry.py
@@ -96,7 +96,10 @@ def test_every_config_builds_a_recipe_on_its_declared_framework(config):
     fail on a GPU, minutes into a run.
     """
     recipe, dataset = build_recipe_and_dataset(
-        config.framework, config.model_config(), step_count=1
+        config.framework,
+        config.model_config(),
+        step_count=1,
+        projector=config.projector,
     )
     assert recipe is not None
     assert dataset is not None
@@ -175,7 +178,9 @@ def test_validation_dataset_unpickles_without_the_scripts_directory(config, tmp_
 
     from scripts.validate_model_configs import _ship_dataset_definition
 
-    _, dataset = build_recipe_and_dataset(config.framework, config.model_config(), 1)
+    _, dataset = build_recipe_and_dataset(
+        config.framework, config.model_config(), 1, projector=config.projector
+    )
 
     _ship_dataset_definition(dataset)
     payload = serialize(dataset)

--- a/tests/test_model_validation_registry.py
+++ b/tests/test_model_validation_registry.py
@@ -75,9 +75,14 @@ def test_config_resolves_by_name_case_insensitively(config):
 def test_config_resolves_by_hf_repo_id(config):
     """``check -m Qwen/Qwen3-4B`` must keep working, not just the short name."""
     matches = [c for c in ALL_CONFIGS if c.model_name == config.model_name]
+    base = [c for c in matches if not c.projector]
     if len(matches) == 1:
         assert _ValidationConfig.find(config.model_name) is config
         assert _ValidationConfig.find(config.model_name.upper()) is config
+    elif len(base) == 1:
+        # A projector entry is a variant of the base entry, not a peer, so the
+        # repo id keeps resolving to the base training run.
+        assert _ValidationConfig.find(config.model_name) is base[0]
     else:
         with pytest.raises(ValueError, match="ambiguous model"):
             _ValidationConfig.find(config.model_name)

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -187,6 +187,12 @@ def test_distributed_optimizer_is_rejected():
         Qwen3_6_35b_Projector_Recipe(use_distributed_optimizer=True)
 
 
+def test_engine_owning_runs_are_rejected():
+    """Engines under the inherited colocate=True would offload the projector."""
+    with pytest.raises(ValidationError, match="debug_train_only=True"):
+        Qwen3_6_35b_Projector_Recipe(debug_train_only=False)
+
+
 def test_rl_objectives_are_rejected():
     """No engines run, so a policy loss or KL would score the dataset's tokens."""
     with pytest.raises(ValidationError, match="sft_loss"):

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -315,6 +315,44 @@ def test_a_projector_entry_without_a_recipe_is_rejected():
         build_recipe_and_dataset(Framework.SLIME, Qwen3_4B(), 1, projector=True)
 
 
+def test_the_frozen_bases_checkpoint_save_is_patched_out(monkeypatch):
+    """slime saves on the last rollout regardless of ``save_interval``.
+
+    For a frozen base that write is a ~70 GB copy of the checkpoint the run
+    loaded, so the provider replaces the actor's ``save`` with a no-op.
+    """
+    pytest.importorskip("torch")  # the framework module is import-time torch
+    import sys
+    from types import ModuleType
+
+    from modal_training_gym.frameworks.slime.embedding_projector import (
+        _skip_base_checkpoint_save,
+    )
+
+    saved: list[int] = []
+    actor = ModuleType("slime.backends.megatron_utils.actor")
+    actor.save = lambda iteration, model, optimizer, scheduler: saved.append(iteration)
+    package = ModuleType("slime.backends.megatron_utils")
+    package.actor = actor
+    for name, module in {
+        "slime": ModuleType("slime"),
+        "slime.backends": ModuleType("slime.backends"),
+        "slime.backends.megatron_utils": package,
+        "slime.backends.megatron_utils.actor": actor,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    _skip_base_checkpoint_save()
+    patched = actor.save
+    actor.save(7, None, None, None)
+    assert saved == []
+
+    # Idempotent: the provider runs once per model chunk, and re-wrapping would
+    # be harmless but re-patching an already-patched attribute hides mistakes.
+    _skip_base_checkpoint_save()
+    assert actor.save is patched
+
+
 def test_projector_keys_are_hidden_whatever_prefix_megatron_asks_for():
     """The base checkpoint predates the projector, so its keys must not appear.
 

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -20,6 +20,9 @@ from modal_training_gym import (
 )
 from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.train import _merge_recipe
+from modal_training_gym.frameworks.slime.modal_helpers.utils import (
+    get_checkpoint_conversion_policy,
+)
 from modal_training_gym.frameworks.slime.projector_config import (
     ARGS_KEY,
     PROVIDER_PATH,
@@ -127,12 +130,28 @@ def test_save_hook_runs_through_the_gyms_phase_reporting_wrapper():
     )
 
 
-def test_base_weights_are_read_from_their_own_conversion_directory():
-    """PP1 here vs PP2 for RL: sharing a directory would invalidate the other."""
+def test_base_weights_come_from_the_rl_recipes_conversion():
+    """Training at PP1 reshards the RL recipe's PP2 base, so it converts once.
+
+    The conversion layout must stay pinned even though training is PP1: slime's
+    converter re-derives PP from the world size when passed PP=1, which at TP2
+    asks Megatron for 4 ranks in a 2-rank job.
+    """
     rl, projector = Qwen3_6_35b_Recipe(), Qwen3_6_35b_Projector_Recipe()
     assert projector.pipeline_model_parallel_size == 1
-    assert projector.ref_load != rl.ref_load
-    assert projector.ref_load.endswith("tp2pp1")
+    assert projector.ref_load == rl.ref_load
+    assert projector.conversion_tensor_model_parallel_size == 2
+    assert projector.conversion_pipeline_model_parallel_size == 2
+    assert projector.ref_load.endswith("tp2pp2")
+
+    nodes, procs, conversion_args = get_checkpoint_conversion_policy(
+        projector, model=Qwen3_6_35B()
+    )
+    # The converter's job must have exactly TP*PP ranks, or Megatron asserts on
+    # a world size that does not match the model layout it was given.
+    assert nodes * procs == 4
+    assert "--tensor-model-parallel-size 2" in conversion_args
+    assert "--pipeline-model-parallel-size 2" in conversion_args
 
 
 def test_pipeline_parallelism_is_rejected():

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -286,3 +286,35 @@ def test_a_projector_entry_without_a_recipe_is_rejected():
 
     with pytest.raises(TrainingGymConfigError, match="no projector-only slime"):
         build_recipe_and_dataset(Framework.SLIME, Qwen3_4B(), 1, projector=True)
+
+
+def test_projector_keys_are_hidden_whatever_prefix_megatron_asks_for():
+    """The base checkpoint predates the projector, so its keys must not appear.
+
+    Megatron's checkpointing calls ``sharded_state_dict()`` with the default
+    empty prefix, but ``prefix`` is the signature's first positional argument
+    and a caller passing one prefixes every key — matching the bare name would
+    then leave the projector in and fail the load of a fine base checkpoint.
+    """
+    pytest.importorskip("torch")  # the framework module is import-time torch
+    from modal_training_gym.frameworks.slime.embedding_projector import (
+        _hide_projector_from_megatron_checkpoints,
+    )
+
+    class FakeModel:
+        def sharded_state_dict(self, prefix=""):
+            return {
+                f"{prefix}decoder.layers.0.mlp.weight": object(),
+                f"{prefix}embedding_projector.mlp.0.weight": object(),
+            }
+
+    model = FakeModel()
+    _hide_projector_from_megatron_checkpoints(model)
+
+    assert list(model.sharded_state_dict()) == ["decoder.layers.0.mlp.weight"]
+    assert list(model.sharded_state_dict("module.")) == [
+        "module.decoder.layers.0.mlp.weight"
+    ]
+    assert list(model.sharded_state_dict(prefix="module.")) == [
+        "module.decoder.layers.0.mlp.weight"
+    ]

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -1,0 +1,201 @@
+"""Projector-only training on slime: the path from a recipe field to slime's CLI.
+
+The container-side halves (provider, forward merge, position rebasing,
+checkpoint hook) need torch and a GPU, so what is pinned here is the wiring the
+launcher owns: the spec reaching the containers, the flags that make the run
+supervised and engine-free, and the guards against configurations that would
+silently train nothing or train on a wrong gradient.
+
+The miles side of the same feature is pinned in
+``tests/test_projector_only_training.py``.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from modal_training_gym import (
+    EmbeddingProjectorDataset,
+    ProjectorSpec,
+    Qwen3_6_35B,
+)
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.frameworks.slime.projector_config import (
+    ARGS_KEY,
+    PROVIDER_PATH,
+    ROLLOUT_PATH,
+    SAVE_HOOK_PATH,
+    TRAINABLE_PARAM_PATTERNS,
+    from_slime_args,
+    should_save_projector,
+)
+from modal_training_gym.train_recipes.slime_recipe import (
+    Qwen3_6_35b_Projector_Recipe,
+    Qwen3_6_35b_Recipe,
+    SlimeRecipe,
+)
+
+
+def _flags(args: list[str]) -> dict[str, str]:
+    return {
+        args[i]: (
+            args[i + 1]
+            if i + 1 < len(args) and not args[i + 1].startswith("--")
+            else ""
+        )
+        for i in range(len(args))
+        if args[i].startswith("--")
+    }
+
+
+def _dataset() -> EmbeddingProjectorDataset:
+    return EmbeddingProjectorDataset.synthetic(n_rows=2, input_dim=4)
+
+
+def _cli_flags(recipe: Qwen3_6_35b_Projector_Recipe) -> dict[str, str]:
+    return _flags(recipe.cli_args(dataset=_dataset(), model=Qwen3_6_35B()))
+
+
+class _FakeArgs:
+    def __init__(self, payload: dict) -> None:
+        setattr(self, ARGS_KEY, payload)
+
+
+def test_spec_reaches_containers_through_extra_config():
+    recipe = Qwen3_6_35b_Projector_Recipe(
+        projector=ProjectorSpec(input_dim=4, hidden_dim=8, num_layers=1)
+    )
+    payload = recipe.extra_config[ARGS_KEY]
+    assert payload["input_dim"] == 4 and payload["num_layers"] == 1
+    # slime sets every extra_config key on args, which is how the provider, the
+    # rollout function and the checkpoint hook read the spec back without new
+    # CLI flags.
+    spec = from_slime_args(_FakeArgs(payload))
+    assert spec.input_dim == 4
+    assert spec.embeddings_key == "projector_embeddings"
+
+
+def test_missing_spec_is_a_clear_error():
+    with pytest.raises(ValueError, match=ARGS_KEY):
+        from_slime_args(_FakeArgs.__new__(_FakeArgs))
+
+
+def test_recipe_emits_supervised_engine_free_flags():
+    flags = _cli_flags(Qwen3_6_35b_Projector_Recipe(projector=ProjectorSpec()))
+
+    assert flags["--custom-model-provider-path"] == PROVIDER_PATH
+    assert flags["--rollout-function-path"] == ROLLOUT_PATH
+    assert flags["--loss-type"] == "sft_loss"
+    assert "--debug-train-only" in flags
+    assert "--disable-compute-advantages-and-returns" in flags
+    # Freezing happens in the provider; this states the same intent in slime's
+    # own terms and is what its freeze wrapper re-applies to the built model.
+    assert flags["--only-train-params-name-list"] == TRAINABLE_PARAM_PATTERNS[0]
+    # No LoRA anywhere: the whole point of freezing the base instead.
+    assert "--lora-rank" not in flags
+    # The projector spec travels in the YAML config, never as a flag.
+    assert "--projector" not in flags
+
+
+def test_no_eval_pass_is_configured():
+    """The rollout function raises on evaluation, so none may be scheduled."""
+    assert Qwen3_6_35b_Projector_Recipe().eval_interval is None
+    assert "--eval-interval" not in _cli_flags(Qwen3_6_35b_Projector_Recipe())
+
+
+def test_save_hook_runs_through_the_gyms_phase_reporting_wrapper():
+    """Dashboard phase/substep timing must survive the projector's own hook."""
+    flags = _cli_flags(Qwen3_6_35b_Projector_Recipe())
+    assert flags["--custom-megatron-before-train-step-hook-path"].startswith(
+        "modal_training_gym.frameworks.slime.phase_reporting"
+    )
+    assert (
+        Qwen3_6_35b_Projector_Recipe().extra_config[
+            "training_gym_custom_megatron_before_train_step_hook_path"
+        ]
+        == SAVE_HOOK_PATH
+    )
+
+
+def test_base_weights_are_read_from_their_own_conversion_directory():
+    """PP1 here vs PP2 for RL: sharing a directory would invalidate the other."""
+    rl, projector = Qwen3_6_35b_Recipe(), Qwen3_6_35b_Projector_Recipe()
+    assert projector.pipeline_model_parallel_size == 1
+    assert projector.ref_load != rl.ref_load
+    assert projector.ref_load.endswith("tp2pp1")
+
+
+def test_pipeline_parallelism_is_rejected():
+    """PP>1 would give later stages an optimizer over an empty parameter set."""
+    with pytest.raises(TrainingGymConfigError, match="pipeline_model_parallel_size=1"):
+        Qwen3_6_35b_Projector_Recipe(
+            pipeline_model_parallel_size=2
+        ).validate_model_parallelism(Qwen3_6_35B())
+
+
+def test_context_parallelism_is_rejected():
+    """CP chunks the sequence its own way; the merge rebases only TP/SP."""
+    with pytest.raises(TrainingGymConfigError, match="context_parallel_size=1"):
+        Qwen3_6_35b_Projector_Recipe(
+            context_parallel_size=2
+        ).validate_model_parallelism(Qwen3_6_35B())
+
+
+def test_tensor_parallelism_without_sequence_parallelism_is_rejected():
+    """Summing the replicated projector's grads over TP assumes disjoint shards."""
+    with pytest.raises(TrainingGymConfigError, match="sequence_parallel=True"):
+        Qwen3_6_35b_Projector_Recipe(
+            sequence_parallel=False
+        ).validate_model_parallelism(Qwen3_6_35B())
+    # The shipped shape passes its own preflight, EP included.
+    Qwen3_6_35b_Projector_Recipe().validate_model_parallelism(Qwen3_6_35B())
+
+
+def test_distributed_optimizer_is_rejected():
+    """Its reduce-scattered main_grad is not what the TP sum may read."""
+    # Pydantic wraps the validator's error; the message is what a user reads.
+    with pytest.raises(ValidationError, match="use_distributed_optimizer=False"):
+        Qwen3_6_35b_Projector_Recipe(use_distributed_optimizer=True)
+
+
+def test_rl_objectives_are_rejected():
+    """No engines run, so a policy loss or KL would score the dataset's tokens."""
+    with pytest.raises(ValidationError, match="sft_loss"):
+        Qwen3_6_35b_Projector_Recipe(loss_type="policy_loss")
+    with pytest.raises(ValidationError, match="KL"):
+        Qwen3_6_35b_Projector_Recipe(use_kl_loss=True)
+    with pytest.raises(ValidationError, match="KL"):
+        Qwen3_6_35b_Projector_Recipe(kl_coef=0.01)
+
+
+def test_megatron_never_writes_the_frozen_base():
+    """Only the hook writes; Megatron's own interval must stay out of the run."""
+    recipe = Qwen3_6_35b_Projector_Recipe()
+    assert recipe.save_interval > recipe.num_rollout
+    assert recipe.no_save_optim is True
+
+
+def test_a_finished_run_always_leaves_a_projector_checkpoint():
+    """The run's last optimizer step saves even when the interval misses it."""
+    recipe = Qwen3_6_35b_Projector_Recipe()
+    total = (
+        recipe.num_rollout
+        * recipe.rollout_batch_size
+        * recipe.n_samples_per_prompt
+        // recipe.global_batch_size
+    )
+    saves = [
+        s
+        for s in range(1, total + 1)
+        if should_save_projector(s, s, total, recipe.projector.save_interval)
+    ]
+    assert saves and saves[-1] == total
+    # A skipped update (gradient overflow) consumed one of the run's steps, so
+    # the last attempt still saves what the applied steps produced...
+    assert should_save_projector(total - 1, total, total, 0)
+    # ...but a run where nothing ever applied has no trained adapter to write.
+    assert not should_save_projector(0, total, total, 0)
+
+
+def test_projector_training_stays_opt_in():
+    """Qwen3.6-35B's default recipe is still the RL one."""
+    assert type(SlimeRecipe.get_base_recipe(Qwen3_6_35B())) is Qwen3_6_35b_Recipe

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -19,6 +19,7 @@ from modal_training_gym import (
     Qwen3_6_35B,
 )
 from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.train import _merge_recipe
 from modal_training_gym.frameworks.slime.projector_config import (
     ARGS_KEY,
     PROVIDER_PATH,
@@ -209,3 +210,22 @@ def test_a_finished_run_always_leaves_a_projector_checkpoint():
 def test_projector_training_stays_opt_in():
     """Qwen3.6-35B's default recipe is still the RL one."""
     assert type(SlimeRecipe.get_base_recipe(Qwen3_6_35B())) is Qwen3_6_35b_Recipe
+
+
+def test_preset_merge_keeps_the_projector_recipe_class():
+    """The merge fills unset fields from the RL preset without demoting to it.
+
+    ``get_base_recipe`` returns the RL recipe, so rebuilding the merged recipe
+    as the preset's class would drop ``projector`` and every guard above.
+    """
+    merged = _merge_recipe(
+        Qwen3_6_35b_Recipe(),
+        Qwen3_6_35b_Projector_Recipe(
+            projector=ProjectorSpec(input_dim=4, num_layers=1)
+        ),
+    )
+    assert type(merged) is Qwen3_6_35b_Projector_Recipe
+    assert merged.projector.input_dim == 4
+    assert merged.pipeline_model_parallel_size == 1
+    assert merged.loss_type == "sft_loss"
+    assert merged.extra_config[ARGS_KEY]["input_dim"] == 4

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -96,6 +96,16 @@ def test_recipe_emits_supervised_engine_free_flags():
     assert "--projector" not in flags
 
 
+def test_other_slime_recipes_command_lines_are_untouched():
+    """The supervised flags are opt-in: an RL recipe still emits neither."""
+    flags = _flags(
+        Qwen3_6_35b_Recipe().cli_args(dataset=_dataset(), model=Qwen3_6_35B())
+    )
+    assert "--loss-type" not in flags
+    assert "--loss-mask-type" not in flags
+    assert "--debug-train-only" not in flags
+
+
 def test_no_eval_pass_is_configured():
     """The rollout function raises on evaluation, so none may be scheduled."""
     assert Qwen3_6_35b_Projector_Recipe().eval_interval is None

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -248,3 +248,41 @@ def test_preset_merge_keeps_the_projector_recipe_class():
     assert merged.pipeline_model_parallel_size == 1
     assert merged.loss_type == "sft_loss"
     assert merged.extra_config[ARGS_KEY]["input_dim"] == 4
+
+
+def test_validation_registry_dispatches_the_projector_recipe_by_name():
+    """``check -m Qwen3.6-35B-A3B-Projector`` has to reach the projector path.
+
+    The registry keys on the ``ModelConfig``, and this model's slime base recipe
+    is the RL one, so the entry carries ``projector=True`` and the backend picks
+    the recipe from its own table. Dispatch-only: it is a 35B MoE on a node.
+    """
+    from modal_training_gym.common.models.validation import (
+        _ValidationConfig,
+        Framework,
+    )
+    from scripts.validation_backends import build_recipe_and_dataset
+
+    config = _ValidationConfig.find("Qwen3.6-35B-A3B-Projector")
+    assert config.projector and not config.run_on_pr
+    assert config.framework is Framework.SLIME
+
+    recipe, dataset = build_recipe_and_dataset(
+        config.framework, config.model_config(), 3, projector=config.projector
+    )
+    assert type(recipe) is Qwen3_6_35b_Projector_Recipe
+    # No public dataset ships encoder embeddings, so the rows are synthetic and
+    # sized to the projector's input width: enough for every step of the run.
+    assert dataset.synthetic_input_dim == recipe.projector.input_dim
+    assert dataset.synthetic_rows == recipe.rollout_batch_size * 3
+
+
+def test_a_projector_entry_without_a_recipe_is_rejected():
+    """A registry entry for a model with no projector recipe must not run RL."""
+    from modal_training_gym.common.errors import TrainingGymConfigError
+    from modal_training_gym.common.models.qwen3_4b import Qwen3_4B
+    from scripts.validation_backends import build_recipe_and_dataset
+    from modal_training_gym.common.models.validation import Framework
+
+    with pytest.raises(TrainingGymConfigError, match="no projector-only slime"):
+        build_recipe_and_dataset(Framework.SLIME, Qwen3_4B(), 1, projector=True)

--- a/tests/test_projector_only_training_slime.py
+++ b/tests/test_projector_only_training_slime.py
@@ -30,6 +30,7 @@ from modal_training_gym.frameworks.slime.projector_config import (
     SAVE_HOOK_PATH,
     TRAINABLE_PARAM_PATTERNS,
     from_slime_args,
+    require_projector_step_hook,
     should_save_projector,
 )
 from modal_training_gym.train_recipes.slime_recipe import (
@@ -128,6 +129,26 @@ def test_save_hook_runs_through_the_gyms_phase_reporting_wrapper():
         ]
         == SAVE_HOOK_PATH
     )
+
+
+def test_an_unwired_step_hook_fails_at_model_construction():
+    """Without the hook there is no grad all-reduce and no checkpoint at all."""
+    from types import SimpleNamespace
+
+    recipe = Qwen3_6_35b_Projector_Recipe()
+    wired = SimpleNamespace(
+        custom_megatron_before_train_step_hook_path=_cli_flags(recipe)[
+            "--custom-megatron-before-train-step-hook-path"
+        ],
+        extra_config=dict(recipe.extra_config or {}),
+    )
+    require_projector_step_hook(wired)
+
+    wired.extra_config.pop(
+        "training_gym_custom_megatron_before_train_step_hook_path", None
+    )
+    with pytest.raises(ValueError, match="unreduced gradients and no checkpoints"):
+        require_projector_step_hook(wired)
 
 
 def test_base_weights_come_from_the_rl_recipes_conversion():


### PR DESCRIPTION
Projector-only training for **Qwen3.6-35B-A3B on slime**: a small MLP mapping externally computed per-token embeddings (protein/DNA encoder outputs) into the decoder's hidden space, trained against a fully frozen base. No LoRA, no optimizer state for 35B parameters, no weight sync, no rollout engines — one 8×H100 node, and the trained artifact is a file of tens of MB.

Stacked on #429 (miles/GLM-5.2), which this branch is based on; the shared pieces of that PR move to `common/` here. Review #429 first — the diff below is only the slime half.

## What's new

- `modal_training_gym/common/{projector_config,embedding_projector}.py` — `ProjectorSpec`, the `EmbeddingProjector` module, freezing, the merge's TP/SP scatter, the TP gradient sum, and checkpoint read/write, now shared by both frameworks. `frameworks/miles/*` keeps only miles' arg name and dotted paths and re-exports the rest, so `from_miles_args` and friends still import from where they did.
- `modal_training_gym/frameworks/slime/{projector_config,embedding_projector}.py` — the slime-side plumbing: `--custom-model-provider-path` (build the model slime's model script asks for, freeze it, attach the projector before Megatron builds the optimizer), a `--rollout-function-path` that is slime's own SFT rollout plus the step lifting each sample's embeddings into `multimodal_train_inputs`, and a before-train-step hook that writes the projector alone.
- `modal_training_gym/train_recipes/slime_recipe/qwen3_6_35b_projector.py` — `Qwen3_6_35b_Projector_Recipe`, inheriting the RL recipe's cluster shape and MoE settings (TP2/PP1/CP1/EP4, one node), supervised and engine-free (`loss_type="sft_loss"`, `debug_train_only`, no advantages, no eval pass), with validators rejecting the configurations that would otherwise train nothing or train on a wrong gradient.
- `SlimeRecipe` gains the four already-existing slime flags this needs (`loss_type`, `loss_mask_type`, `disable_compute_advantages_and_returns`, `debug_train_only`) plus `only_train_params_name_list` and `custom_model_provider_path`, documented in the recipe docstring.

## The one thing slime does differently from miles

miles offsets any `multimodal_train_inputs` key whose name ends in `_positions` by the sample's start in the packed sequence; slime concatenates the per-sample tensors and adds nothing. So each sample also ships its row count, and the merge rebases positions itself off the `cu_seqlens` slime handed to `PackedSeqParams`:

```python
starts = cu_seqlens[:-1]                       # sample i starts here
packed = positions + repeat_interleave(starts, row_counts)
```

A `cu_seqlens`/row-count length mismatch raises rather than writing embeddings onto the wrong tokens.

## Guardrails (each one is a silent-garbage failure mode, not a crash)

| Rejected | Why |
| --- | --- |
| `pipeline_model_parallel_size > 1` | only the first stage holds trainable parameters; later stages would build an optimizer over an empty set |
| `context_parallel_size > 1` | positions are rebased onto a tensor/sequence shard, not onto CP chunking |
| TP > 1 with `sequence_parallel=False` | the replicated projector's grads are summed over the TP group, which is the whole-sequence gradient only while each rank merges a disjoint shard |
| `use_distributed_optimizer` | that sum reads whole `main_grad` buffers; the distributed optimizer replaces them with reduce-scattered shards |
| `loss_type != "sft_loss"`, any KL term | no engines run, so there is nothing generated to score, and a KL against the frozen base is a KL against itself |

## Checkpointing and weight sync

Only the projector is written: `projector_latest.pt` is refreshed after every applied optimizer step, and `projector.save_interval` decides only which steps additionally keep a numbered file, so a run that outlives or undershoots the `train_iters` prediction still leaves the adapter it trained. Steps are counted on `optimizer.step`, so a skipped update does not shift the interval; Megatron's own `save_interval` is left far above `num_rollout` so the unchanged 35B base is never rewritten, and the projector stays out of Megatron's state dicts so the base checkpoint still loads. `ref_load` is the RL recipe's own TP2/PP2 conversion directory: slime's HF→torch_dist converter re-derives PP from the world size, so a TP2/PP1 conversion asserts, and torch_dist reshards PP2→PP1 on load anyway. Sharing it means a projector run on a model already converted for RL converts nothing.

Weight sync is out of scope by design: slime's sync walks every named parameter, so an RL variant would have to exclude the projector, and a projector's contribution to a rollout has no representation in an sglang request today. That is the follow-up if RL over a projector is wanted.

## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/ab5f6cfa095c4301b85e6d84ade73a02
Requested by: @zhouhelena1
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->