### PR TITLE
Update skills based on codegolf training

### DIFF
--- a/skills/agent-driven-training/SKILL.md
+++ b/skills/agent-driven-training/SKILL.md
@@ -25,9 +25,14 @@ when_to_use: >-
 
 ## 1. Configure and preflight
 
-If the user has not already chosen the model, dataset and reward function,
-propose an implementation for the missing pieces and ask the user to confirm
-that it matches the intended task before implementing it.
+If the user has not already chosen the model, dataset, reward function,
+topology, and final training horizon, propose the missing pieces and ask the
+user to confirm them before implementation. Present the staged plan explicitly:
+the one-step proof, the approximately 10-step smoke test, and the proposed full
+run with its model, GPU topology, important recipe settings, and maximum step
+count. Proof or smoke-test approval does not authorize the full run. Never
+infer an expensive final horizon from a vague request; launch it only after the
+user confirms that configuration and step count.
 
 Create or adapt the config only after that decision. Before spending GPU
 capacity:
@@ -88,16 +93,26 @@ Change one setting at a time and repeat the smoke test with a fresh run ID.
 
 ## 4. Promote
 
-Promote only when the proof and smoke runs are healthy and the reward remains
-informative, and trace inspection confirms that prompts and responses make
-sense for the task. Launch a fresh full run from the final config and monitor
-it until completion or an early-stop decision.
+Promote only when the proof and smoke runs are healthy, the reward remains
+informative, trace inspection confirms that prompts and responses make sense
+for the task, and the user has confirmed the final configuration and maximum
+step count. Launch a fresh full run from that exact config and monitor it until
+completion or an evidence-based early-stop decision.
 
 A full run is not a commitment to spend its entire configured horizon.
 Reassess efficacy early using both reward trajectories and sampled traces. If
-reward remains flat, declines, or is otherwise uninformative, read
+reward remains flat, declines, or is otherwise uninformative, first verify
+whether the algorithm makes that trajectory expected. Then read
 [debug-reward.md](references/debug-reward.md) and make an early-stop decision
-rather than letting a healthy but ineffective job finish by default.
+from task metrics and traces rather than letting a healthy but ineffective job
+finish by default.
+
+Keep checking every active run until it reaches a terminal state or a deliberate
+stop decision. Record the launch time, last progress time, current phase, and
+observed step duration. If startup or a step takes materially longer than the
+run's prior timings or the expected window, inspect `run get --verbose` and
+`run logs` immediately. Diagnose and fix an authorized bottleneck instead of
+continuing to wait without a new progress signal.
 
 Report the run ID, checkpoint, early-versus-late reward, task-specific success
 rate, timing, and whether all apps stopped.

--- a/skills/agent-driven-training/SKILL.md
+++ b/skills/agent-driven-training/SKILL.md
@@ -94,12 +94,11 @@ Change one setting at a time and repeat the smoke test with a fresh run ID.
 Promote only when the proof and smoke runs are healthy, the reward remains
 informative, trace inspection confirms that prompts and responses make sense
 for the task, and the user has confirmed the final configuration and maximum
-step count. Launch a fresh full run from that exact config and monitor it until completion or an evidence-based early-stop decision.
+step count. Launch a fresh full run from that exact config and monitor it until completion or an early-stop decision.
 
 A full run is not a commitment to spend its entire configured horizon.
 Reassess efficacy early using both reward trajectories and sampled traces. If
-reward remains flat, declines, or is otherwise uninformative, first verify
-whether the algorithm makes that trajectory expected. Then read
+reward remains flat, declines, or is otherwise uninformative, read
 [debug-reward.md](references/debug-reward.md) and make an early-stop decision
 from task metrics and traces rather than letting a healthy but ineffective job finish by default.
 

--- a/skills/agent-driven-training/SKILL.md
+++ b/skills/agent-driven-training/SKILL.md
@@ -27,12 +27,10 @@ when_to_use: >-
 
 If the user has not already chosen the model, dataset, reward function,
 topology, and final training horizon, propose the missing pieces and ask the
-user to confirm them before implementation. Present the staged plan explicitly:
-the one-step proof, the approximately 10-step smoke test, and the proposed full
-run with its model, GPU topology, important recipe settings, and maximum step
-count. Proof or smoke-test approval does not authorize the full run. Never
-infer an expensive final horizon from a vague request; launch it only after the
-user confirms that configuration and step count.
+user to confirm them before implementation. Present the staged plan 
+explicitly: the one-step proof, the smoke test, and the proposed full run 
+with its model, GPU topology, important recipe settings, and maximum step 
+count. Proof or smoke-test approval does not authorize the full run.
 
 Create or adapt the config only after that decision. Before spending GPU
 capacity:
@@ -96,16 +94,14 @@ Change one setting at a time and repeat the smoke test with a fresh run ID.
 Promote only when the proof and smoke runs are healthy, the reward remains
 informative, trace inspection confirms that prompts and responses make sense
 for the task, and the user has confirmed the final configuration and maximum
-step count. Launch a fresh full run from that exact config and monitor it until
-completion or an evidence-based early-stop decision.
+step count. Launch a fresh full run from that exact config and monitor it until completion or an evidence-based early-stop decision.
 
 A full run is not a commitment to spend its entire configured horizon.
 Reassess efficacy early using both reward trajectories and sampled traces. If
 reward remains flat, declines, or is otherwise uninformative, first verify
 whether the algorithm makes that trajectory expected. Then read
 [debug-reward.md](references/debug-reward.md) and make an early-stop decision
-from task metrics and traces rather than letting a healthy but ineffective job
-finish by default.
+from task metrics and traces rather than letting a healthy but ineffective job finish by default.
 
 Keep checking every active run until it reaches a terminal state or a deliberate
 stop decision. Record the launch time, last progress time, current phase, and

--- a/skills/agent-driven-training/references/debug-reward.md
+++ b/skills/agent-driven-training/references/debug-reward.md
@@ -17,7 +17,9 @@ DAPO oversamples candidates and filters groups such as all-correct or
 all-incorrect samples. Its reported reward is therefore conditioned on a
 changing retained population and need not rise monotonically. A DAPO plateau
 alone is not a stop signal; compare fixed task metrics, filter/retention counts,
-and representative traces.
+and representative traces. Use `run params` to confirm dynamic sampling,
+`run get --verbose` to inspect rollout summaries and task metrics, and
+`run trace` to inspect filtering evidence and raw samples.
 
 - Flat near chance: the model may not be learning, the signal may be sparse,
   or extraction may return zero broadly.
@@ -37,9 +39,7 @@ Set an early efficacy checkpoint proportional to the run length; for example,
 reassess a 150-step run across roughly steps 10–40. If enough comparable
 samples and fixed task metrics show that learning remains flat outside normal
 noise, declines, or is otherwise uninformative, stop the run instead of waiting
-for completion. Do not stop on a single noisy point or an algorithm-expected
-plateau, but do not keep a healthy yet ineffective job alive only because it
-has not failed.
+for completion. Do not stop on a single noisy point or an algorithm-expected plateau, but do not keep a healthy yet ineffective job alive only because it has not failed.
 
 To stop it, use `training-gym run get <run-id>` to obtain the Modal 
 app ID, then:

--- a/skills/agent-driven-training/references/debug-reward.md
+++ b/skills/agent-driven-training/references/debug-reward.md
@@ -12,6 +12,13 @@ training-gym run get <run-id> --verbose
 Compare the baseline, early steps, recent steps, sample counts, and variance.
 Do not infer learning from the final value alone.
 
+Before interpreting the curve, identify what population the algorithm reports.
+DAPO oversamples candidates and filters groups such as all-correct or
+all-incorrect samples. Its reported reward is therefore conditioned on a
+changing retained population and need not rise monotonically. A DAPO plateau
+alone is not a stop signal; compare fixed task metrics, filter/retention counts,
+and representative traces.
+
 - Flat near chance: the model may not be learning, the signal may be sparse,
   or extraction may return zero broadly.
 - Declining: inspect regressions, truncation, instability, and whether the
@@ -27,11 +34,12 @@ separate saturation from normal variance.
 ## Decide whether to stop an active run
 
 Set an early efficacy checkpoint proportional to the run length; for example,
-reassess a 150-step run across roughly steps 10–40. If enough samples show that
-reward remains flat outside normal noise, declines, or is otherwise
-uninformative, stop the run instead of waiting for completion. Do not stop on a
-single noisy point, but do not keep a healthy yet ineffective job alive only
-because it has not failed.
+reassess a 150-step run across roughly steps 10–40. If enough comparable
+samples and fixed task metrics show that learning remains flat outside normal
+noise, declines, or is otherwise uninformative, stop the run instead of waiting
+for completion. Do not stop on a single noisy point or an algorithm-expected
+plateau, but do not keep a healthy yet ineffective job alive only because it
+has not failed.
 
 To stop it, use `training-gym run get <run-id>` to obtain the Modal 
 app ID, then:
@@ -76,6 +84,8 @@ false positive or false negative.
   do not launch a full horizon to produce an uninformative curve.
 - Sparse but valid signal: adjust one reward or sampling choice and repeat the
   smoke test.
+- Base model almost never crosses a required correctness gate: propose a
+  stronger model or a justified graded signal/curriculum, then repeat the proof.
 - Model behavior problem: change one training setting and compare fresh runs
   over equivalent steps and samples.
 

--- a/skills/agent-driven-training/references/debug-reward.md
+++ b/skills/agent-driven-training/references/debug-reward.md
@@ -13,13 +13,13 @@ Compare the baseline, early steps, recent steps, sample counts, and variance.
 Do not infer learning from the final value alone.
 
 Before interpreting the curve, identify what population the algorithm reports.
-DAPO oversamples candidates and filters groups such as all-correct or
-all-incorrect samples. Its reported reward is therefore conditioned on a
-changing retained population and need not rise monotonically. A DAPO plateau
-alone is not a stop signal; compare fixed task metrics, filter/retention counts,
-and representative traces. Use `run params` to confirm dynamic sampling,
-`run get --verbose` to inspect rollout summaries and task metrics, and
-`run trace` to inspect filtering evidence and raw samples.
+Algorithms that oversample or dynamically filter candidates may report reward
+over a changing retained population, so their reward need not rise
+monotonically. DAPO is one example. A plateau alone is not a stop signal;
+compare fixed task metrics, filter/retention counts, and representative traces.
+Use `run params` to confirm the sampling configuration, `run get --verbose` to
+inspect rollout summaries and task metrics, and `run trace` to inspect
+filtering evidence and raw samples.
 
 - Flat near chance: the model may not be learning, the signal may be sparse,
   or extraction may return zero broadly.
@@ -39,7 +39,8 @@ Set an early efficacy checkpoint proportional to the run length; for example,
 reassess a 150-step run across roughly steps 10–40. If enough comparable
 samples and fixed task metrics show that learning remains flat outside normal
 noise, declines, or is otherwise uninformative, stop the run instead of waiting
-for completion. Do not stop on a single noisy point or an algorithm-expected plateau, but do not keep a healthy yet ineffective job alive only because it has not failed.
+for completion. Do not stop on a single noisy point or an algorithm-expected plateau, 
+but do not keep a healthy yet ineffective job alive only because it has not failed.
 
 To stop it, use `training-gym run get <run-id>` to obtain the Modal 
 app ID, then:

--- a/skills/agent-driven-training/references/debug-reward.md
+++ b/skills/agent-driven-training/references/debug-reward.md
@@ -85,7 +85,7 @@ false positive or false negative.
 - Sparse but valid signal: adjust one reward or sampling choice and repeat the
   smoke test.
 - Base model almost never crosses a required correctness gate: propose a
-  stronger model or a justified graded signal/curriculum, then repeat the proof.
+  stronger model or a justified graded signal/curriculum.
 - Model behavior problem: change one training setting and compare fresh runs
   over equivalent steps and samples.
 


### PR DESCRIPTION
from codegolf agent training:

- agent wrongly cancelled a run because it saw reward plateauing but for dapo, reward is based on oversampled and filtered samples, so reward over time is not sufficient to conclude early stop
- often agent starts a monitor with some broken config and because it doesn't fire, the monitor is just broken the whole time -> so be clear in skill about ACTIVELY monitoring the runs, not just passively so (that way, it detects broken configs without wasting as much time)
- add full run final experiment config (e.g. num rollouts/steps) to user confirmation prompt for vague prompts