### PR TITLE
Distinguish log-prob timing passes by store_prefix

### DIFF
--- a/dashboards/frontend/src/lib/timing.test.js
+++ b/dashboards/frontend/src/lib/timing.test.js
@@ -2,6 +2,19 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { clipIdleSpans, nestedHitTargetsForRow, runTimeline } from "./timing.js";
+import { categoryOf, colorFor, labelFor } from "./timing_vocabulary.js";
+
+test("phase variants inherit vocabulary and add a readable label suffix", () => {
+  assert.equal(categoryOf("compute_log_probs:ref"), "train");
+  assert.equal(colorFor("compute_log_probs:ref"), colorFor("compute_log_probs"));
+  assert.equal(labelFor("compute_log_probs:ref"), "Calculate log probs (ref)");
+  assert.equal(categoryOf("compute_log_probs"), "train");
+  assert.equal(
+    colorFor("compute_log_probs"),
+    "var(--color-c-dataviz-train-large)",
+  );
+  assert.equal(labelFor("compute_log_probs"), "Calculate log probs");
+});
 
 test("nested hit targets cover drawn bars without entering siblings", () => {
   const bars = [

--- a/dashboards/frontend/src/lib/timing_geometry.js
+++ b/dashboards/frontend/src/lib/timing_geometry.js
@@ -5,6 +5,7 @@ import {
   NEGLIGIBLE_WORK_S,
   SAMPLED,
   TOOLTIP_HIDDEN_PHASES,
+  basePhaseName,
 } from "./timing_vocabulary.js";
 import {
   collect,
@@ -25,7 +26,9 @@ const COLLAPSED_GAP_FRACTION = 0.02;
 const BREAK_LABEL_GAP_PX = 4;
 
 export function isRenderedTimingSpan(span) {
-  return !span.mergedGeneration && !HIDDEN_PHASES.has(span.name);
+  return (
+    !span.mergedGeneration && !HIDDEN_PHASES.has(basePhaseName(span.name))
+  );
 }
 
 export function breakLabelLayout(
@@ -63,7 +66,7 @@ export function mergeSyncGenerationSpans(spans) {
       .filter(
         (span) =>
           span.role === "driver" &&
-          span.name === "generate_rollouts" &&
+          basePhaseName(span.name) === "generate_rollouts" &&
           span.rolloutId != null,
       )
       .map((span) => [span.rolloutId, span]),
@@ -73,7 +76,7 @@ export function mergeSyncGenerationSpans(spans) {
       .filter(
         (span) =>
           span.role === "rollout" &&
-          span.name === "generate_samples" &&
+          basePhaseName(span.name) === "generate_samples" &&
           span.rolloutId != null,
       )
       .map((span) => span.rolloutId),
@@ -82,7 +85,7 @@ export function mergeSyncGenerationSpans(spans) {
     const sampleGeneration =
       wrapper
         ? nestedChild(wrapper, "sample_generation")
-        : span.name === "sample_generation"
+        : basePhaseName(span.name) === "sample_generation"
           ? span
           : null;
     const aggregateStats = Object.fromEntries(
@@ -122,11 +125,11 @@ export function mergeSyncGenerationSpans(spans) {
       }
     };
     if (sampleGeneration) accumulate("sample_generation", sampleGeneration);
-    if (!wrapper && span.name !== "sample_generation") {
+    if (!wrapper && basePhaseName(span.name) !== "sample_generation") {
       accumulate(span.name, span);
     }
     for (const descendant of descendants) {
-      if (!TOOLTIP_HIDDEN_PHASES.has(descendant.name)) {
+      if (!TOOLTIP_HIDDEN_PHASES.has(basePhaseName(descendant.name))) {
         const duration = descendant.duration ?? descendant.end - descendant.start;
         accumulate(descendant.name, {
           ...descendant,
@@ -158,11 +161,14 @@ export function mergeSyncGenerationSpans(spans) {
     if (span.role !== "rollout") continue;
     const driver = drivers.get(span.rolloutId);
     if (!driver) continue;
-    if (span.name === "generate_samples") {
+    if (basePhaseName(span.name) === "generate_samples") {
       mergeGeneration(span, driver, span);
       continue;
     }
-    if (!SAMPLED.has(span.name) && span.name !== "reward_post_process") {
+    if (
+      !SAMPLED.has(basePhaseName(span.name)) &&
+      basePhaseName(span.name) !== "reward_post_process"
+    ) {
       continue;
     }
     if (rolloutGenerationWrappers.has(span.rolloutId)) {
@@ -175,7 +181,7 @@ export function mergeSyncGenerationSpans(spans) {
 
 function nestedChild(span, name) {
   for (const child of span.children || []) {
-    if (child.name === name) return child;
+    if (basePhaseName(child.name) === name) return child;
     const nested = nestedChild(child, name);
     if (nested) return nested;
   }
@@ -557,7 +563,9 @@ export function runTimeline(
   const steps = stepsOf(measured);
   const rawSpans = measured;
   const sync = rawSpans.some(
-    (span) => span.role === "driver" && span.name === "generate_rollouts",
+    (span) =>
+      span.role === "driver" &&
+      basePhaseName(span.name) === "generate_rollouts",
   );
   const async =
     asyncOverride ?? isAsyncSpans(rawSpans);

--- a/dashboards/frontend/src/lib/timing_spans.js
+++ b/dashboards/frontend/src/lib/timing_spans.js
@@ -6,6 +6,7 @@ import {
   NEGLIGIBLE_WORK_S,
   SAMPLED,
   TOOLTIP_HIDDEN_PHASES,
+  basePhaseName,
   categoryOf,
   labelFor,
   rolloutIdForTimingKey,
@@ -34,7 +35,7 @@ export function collect(timings) {
           ? phase.invocations
           : [];
         const runs =
-          !SAMPLED.has(name) && invocations.length === count
+          !SAMPLED.has(basePhaseName(name)) && invocations.length === count
             ? invocations
             : [];
         if (runs.length) {
@@ -44,7 +45,7 @@ export function collect(timings) {
             spans.push({
               ...where,
               laneKey: `${id}:${role}`,
-              kind: IDLE_PHASES.has(name) ? "idle" : "work",
+              kind: IDLE_PHASES.has(basePhaseName(name)) ? "idle" : "work",
               start,
               end,
               clockStart: start,
@@ -59,9 +60,9 @@ export function collect(timings) {
         spans.push({
           ...where,
           laneKey: `${id}:${role}`,
-          kind: IDLE_PHASES.has(name)
+          kind: IDLE_PHASES.has(basePhaseName(name))
             ? "idle"
-            : SAMPLED.has(name) || count > 1
+            : SAMPLED.has(basePhaseName(name)) || count > 1
               ? "sampled"
               : "work",
           start: laneStart + (Number(phase?.first_start_s) || 0),
@@ -206,7 +207,10 @@ export function isAsyncSpans(spans) {
   for (const span of spans) {
     if (span.role === "rollout") {
       hasRollout = true;
-    } else if (span.role === "driver" && span.name === "generate_rollouts") {
+    } else if (
+      span.role === "driver" &&
+      basePhaseName(span.name) === "generate_rollouts"
+    ) {
       sync = true;
     }
   }
@@ -232,7 +236,10 @@ export function groupTooltipChildren(children, aggregateStats = {}) {
   const rolesByName = new Map();
   const workerRoles = new Set();
   for (const child of allChildren) {
-    if (child.mergedGeneration || TOOLTIP_HIDDEN_PHASES.has(child.name)) {
+    if (
+      child.mergedGeneration ||
+      TOOLTIP_HIDDEN_PHASES.has(basePhaseName(child.name))
+    ) {
       continue;
     }
     const roles = rolesByName.get(child.name) || new Set();
@@ -245,7 +252,10 @@ export function groupTooltipChildren(children, aggregateStats = {}) {
   const allWorkerRolesPresent =
     workerRoles.has("actor") && workerRoles.has("critic");
   for (const child of allChildren) {
-    if (child.mergedGeneration || TOOLTIP_HIDDEN_PHASES.has(child.name)) {
+    if (
+      child.mergedGeneration ||
+      TOOLTIP_HIDDEN_PHASES.has(basePhaseName(child.name))
+    ) {
       continue;
     }
     const count = child.count || 1;
@@ -322,15 +332,15 @@ export function nest(spans) {
   }
   for (const span of ordered) {
     let parent = null;
-    for (const parentName of NESTS_IN[span.name] || []) {
+    for (const parentName of NESTS_IN[basePhaseName(span.name)] || []) {
       for (const other of byRolloutAndName.get(
         `${span.rolloutId}:${parentName}`,
       ) || []) {
         if (
           other !== span &&
           (other.group === span.group ||
-            (span.name === "generate_samples" &&
-              other.name === "generate_rollouts")) &&
+            (basePhaseName(span.name) === "generate_samples" &&
+              basePhaseName(other.name) === "generate_rollouts")) &&
           (other.laneKey === span.laneKey
             ? other.start <= span.start && span.end <= other.end
             : other.start <= span.start + CROSS_LANE_CONTAINMENT_TOLERANCE_S &&
@@ -352,15 +362,16 @@ export function nest(spans) {
   for (const span of ordered) {
     const occurrences = new Map();
     for (const child of [...span.children].sort((a, b) => a.start - b.start)) {
-      if (!["forward_backward", "optimizer_step"].includes(child.name)) continue;
-      const occurrence = (occurrences.get(child.name) || 0) + 1;
-      occurrences.set(child.name, occurrence);
+      const childBase = basePhaseName(child.name);
+      if (!["forward_backward", "optimizer_step"].includes(childBase)) continue;
+      const occurrence = (occurrences.get(childBase) || 0) + 1;
+      occurrences.set(childBase, occurrence);
       child.ordinal = occurrence;
     }
     const duration = Math.max(span.end - span.start, 0);
     const aggregates = new Map();
     for (const child of span.children) {
-      if (!SAMPLED.has(child.name)) {
+      if (!SAMPLED.has(basePhaseName(child.name))) {
         continue;
       }
       const childDuration = Math.max(child.end - child.start, 0);
@@ -388,7 +399,7 @@ export function nest(spans) {
       aggregates.set(child.name, current);
     }
     const children = span.children.filter(
-      (child) => !SAMPLED.has(child.name),
+      (child) => !SAMPLED.has(basePhaseName(child.name)),
     );
     for (const child of aggregates.values()) {
       children.push({

--- a/dashboards/frontend/src/lib/timing_vocabulary.js
+++ b/dashboards/frontend/src/lib/timing_vocabulary.js
@@ -136,7 +136,7 @@ export const PHASE_DESCRIPTIONS = {
 };
 
 export function descriptionFor(name) {
-  return PHASE_DESCRIPTIONS[name] || null;
+  return PHASE_DESCRIPTIONS[basePhaseName(name)] || null;
 }
 
 export const IDLE_PHASES = new Set([
@@ -180,17 +180,29 @@ export const GROUPS = [
 
 export const NEGLIGIBLE_WORK_S = 0.0005;
 export const CROSS_LANE_CONTAINMENT_TOLERANCE_S = 0.01;
+
+export function basePhaseName(name) {
+  if (typeof name !== "string") return name;
+  const separator = name.indexOf(":");
+  return separator === -1 ? name : name.slice(0, separator);
+}
+
 export function labelFor(name, rolloutId = null) {
+  const base = basePhaseName(name);
+  const variant = name.slice(base.length + 1);
   if (
-    (name === "wait_for_rollout" || name === "wait_for_next_rollout") &&
+    (base === "wait_for_rollout" || base === "wait_for_next_rollout") &&
     rolloutId != null
   ) {
-    const step = Number(rolloutId) + (name === "wait_for_next_rollout" ? 2 : 1);
+    const step =
+      Number(rolloutId) + (base === "wait_for_next_rollout" ? 2 : 1);
     if (Number.isInteger(step)) {
-      return `Waiting for rollout generation (step ${step})`;
+      const label = `Waiting for rollout generation (step ${step})`;
+      return variant ? `${label} (${variant.replace(/_/g, " ")})` : label;
     }
   }
-  return TIMING_LABELS[name] || name.replace(/_/g, " ");
+  const label = TIMING_LABELS[base] || base.replace(/_/g, " ");
+  return variant ? `${label} (${variant.replace(/_/g, " ")})` : label;
 }
 
 export function isLegacyTiming(timings) {
@@ -230,7 +242,7 @@ export function shouldShowOpenRolloutAction({
     showOpenRollout &&
     typeof onOpenRollout === "function" &&
     bar &&
-    ["generate_samples", "generate_rollouts"].includes(bar.name) &&
+    ["generate_samples", "generate_rollouts"].includes(basePhaseName(bar.name)) &&
     bar.kind !== "idle" &&
     rolloutId != null &&
     rolloutIds.includes(rolloutId),
@@ -238,11 +250,12 @@ export function shouldShowOpenRolloutAction({
 }
 
 export function categoryOf(name) {
-  return PHASE_CATEGORY[name] || "idle";
+  return PHASE_CATEGORY[basePhaseName(name)] || "idle";
 }
 
 export function colorFor(name) {
-  return PHASE_COLORS[name] || CATEGORIES[categoryOf(name)].color;
+  const base = basePhaseName(name);
+  return PHASE_COLORS[base] || CATEGORIES[categoryOf(base)].color;
 }
 
 export function fmtSecs(s, unit = null) {

--- a/modal_training_gym/common/step_timing.py
+++ b/modal_training_gym/common/step_timing.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, model_validator
 from modal_training_gym.common.status import SlimeStatus
 from modal_training_gym.common.timing_recorder import (
     MAX_PHASE_INVOCATIONS,
+    MAX_PHASE_NAME_LENGTH,
     MAX_TIMING_PHASES,
     trim_invocation_lists,
 )
@@ -19,8 +20,6 @@ from modal_training_gym.utils.metadata import (
 )
 
 MAX_ROLLOUT_ID = 1_000_000
-# Keep phase names bounded because they become per-record JSON object keys.
-MAX_PHASE_NAME_LENGTH = 128
 
 
 class Role(str, Enum):

--- a/modal_training_gym/common/timing_recorder.py
+++ b/modal_training_gym/common/timing_recorder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import threading
 import time
 from contextlib import contextmanager
@@ -16,10 +17,25 @@ TIMING_DEBUG_ENV = "TRAINING_GYM_TIMING_DEBUG"
 MIN_PUBLISH_INTERVAL_S = 3.0
 MAX_PHASE_INVOCATIONS = 10_000
 MAX_TIMING_PHASES = 64
+# Keep phase names bounded because they become per-record JSON object keys.
+MAX_PHASE_NAME_LENGTH = 128
 # Keep posted invocation detail bounded without changing measured aggregates.
 MAX_TOTAL_INVOCATIONS = 20_000
 
 PER_SAMPLE_PHASES = frozenset({"reward", "reward_batch", "sample_generation"})
+
+
+def variant_phase(base: str, variant: str | None) -> str:
+    """Add a normalized variant to a phase name without exceeding the limit."""
+    if not variant:
+        return base
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", variant.strip()).strip("_")
+    if not normalized:
+        return base
+    available = MAX_PHASE_NAME_LENGTH - len(base) - 2
+    if available <= 0:
+        return base[: MAX_PHASE_NAME_LENGTH - 1]
+    return f"{base}:{normalized[:available]}"
 
 
 def _timing_debug(event: str, **fields: object) -> None:
@@ -354,8 +370,10 @@ reporting.register_pre_drain_hook(_close_preloop_recorders)
 
 
 __all__ = [
+    "MAX_PHASE_NAME_LENGTH",
     "RoleRecorder",
     "time_phase",
     "recording_lane",
     "recording_lane_on_reporting_rank",
+    "variant_phase",
 ]

--- a/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
+++ b/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 PREAMBLE_MARKER = "PATCHED_TRAINING_GYM_TIMING_PREAMBLE"
 RECORDER_MARKER = "PATCHED_TRAINING_GYM_TIMING_RECORDER"
+BlockSpec = tuple[str, str] | tuple[str, str, str]
 
 
 def phase_marker(phase: str) -> str:
@@ -214,7 +215,7 @@ class PackageTarget:
 
     path: str
     scope: tuple[str, str, str] | None
-    blocks: tuple[tuple[str, str], ...]
+    blocks: tuple[BlockSpec, ...]
 
 
 # status patcher runs first, so the anchors are the upstream lines.
@@ -413,6 +414,7 @@ PACKAGE_TARGETS: tuple[PackageTarget, ...] = (
                 "                rollout_id=rollout_id,\n"
                 "                store_prefix=store_prefix,\n"
                 "            )\n",
+                "_tg_variant_phase('compute_log_probs', store_prefix)",
             ),
             (
                 "trainer_finalize",
@@ -544,12 +546,9 @@ def _patch_package_file(root: Path, target: PackageTarget) -> None:
         print(f"{target.path} already patched for substep timing")
         return
 
-    for phase, block in target.blocks:
-        phase_expr = (
-            "_tg_variant_phase('compute_log_probs', store_prefix)"
-            if phase == "compute_log_probs"
-            else None
-        )
+    for block_spec in target.blocks:
+        phase, block = block_spec[:2]
+        phase_expr = block_spec[2] if len(block_spec) == 3 else None
         src = replace_once(
             src,
             block,
@@ -560,7 +559,11 @@ def _patch_package_file(root: Path, target: PackageTarget) -> None:
         src = wrap_scope(src, target.scope, path)  # last: it reindents the body
     src = _inject_preamble(src)
 
-    missing = [phase for phase, _ in target.blocks if phase_marker(phase) not in src]
+    missing = [
+        phase
+        for phase, _ in (block_spec[:2] for block_spec in target.blocks)
+        if phase_marker(phase) not in src
+    ]
     if missing:
         raise RuntimeError(f"{path}: phases not instrumented: {missing}")
     if target.scope is not None and RECORDER_MARKER not in src:

--- a/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
+++ b/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
@@ -36,6 +36,7 @@ PREAMBLE = (
     "        recording_lane as _tg_role,\n"
     "        recording_lane_on_reporting_rank as _tg_mrec,\n"
     "        time_phase as _tg_time_phase,\n"
+    "        variant_phase as _tg_variant_phase,\n"
     "    )\n"
     "except ImportError:\n"
     "    print('WARNING: modal_training_gym not importable; substep timing off')\n"
@@ -63,6 +64,9 @@ PREAMBLE = (
     "    @_tg_cm\n"
     "    def _tg_time_phase(name):\n"
     "        yield\n"
+    "\n"
+    "    def _tg_variant_phase(base, variant):\n"
+    "        return base\n"
     "\n"
 )
 
@@ -112,8 +116,13 @@ def indent_block(block: str) -> str:
     return "\n".join(f"    {ln}" if ln.strip() else ln for ln in block.splitlines())
 
 
-def wrap_block(block: str, phase: str, opener: str = "_tg_rec.phase") -> str:
-    """Wrap a block in ``with <opener>('<phase>'):``.
+def wrap_block(
+    block: str,
+    phase: str,
+    opener: str = "_tg_rec.phase",
+    phase_expr: str | None = None,
+) -> str:
+    """Wrap a block in ``with <opener>(<phase>):``.
 
     For a bare ``if``, only the body is wrapped, so a skipped branch records
     nothing instead of a ~0s bar for work that never ran. An ``if/else`` is
@@ -134,7 +143,8 @@ def wrap_block(block: str, phase: str, opener: str = "_tg_rec.phase") -> str:
     return (
         head
         + f"{indent}# {phase_marker(phase)}\n"
-        + f"{indent}with {opener}('{phase}'):\n{indent_block(body)}\n"
+        + f"{indent}with {opener}({phase_expr or repr(phase)}):\n"
+        + f"{indent_block(body)}\n"
     )
 
 
@@ -535,7 +545,17 @@ def _patch_package_file(root: Path, target: PackageTarget) -> None:
         return
 
     for phase, block in target.blocks:
-        src = replace_once(src, block, wrap_block(block, phase, "_tg_time_phase"), path)
+        phase_expr = (
+            "_tg_variant_phase('compute_log_probs', store_prefix)"
+            if phase == "compute_log_probs"
+            else None
+        )
+        src = replace_once(
+            src,
+            block,
+            wrap_block(block, phase, "_tg_time_phase", phase_expr),
+            path,
+        )
     if target.scope is not None:
         src = wrap_scope(src, target.scope, path)  # last: it reindents the body
     src = _inject_preamble(src)

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_substep_timing.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_substep_timing.py
@@ -36,6 +36,7 @@ PREAMBLE = (
     "        recording_lane as _tg_role,\n"
     "        recording_lane_on_reporting_rank as _tg_mrec,\n"
     "        time_phase as _tg_time_phase,\n"
+    "        variant_phase as _tg_variant_phase,\n"
     "    )\n"
     "except ImportError:\n"
     "    print('WARNING: modal_training_gym not importable; substep timing off')\n"
@@ -63,6 +64,9 @@ PREAMBLE = (
     "    @_tg_cm\n"
     "    def _tg_time_phase(name):\n"
     "        yield\n"
+    "\n"
+    "    def _tg_variant_phase(base, variant):\n"
+    "        return base\n"
     "\n"
 )
 
@@ -112,8 +116,13 @@ def indent_block(block: str) -> str:
     return "\n".join(f"    {ln}" if ln.strip() else ln for ln in block.splitlines())
 
 
-def wrap_block(block: str, phase: str, opener: str = "_tg_rec.phase") -> str:
-    """Wrap a block in ``with <opener>('<phase>'):``.
+def wrap_block(
+    block: str,
+    phase: str,
+    opener: str = "_tg_rec.phase",
+    phase_expr: str | None = None,
+) -> str:
+    """Wrap a block in ``with <opener>(<phase>):``.
 
     For a bare ``if``, only the body is wrapped, so a skipped branch records
     nothing instead of a ~0s bar for work that never ran. An ``if/else`` is
@@ -134,7 +143,8 @@ def wrap_block(block: str, phase: str, opener: str = "_tg_rec.phase") -> str:
     return (
         head
         + f"{indent}# {phase_marker(phase)}\n"
-        + f"{indent}with {opener}('{phase}'):\n{indent_block(body)}\n"
+        + f"{indent}with {opener}({phase_expr or repr(phase)}):\n"
+        + f"{indent_block(body)}\n"
     )
 
 
@@ -589,7 +599,17 @@ def _patch_package_file(root: Path, target: PackageTarget) -> None:
         return
 
     for phase, block in target.blocks:
-        src = replace_once(src, block, wrap_block(block, phase, "_tg_time_phase"), path)
+        phase_expr = (
+            "_tg_variant_phase('compute_log_probs', store_prefix)"
+            if phase == "compute_log_probs"
+            else None
+        )
+        src = replace_once(
+            src,
+            block,
+            wrap_block(block, phase, "_tg_time_phase", phase_expr),
+            path,
+        )
     if target.scope is not None:
         src = wrap_scope(src, target.scope, path)  # last: it reindents the body
     src = _inject_preamble(src)

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_substep_timing.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_substep_timing.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 PREAMBLE_MARKER = "PATCHED_TRAINING_GYM_TIMING_PREAMBLE"
 RECORDER_MARKER = "PATCHED_TRAINING_GYM_TIMING_RECORDER"
+BlockSpec = tuple[str, str] | tuple[str, str, str]
 
 
 def phase_marker(phase: str) -> str:
@@ -362,7 +363,7 @@ class PackageTarget:
 
     path: str
     scope: tuple[str, str, str] | None
-    blocks: tuple[tuple[str, str], ...]
+    blocks: tuple[BlockSpec, ...]
 
 
 # The rollout worker: one lane per generate call.
@@ -461,6 +462,7 @@ ACTOR_TARGET = PackageTarget(
             "                store_prefix=store_prefix,\n"
             "                use_rollout_top_p_replay=True,\n"
             "            )\n",
+            "_tg_variant_phase('compute_log_probs', store_prefix)",
         ),
         (
             "trainer_finalize",
@@ -598,12 +600,9 @@ def _patch_package_file(root: Path, target: PackageTarget) -> None:
         print(f"{target.path} already patched for substep timing")
         return
 
-    for phase, block in target.blocks:
-        phase_expr = (
-            "_tg_variant_phase('compute_log_probs', store_prefix)"
-            if phase == "compute_log_probs"
-            else None
-        )
+    for block_spec in target.blocks:
+        phase, block = block_spec[:2]
+        phase_expr = block_spec[2] if len(block_spec) == 3 else None
         src = replace_once(
             src,
             block,
@@ -614,7 +613,11 @@ def _patch_package_file(root: Path, target: PackageTarget) -> None:
         src = wrap_scope(src, target.scope, path)  # last: it reindents the body
     src = _inject_preamble(src)
 
-    missing = [phase for phase, _ in target.blocks if phase_marker(phase) not in src]
+    missing = [
+        phase
+        for phase, _ in (block_spec[:2] for block_spec in target.blocks)
+        if phase_marker(phase) not in src
+    ]
     if missing:
         raise RuntimeError(f"{path}: phases not instrumented: {missing}")
     if target.scope is not None and RECORDER_MARKER not in src:

--- a/tests/test_substep_timing_patch.py
+++ b/tests/test_substep_timing_patch.py
@@ -234,7 +234,8 @@ def test_miles_package_patch_matches_golden(
     assert patched == golden_path.read_text(), (
         f"golden mismatch for {golden}; rerun with --rewrite to accept"
     )
-    for phase, _ in target.blocks:
+    for block_spec in target.blocks:
+        phase = block_spec[0]
         if phase == "compute_log_probs":
             assert (
                 "with _tg_time_phase(_tg_variant_phase("
@@ -267,7 +268,8 @@ def test_slime_package_patch_matches_golden(
     assert patched == golden_path.read_text(), (
         f"golden mismatch for {golden}; rerun with --rewrite to accept"
     )
-    for phase, _ in target.blocks:
+    for block_spec in target.blocks:
+        phase = block_spec[0]
         if phase == "compute_log_probs":
             assert (
                 "with _tg_time_phase(_tg_variant_phase("

--- a/tests/test_substep_timing_patch.py
+++ b/tests/test_substep_timing_patch.py
@@ -235,7 +235,13 @@ def test_miles_package_patch_matches_golden(
         f"golden mismatch for {golden}; rerun with --rewrite to accept"
     )
     for phase, _ in target.blocks:
-        assert f"with _tg_time_phase('{phase}'):" in patched
+        if phase == "compute_log_probs":
+            assert (
+                "with _tg_time_phase(_tg_variant_phase("
+                "'compute_log_probs', store_prefix)):"
+            ) in patched
+        else:
+            assert f"with _tg_time_phase('{phase}'):" in patched
     if target.scope is not None:
         assert "_tg_role('rollout', rollout_id)" in patched or "_tg_mrec(" in patched
     compile(patched, path, "exec")
@@ -262,7 +268,13 @@ def test_slime_package_patch_matches_golden(
         f"golden mismatch for {golden}; rerun with --rewrite to accept"
     )
     for phase, _ in target.blocks:
-        assert f"with _tg_time_phase('{phase}'):" in patched
+        if phase == "compute_log_probs":
+            assert (
+                "with _tg_time_phase(_tg_variant_phase("
+                "'compute_log_probs', store_prefix)):"
+            ) in patched
+        else:
+            assert f"with _tg_time_phase('{phase}'):" in patched
     if target.scope is not None:
         assert "_tg_role('rollout', rollout_id)" in patched or "_tg_mrec(" in patched
     compile(patched, path, "exec")
@@ -395,6 +407,27 @@ def test_per_sample_generation_target_wraps_only_generation_branch(
     assert patched.index("with _tg_time_phase('sample_generation'):") < patched.index(
         "with _tg_time_phase('reward'):"
     )
+    compile(patched, str(work), "exec")
+
+
+@pytest.mark.parametrize("framework", ["miles", "slime"])
+def test_log_prob_phase_uses_store_prefix_variant(patchers, tmp_path, framework):
+    patcher = patchers[framework]
+    target = next(
+        target
+        for target in patcher.PACKAGE_TARGETS
+        if target.path.endswith("backends/megatron_utils/actor.py")
+    )
+    work = tmp_path / target.path
+    work.parent.mkdir(parents=True)
+    work.write_text((TESTDATA / f"{framework}/actor.py.input").read_text())
+    patcher.patch_package_file(tmp_path, target)
+    patched = work.read_text()
+    assert (
+        "with _tg_time_phase(_tg_variant_phase('compute_log_probs', store_prefix)):"
+        in patched
+    )
+    assert "# PATCHED_TRAINING_GYM_TIMING_COMPUTE_LOG_PROBS" in patched
     compile(patched, str(work), "exec")
 
 

--- a/tests/test_timing_recorder.py
+++ b/tests/test_timing_recorder.py
@@ -8,7 +8,11 @@ from types import ModuleType
 from modal_training_gym.common import reporting
 from modal_training_gym.common import timing_recorder
 from modal_training_gym.common.step_timing import RoleTimingRecord
-from modal_training_gym.common.timing_recorder import RoleRecorder
+from modal_training_gym.common.timing_recorder import (
+    MAX_PHASE_NAME_LENGTH,
+    RoleRecorder,
+    variant_phase,
+)
 
 
 def _configure(monkeypatch):
@@ -17,6 +21,17 @@ def _configure(monkeypatch):
     monkeypatch.setenv("TRAINING_GYM_FRAMEWORK_STATUS_URL", "https://dashboard.test")
     monkeypatch.setenv("TRAINING_GYM_TRAINING_RUN_ID", "run-1")
     monkeypatch.setattr(timing_recorder, "_TIMING_MODE_CACHE", None)
+
+
+def test_variant_phase_normalizes_and_bounds_prefixes():
+    assert variant_phase("compute_log_probs", "") == "compute_log_probs"
+    assert variant_phase("compute_log_probs", None) == "compute_log_probs"
+    assert variant_phase("compute_log_probs", "  ref__ ") == "compute_log_probs:ref"
+    assert (
+        variant_phase("compute_log_probs", "teacher model!")
+        == "compute_log_probs:teacher_model"
+    )
+    assert len(variant_phase("compute_log_probs", "x" * 1000)) < MAX_PHASE_NAME_LENGTH
 
 
 def test_dist_down_rank_environment_elects_one_publisher(monkeypatch):

--- a/tests/testdata/miles/actor.py.timing.output
+++ b/tests/testdata/miles/actor.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import atexit
 import logging
@@ -405,7 +409,7 @@ class MegatronTrainRayActor(TrainRayActor):
     ) -> dict[str, list[torch.Tensor]]:
 
         # PATCHED_TRAINING_GYM_TIMING_COMPUTE_LOG_PROBS
-        with _tg_time_phase('compute_log_probs'):
+        with _tg_time_phase(_tg_variant_phase('compute_log_probs', store_prefix)):
             with timer(f"{store_prefix}log_probs"):
                 return forward_only(
                     get_log_probs_and_entropy,

--- a/tests/testdata/miles/model.py.timing.output
+++ b/tests/testdata/miles/model.py.timing.output
@@ -9,6 +9,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -36,6 +37,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 
 import dataclasses

--- a/tests/testdata/miles/rm_hub_init.py.timing.output
+++ b/tests/testdata/miles/rm_hub_init.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import asyncio
 import hashlib

--- a/tests/testdata/miles/rollout_manager.py.timing.output
+++ b/tests/testdata/miles/rollout_manager.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import asyncio
 import logging

--- a/tests/testdata/miles/sglang_rollout.py.timing.output
+++ b/tests/testdata/miles/sglang_rollout.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import asyncio
 import copy

--- a/tests/testdata/miles/train.py.timing.output
+++ b/tests/testdata/miles/train.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 # PATCHED_TRAINING_GYM_PREAMBLE: bootstrap phase reporter (runs once per process)
 import sys as _tg_sys

--- a/tests/testdata/miles/train_async.py.timing.output
+++ b/tests/testdata/miles/train_async.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 # PATCHED_TRAINING_GYM_PREAMBLE: bootstrap phase reporter (runs once per process)
 import sys as _tg_sys

--- a/tests/testdata/slime/actor.py.timing.output
+++ b/tests/testdata/slime/actor.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import logging
 import os
@@ -389,7 +393,7 @@ class MegatronTrainRayActor(TrainRayActor):
     ) -> dict[str, list[torch.Tensor]]:
 
         # PATCHED_TRAINING_GYM_TIMING_COMPUTE_LOG_PROBS
-        with _tg_time_phase('compute_log_probs'):
+        with _tg_time_phase(_tg_variant_phase('compute_log_probs', store_prefix)):
             with timer(f"{store_prefix}log_probs"):
                 return forward_only(
                     get_log_probs_and_entropy,

--- a/tests/testdata/slime/model.py.timing.output
+++ b/tests/testdata/slime/model.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import dataclasses
 import gc

--- a/tests/testdata/slime/rm_hub_init.py.timing.output
+++ b/tests/testdata/slime/rm_hub_init.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import asyncio
 import logging

--- a/tests/testdata/slime/rollout.py.timing.output
+++ b/tests/testdata/slime/rollout.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import dataclasses
 import itertools

--- a/tests/testdata/slime/sglang_rollout.py.timing.output
+++ b/tests/testdata/slime/sglang_rollout.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 import asyncio
 import copy

--- a/tests/testdata/slime/train.py.timing.output
+++ b/tests/testdata/slime/train.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 # PATCHED_TRAINING_GYM_PREAMBLE: bootstrap phase reporter (runs once per process)
 import sys as _tg_sys

--- a/tests/testdata/slime/train_async.py.timing.output
+++ b/tests/testdata/slime/train_async.py.timing.output
@@ -8,6 +8,7 @@ try:
         recording_lane as _tg_role,
         recording_lane_on_reporting_rank as _tg_mrec,
         time_phase as _tg_time_phase,
+        variant_phase as _tg_variant_phase,
     )
 except ImportError:
     print('WARNING: modal_training_gym not importable; substep timing off')
@@ -35,6 +36,9 @@ except ImportError:
     @_tg_cm
     def _tg_time_phase(name):
         yield
+
+    def _tg_variant_phase(base, variant):
+        return base
 
 # PATCHED_TRAINING_GYM_PREAMBLE: bootstrap phase reporter (runs once per process)
 import sys as _tg_sys


### PR DESCRIPTION
A run whose recipe needs more than one forward-only log-prob pass per step (e.g. `Qwen3.5-4B-Miles`: `use_kl_loss=True` + a `ref_load` checkpoint) renders two identical adjacent `Calculate log probs` bars, with nothing to say which is which. The passes are real and already distinguished framework-side by `store_prefix` (`""`, `ref_`, teacher, old policy) — but the timing patch wrapped them with a literal phase name, so the prefix was dropped and every pass recorded under `compute_log_probs`.

The phase name now carries the prefix as a variant, `base:variant`:

```
compute_log_probs          # the actor's own pass
compute_log_probs:ref      # reference model, for the KL term
compute_log_probs:teacher
```

Name building lives in `variant_phase()` in the gym (normalizes/sanitizes an arbitrary prefix, bounded by `MAX_PHASE_NAME_LENGTH`, empty prefix → base name unchanged) and is exposed to patched framework source through the patch preamble, with a no-op fallback alongside the existing ones. `wrap_block` gained an optional phase *expression* so the opener can be `_tg_time_phase(_tg_variant_phase('compute_log_probs', store_prefix))` while the `PATCHED_TRAINING_GYM_TIMING_…` marker stays keyed on the base name. Both the miles and slime patches change together, per the shared lanes/phase-name/record contract.

Frontend-side, a variant name would otherwise fall out of the vocabulary entirely (no category → `idle`, no color, raw label), so every phase-keyed lookup — `categoryOf`, `colorFor`, `labelFor`, `NESTS_IN`, and the `SAMPLED` / `IDLE_PHASES` / `TOOLTIP_HIDDEN_PHASES` / `span.name` comparisons in `timing_spans.js` and `timing_geometry.js` — resolves through `basePhaseName()`. No per-variant vocabulary entries: an unknown variant inherits its base's category, color and nesting and renders as `Calculate log probs (ref)`. Names without a variant, and every existing run's records, behave exactly as before.

Verified with `tests/test_substep_timing_patch.py`, `test_miles_patches.py`, `test_substep_times.py`, `test_timing_recorder.py` (new coverage for variant normalization and for the patched log-prob site), the frontend unit tests, ruff and pyright on the changed modules. The 14 patch golden files were regenerated via `--rewrite`.


Link to Devin session: https://modal.devinenterprise.com/sessions/ba28d6e9717f4569aa9c6e356627b668
Requested by: @cskitty