### PR TITLE
standardize var naming in tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class MathDataset(HuggingFaceDataset):
     apply_chat_template = True
 
 
-result = TrainConfig(
+config = TrainConfig(
     model=Qwen3_4B(),
     dataset=MathDataset(n_rows=120),
     recipe=Qwen3_4b_Recipe(
@@ -69,8 +69,9 @@ result = TrainConfig(
         sglang_mem_fraction_static=0.6,
         rm_type="deepscaler",
     ),
-).train()
-print(result.training_run_id)
+)
+run = config.launch()
+print(run.training_run_id)
 ```
 
 While that's running, you can view the run in the dashboard:

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -15,7 +15,7 @@ class MathDataset(HuggingFaceDataset):
 
 
 def main() -> None:
-    result = TrainConfig(
+    config = TrainConfig(
         model=Qwen3_4B(),
         dataset=MathDataset(n_rows=120),
         recipe=Qwen3_4b_Recipe(
@@ -35,8 +35,9 @@ def main() -> None:
             sglang_mem_fraction_static=0.6,
             rm_type="deepscaler",
         ),
-    ).train()
-    print(result.training_run_id)
+    )
+    run = config.launch()
+    print(run.training_run_id)
 
 
 if __name__ == "__main__":

--- a/tutorials/rl/000_rl_basics/000_rl_basics.ipynb
+++ b/tutorials/rl/000_rl_basics/000_rl_basics.ipynb
@@ -372,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_run = TrainConfig(\n",
+    "config = TrainConfig(\n",
     "    model=base_model,\n",
     "    dataset=train_dataset,\n",
     "    recipe=SlimeRecipe(\n",
@@ -399,8 +399,8 @@
     "    ),\n",
     ")\n",
     "\n",
-    "train_result = train_run.train()\n",
-    "print(f\"run id: {train_result.training_run_id}\")"
+    "run = config.launch()\n",
+    "print(f\"run id: {run.training_run_id}\")"
    ]
   },
   {
@@ -420,7 +420,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = list_checkpoints(train_result.training_run_id)[-1]\n",
+    "result = run.result()\n",
+    "checkpoint = list_checkpoints(result.training_run_id)[-1]\n",
     "print(f\"checkpoint: {checkpoint.path}\")\n",
     "\n",
     "trained_deployment = Endpoint.launch(\n",
@@ -468,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_train_run = TrainConfig(\n",
+    "new_config = TrainConfig(\n",
     "    model=Qwen3_5_4B(),\n",
     "    dataset=train_dataset,\n",
     "    checkpoint=checkpoint,\n",
@@ -497,8 +498,8 @@
     "    ),\n",
     ")\n",
     "\n",
-    "new_train_result = new_train_run.train()\n",
-    "print(f\"run id: {new_train_result.training_run_id}\")"
+    "new_run = new_config.launch()\n",
+    "print(f\"run id: {new_run.training_run_id}\")"
    ]
   },
   {
@@ -518,7 +519,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_checkpoint = list_checkpoints(new_train_result.training_run_id)[-1]\n",
+    "new_result = new_run.result()\n",
+    "new_checkpoint = list_checkpoints(new_result.training_run_id)[-1]\n",
     "print(new_checkpoint.path)\n",
     "\n",
     "new_deployment = Endpoint.launch(\n",

--- a/tutorials/rl/000_rl_basics/000_rl_basics.py
+++ b/tutorials/rl/000_rl_basics/000_rl_basics.py
@@ -220,7 +220,7 @@ def _main_impl() -> None:
     # Once we run the code below, training kicks off and we'll immediately get a run ID, which we may
     # use to watch the run's progress in the dashboard.
 
-    train_run = TrainConfig(
+    config = TrainConfig(
         model=base_model,
         dataset=train_dataset,
         recipe=SlimeRecipe(
@@ -247,14 +247,15 @@ def _main_impl() -> None:
         ),
     )
 
-    train_result = train_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
     # ## Serve and evaluate the trained checkpoint
     #
     # We'll get the latest checkpoint and create a new Endpoint so we may evaluate it.
 
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_deployment = Endpoint.launch(
@@ -274,7 +275,7 @@ def _main_impl() -> None:
     # A likely cause is that it only trained for 10 iterations.
     # Let's continue training, starting from the last checkpoint.
 
-    new_train_run = TrainConfig(
+    new_config = TrainConfig(
         model=Qwen3_5_4B(),
         dataset=train_dataset,
         checkpoint=checkpoint,
@@ -303,14 +304,15 @@ def _main_impl() -> None:
         ),
     )
 
-    new_train_result = new_train_run.train()
-    print(f"run id: {new_train_result.training_run_id}")
+    new_run = new_config.launch()
+    print(f"run id: {new_run.training_run_id}")
 
     # ## Evals Evals Evals
     #
     # Once again, we'll create a new Endpoint for the new checkpoint and run evals on it.
 
-    new_checkpoint = list_checkpoints(new_train_result.training_run_id)[-1]
+    new_result = new_run.result()
+    new_checkpoint = list_checkpoints(new_result.training_run_id)[-1]
     print(new_checkpoint.path)
 
     new_deployment = Endpoint.launch(

--- a/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.ipynb
+++ b/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.ipynb
@@ -405,7 +405,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_run = TrainConfig(\n",
+    "config = TrainConfig(\n",
     "    model=student_model,\n",
     "    dataset=train_dataset,\n",
     "    recipe=SlimeRecipe(\n",
@@ -445,8 +445,8 @@
     "    ),\n",
     ")\n",
     "\n",
-    "train_result = train_run.train()\n",
-    "print(f\"run id: {train_result.training_run_id}\")"
+    "run = config.launch()\n",
+    "print(f\"run id: {run.training_run_id}\")"
    ]
   },
   {
@@ -467,7 +467,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = list_checkpoints(train_result.training_run_id)[-1]\n",
+    "result = run.result()\n",
+    "checkpoint = list_checkpoints(result.training_run_id)[-1]\n",
     "print(f\"checkpoint: {checkpoint.path}\")\n",
     "\n",
     "trained_student_deployment = Endpoint.launch(\n",

--- a/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.py
+++ b/tutorials/rl/003_on_policy_distillation/003_on_policy_distillation.py
@@ -271,7 +271,7 @@ def _main_impl() -> None:
     # we set parameters such as `environment` and `extra_config` to supply
     # framework-necessary environment variables and flags.
 
-    train_run = TrainConfig(
+    config = TrainConfig(
         model=student_model,
         dataset=train_dataset,
         recipe=SlimeRecipe(
@@ -311,15 +311,16 @@ def _main_impl() -> None:
         ),
     )
 
-    train_result = train_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
     # ## Evaluate the trained student
     #
     # We'll deploy our trained student and compare it
     # to our baseline evaluation from earlier.
 
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_student_deployment = Endpoint.launch(

--- a/tutorials/rl/005_dapo/005_dapo.ipynb
+++ b/tutorials/rl/005_dapo/005_dapo.ipynb
@@ -320,7 +320,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_run = TrainConfig(\n",
+    "config = TrainConfig(\n",
     "    model=base_model,\n",
     "    dataset=train_dataset,\n",
     "    recipe=SlimeRecipe(\n",
@@ -380,8 +380,8 @@
     "    ),\n",
     ")\n",
     "\n",
-    "train_result = training_run.train()\n",
-    "print(f\"run id: {train_result.training_run_id}\")"
+    "run = config.launch()\n",
+    "print(f\"run id: {run.training_run_id}\")"
    ]
   },
   {
@@ -401,7 +401,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = list_checkpoints(train_result.training_run_id)[-1]\n",
+    "result = run.result()\n",
+    "checkpoint = list_checkpoints(result.training_run_id)[-1]\n",
     "print(f\"checkpoint: {checkpoint.path}\")\n",
     "\n",
     "trained_deployment = Endpoint.launch(\n",

--- a/tutorials/rl/005_dapo/005_dapo.py
+++ b/tutorials/rl/005_dapo/005_dapo.py
@@ -186,7 +186,7 @@ def _main_impl() -> None:
     #
     # Again, for demonstration purposes, we set `n_samples_per_prompt=8`.
 
-    training_run = TrainConfig(
+    config = TrainConfig(
         model=base_model,
         dataset=train_dataset,
         recipe=SlimeRecipe(
@@ -246,14 +246,15 @@ def _main_impl() -> None:
         ),
     )
 
-    train_result = training_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
     # ## Evaluate the trained model
     #
     # Let's run the same eval on the trained checkpoint.
 
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_deployment = Endpoint.launch(

--- a/tutorials/rl/006_audio_asr/006_audio_asr.ipynb
+++ b/tutorials/rl/006_audio_asr/006_audio_asr.ipynb
@@ -314,7 +314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_run = TrainConfig(\n",
+    "config = TrainConfig(\n",
     "    model=Qwen3_ASR_1_7B(),\n",
     "    dataset=train_dataset,\n",
     "    recipe=Qwen3_ASR_1_7b_Recipe(\n",
@@ -328,8 +328,8 @@
     "        custom_rm_function=wer_rm,\n",
     "    ),\n",
     ")\n",
-    "train_result = train_run.train()\n",
-    "print(f\"run id: {train_result.training_run_id}\")"
+    "run = config.launch()\n",
+    "print(f\"run id: {run.training_run_id}\")"
    ]
   },
   {
@@ -349,7 +349,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = list_checkpoints(train_result.training_run_id)[-1]\n",
+    "result = run.result()\n",
+    "checkpoint = list_checkpoints(result.training_run_id)[-1]\n",
     "print(f\"checkpoint: {checkpoint.path}\")\n",
     "\n",
     "trained_deployment = CustomDeployment.launch(\n",

--- a/tutorials/rl/006_audio_asr/006_audio_asr.py
+++ b/tutorials/rl/006_audio_asr/006_audio_asr.py
@@ -190,7 +190,7 @@ def _main_impl() -> None:
     # settings that surface reward variance. To not pass the burden of specifying onto you,
     # we created `Qwen3_ASR_1_7b_Recipe` so that you can focus on training.
 
-    train_run = TrainConfig(
+    config = TrainConfig(
         model=Qwen3_ASR_1_7B(),
         dataset=train_dataset,
         recipe=Qwen3_ASR_1_7b_Recipe(
@@ -204,14 +204,15 @@ def _main_impl() -> None:
             custom_rm_function=wer_rm,
         ),
     )
-    train_result = train_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
     # ## Evaluate the trained checkpoint
     #
     # Let's run the same eval on the trained checkpoint.
 
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_deployment = CustomDeployment.launch(

--- a/tutorials/tutorial_generator/rl/000_rl_basics.py
+++ b/tutorials/tutorial_generator/rl/000_rl_basics.py
@@ -322,7 +322,7 @@ def _train_intro():
 
 @code
 def _train():
-    train_run = TrainConfig(
+    config = TrainConfig(
         model=base_model,
         dataset=train_dataset,
         recipe=SlimeRecipe(
@@ -349,8 +349,8 @@ def _train():
         ),
     )
     
-    train_result = train_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
 
 @markdown
@@ -364,7 +364,8 @@ def _eval_trained_intro():
 
 @code
 def _deploy_trained():
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_deployment = Endpoint.launch(
@@ -400,7 +401,7 @@ def _continue_to_train_off_of_a_checkpoint():
 
 @code
 def _continue_to_train_off_of_a_checkpoint_code():
-    new_train_run = TrainConfig(
+    new_config = TrainConfig(
         model=Qwen3_5_4B(),
         dataset=train_dataset,
         checkpoint=checkpoint,
@@ -429,8 +430,8 @@ def _continue_to_train_off_of_a_checkpoint_code():
         ),
     )
 
-    new_train_result = new_train_run.train()
-    print(f"run id: {new_train_result.training_run_id}")
+    new_run = new_config.launch()
+    print(f"run id: {new_run.training_run_id}")
 
 
 @markdown
@@ -444,7 +445,8 @@ def _trained_eval_off_of_a_checkpoint():
 
 @code
 def _trained_eval_off_of_a_checkpoint_code():
-    new_checkpoint = list_checkpoints(new_train_result.training_run_id)[-1]
+    new_result = new_run.result()
+    new_checkpoint = list_checkpoints(new_result.training_run_id)[-1]
     print(new_checkpoint.path)
 
     new_deployment = Endpoint.launch(

--- a/tutorials/tutorial_generator/rl/003_on_policy_distillation.py
+++ b/tutorials/tutorial_generator/rl/003_on_policy_distillation.py
@@ -345,7 +345,7 @@ def _train_intro():
 
 @code
 def _train():
-    train_run = TrainConfig(
+    config = TrainConfig(
         model=student_model,
         dataset=train_dataset,
         recipe=SlimeRecipe(
@@ -385,8 +385,8 @@ def _train():
         ),
     )
 
-    train_result = train_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
 
 @markdown
@@ -401,7 +401,8 @@ def _eval_trained_intro():
 
 @code
 def _eval_trained():
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_student_deployment = Endpoint.launch(

--- a/tutorials/tutorial_generator/rl/005_dapo.py
+++ b/tutorials/tutorial_generator/rl/005_dapo.py
@@ -258,7 +258,7 @@ def _train_intro():
 
 @code
 def _train():
-    training_run = TrainConfig(
+    config = TrainConfig(
         model=base_model,
         dataset=train_dataset,
         recipe=SlimeRecipe(
@@ -318,8 +318,8 @@ def _train():
         ),
     )
 
-    train_result = training_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
 
 @markdown
@@ -333,7 +333,8 @@ def _eval_trained_intro():
 
 @code
 def _eval_trained():
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_deployment = Endpoint.launch(

--- a/tutorials/tutorial_generator/rl/006_audio_asr.py
+++ b/tutorials/tutorial_generator/rl/006_audio_asr.py
@@ -263,7 +263,7 @@ def _train_intro():
 
 @code
 def _train():
-    train_run = TrainConfig(
+    config = TrainConfig(
         model=Qwen3_ASR_1_7B(),
         dataset=train_dataset,
         recipe=Qwen3_ASR_1_7b_Recipe(
@@ -277,8 +277,8 @@ def _train():
             custom_rm_function=wer_rm,
         ),
     )
-    train_result = train_run.train()
-    print(f"run id: {train_result.training_run_id}")
+    run = config.launch()
+    print(f"run id: {run.training_run_id}")
 
 
 @markdown
@@ -291,7 +291,8 @@ def _eval_trained_intro():
 
 @code
 def _eval_trained():
-    checkpoint = list_checkpoints(train_result.training_run_id)[-1]
+    result = run.result()
+    checkpoint = list_checkpoints(result.training_run_id)[-1]
     print(f"checkpoint: {checkpoint.path}")
 
     trained_deployment = CustomDeployment.launch(


### PR DESCRIPTION
To ensure alignment with the guides, standardize variable naming for all tutorials to be of the form:
```
config = TrainConfig(
    ...
)
run = config.launch()
result = run.result()
```
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->