### PR TITLE
Redeploy the dashboard on merges to main

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -1,0 +1,75 @@
+name: Dashboard Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/dashboard-deploy.yml"
+      - "dashboards/**"
+      - "modal_training_gym/**"
+      - "pyproject.toml"
+      - "uv.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dashboard-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: modal-deploy
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      MODAL_ENVIRONMENT: training-gym
+      # Proxy-auth pair the dashboard needs to call authenticated endpoints.
+      MODAL_KEY: ${{ secrets.MODAL_KEY }}
+      MODAL_SECRET: ${{ secrets.MODAL_SECRET }}
+      UV_CACHE_DIR: /tmp/uv-cache
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Sync dependencies
+        run: uv sync
+
+      # The proxy-auth mode is a property of the deployment, not of the code, so
+      # it has to be stated explicitly — deploying in the wrong mode silently
+      # changes who can reach the dashboard.
+      - name: Check deploy configuration
+        run: |
+          case "${DASHBOARD_PROXY_AUTH}" in
+            true)
+              if [ -z "${MODAL_KEY}" ] || [ -z "${MODAL_SECRET}" ]; then
+                echo "DASHBOARD_PROXY_AUTH=true requires the MODAL_KEY and MODAL_SECRET secrets." >&2
+                exit 1
+              fi
+              ;;
+            false) ;;
+            *)
+              echo "Set the DASHBOARD_PROXY_AUTH repository variable to 'true' or 'false'." >&2
+              exit 1
+              ;;
+          esac
+        env:
+          DASHBOARD_PROXY_AUTH: ${{ vars.DASHBOARD_PROXY_AUTH }}
+
+      - name: Deploy dashboard to Modal
+        run: |
+          if [ "${DASHBOARD_PROXY_AUTH}" = "true" ]; then
+            uv run scripts/deploy_dashboard.py --proxy-auth
+          else
+            uv run scripts/deploy_dashboard.py --no-proxy-auth
+          fi
+        env:
+          DASHBOARD_PROXY_AUTH: ${{ vars.DASHBOARD_PROXY_AUTH }}

--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -9,6 +9,7 @@ on:
       - "dashboards/**"
       - "modal_training_gym/**"
       - "pyproject.toml"
+      - "scripts/deploy_dashboard.py"
       - "uv.lock"
   workflow_dispatch:
 
@@ -21,6 +22,9 @@ concurrency:
 
 jobs:
   deploy:
+    # `workflow_dispatch` can be launched from any ref; the deployed dashboard
+    # is a single shared app, so only main ever reaches it.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: modal-deploy
     env:

--- a/scripts/deploy_dashboard.py
+++ b/scripts/deploy_dashboard.py
@@ -1,0 +1,41 @@
+"""Deploy the training-gym dashboard non-interactively (used by CI).
+
+`modal deploy dashboards/app.py` always registers the ASGI app without proxy
+auth, so the deploy goes through the CLI's `setup()`, which honours the
+requested mode and provisions the `_training-gym-modal-creds` Secret the
+dashboard uses to stream logs from training apps.
+
+Usage:
+    python scripts/deploy_dashboard.py --proxy-auth
+    python scripts/deploy_dashboard.py --no-proxy-auth
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from modal_training_gym.cli.setup import setup
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--proxy-auth",
+        dest="proxy_auth",
+        action="store_true",
+        help="Require Modal proxy authentication for the dashboard.",
+    )
+    group.add_argument(
+        "--no-proxy-auth",
+        dest="proxy_auth",
+        action="store_false",
+        help="Deploy the dashboard without Modal proxy authentication.",
+    )
+    args = parser.parse_args()
+
+    setup(require_proxy_auth=args.proxy_auth, interactive=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `Dashboard Deploy`, a push-to-`main` workflow that redeploys `training-gym-dashboard`, mirroring the `deploy` job in `docs.yml` (`modal-deploy` environment, `MODAL_ENVIRONMENT: training-gym`). Path-filtered on `dashboards/**` and `modal_training_gym/**` since the dashboard image bundles the package, plus `workflow_dispatch` for manual redeploys (job gated on `refs/heads/main` — the dashboard is one shared app, so no other ref should reach it). No frontend build step: the image builds the Svelte SPA itself.


Link to Devin session: https://modal.devinenterprise.com/sessions/b32011a4266842a9ba76fcf2795b5e2c
Requested by: @joyliu-q