### PR TITLE
Support reproducible Slime git overlays

### DIFF
--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -163,6 +163,24 @@ _PATCH_SGLANG_PARALLEL_ALIASES_B64 = encode_patch(
     "patch_sglang_parallel_aliases", _SLIME_PATCHES
 )
 
+_SLIME_SOURCE_PATCHES_B64 = (
+    _PATCH_MEGATRON_BRIDGE_B64,
+    _PATCH_ADVANTAGES_B64,
+    _PATCH_STOP_TOKEN_DIAG_B64,
+    _PATCH_QWEN3_ASR_EXPORT_B64,
+    _PATCH_QWEN3_VL_EXPORT_B64,
+    _PATCH_QWEN3_VL_TORCH_DIST_B64,
+    _PATCH_ROLLOUT_STATUS_B64,
+    _PATCH_SUBSTEP_TIMING_B64,
+    _PATCH_ADVANTAGE_DIST_B64,
+    _PATCH_ZERO_STD_METRICS_B64,
+    _PATCH_SGLANG_PARALLEL_ALIASES_B64,
+)
+
+
+def _patch_commands(patches: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(f"echo {patch} | base64 -d | python3" for patch in patches)
+
 
 def _build_slime_base_image() -> "Image":
     return (
@@ -186,6 +204,46 @@ def _build_slime_base_image() -> "Image":
             f"echo {_PATCH_SUBSTEP_TIMING_B64} | base64 -d | python3",
         )
     )
+
+
+def _slime_git_overlay_command(repository: str, revision: str) -> str:
+    """Build the reproducible image command for a fork source overlay."""
+    repo = shlex.quote(repository)
+    sha = shlex.quote(revision)
+    checkout = "/tmp/training-gym-slime"
+    return (
+        "set -eux; "
+        "command -v git >/dev/null; "
+        f"rm -rf {checkout}; "
+        f"git init {checkout}; "
+        f"git -C {checkout} remote add origin {repo}; "
+        f"git -C {checkout} fetch --depth=1 origin {sha}; "
+        f"git -C {checkout} checkout --detach FETCH_HEAD; "
+        f'test "$(git -C {checkout} rev-parse HEAD)" = {sha}; '
+        f"rm -rf {checkout}/.git {SLIME_ROOT}; "
+        f"mv {checkout} {SLIME_ROOT}"
+    )
+
+
+def _overlay_slime_source(image: "Image", slime: SlimeRecipe) -> "Image":
+    if slime.local_slime:
+        image = image.add_local_dir(
+            slime.local_slime,
+            remote_path=SLIME_ROOT,
+            copy=True,
+            ignore=["**/__pycache__", "**/*.pyc", "**/.git", "**/.venv"],
+        )
+    elif slime.slime_git_repository and slime.slime_git_revision:
+        image = image.run_commands(
+            _slime_git_overlay_command(
+                slime.slime_git_repository, slime.slime_git_revision
+            )
+        )
+    else:
+        return image
+
+    # The source override replaced /root/slime after the base-image patches ran.
+    return image.run_commands(*_patch_commands(_SLIME_SOURCE_PATCHES_B64))
 
 
 def _build_conversion_config(slime_cfg: Any, model: Any = None) -> dict[str, Any]:
@@ -355,13 +413,7 @@ def build_slime_app(
     if isinstance(dataset, HarborDataset):
         image = image.uv_pip_install(f"harbor=={HARBOR_PKG_VERSION}")
 
-    if slime.local_slime:
-        image = image.add_local_dir(
-            slime.local_slime,
-            remote_path=SLIME_ROOT,
-            copy=True,
-            ignore=["**/__pycache__", "**/*.pyc", "**/.git", "**/.venv"],
-        )
+    image = _overlay_slime_source(image, slime)
 
     if slime.image_run_commands:
         image = image.run_commands(*slime.image_run_commands)
@@ -546,6 +598,8 @@ def build_slime_app(
         recipe_app_tags=slime.app_tags,
         wandb=slime.wandb,
     )
+    if slime.slime_git_revision:
+        tags["slime_git_revision"] = slime.slime_git_revision
     app = App(app_name, tags=tags)
     gpu_spec = f"{slime.gpu_type}:{slime.actor_num_gpus_per_node}"
 

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -600,8 +600,7 @@ def build_slime_app(
         recipe_app_tags=slime.app_tags,
         wandb=slime.wandb,
     )
-    if slime.slime_git_revision:
-        tags["slime_git_revision"] = slime.slime_git_revision
+
     app = App(app_name, tags=tags)
     gpu_spec = f"{slime.gpu_type}:{slime.actor_num_gpus_per_node}"
 

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -163,10 +163,27 @@ _PATCH_SGLANG_PARALLEL_ALIASES_B64 = encode_patch(
     "patch_sglang_parallel_aliases", _SLIME_PATCHES
 )
 
+_SLIME_BASE_PATCHES_B64 = (
+    _PATCH_MEGATRON_BRIDGE_B64,
+    _PATCH_ADVANTAGES_B64,
+    _PATCH_BRIDGE_NONE_TASK_B64,
+    _PATCH_STOP_TOKEN_DIAG_B64,
+    _PATCH_QWEN3_ASR_EXPORT_B64,
+    _PATCH_QWEN3_VL_EXPORT_B64,
+    _PATCH_QWEN3_VL_TORCH_DIST_B64,
+    _PATCH_ROLLOUT_STATUS_B64,
+    _PATCH_ADVANTAGE_DIST_B64,
+    _PATCH_LOG_ELIDE_B64,
+    _PATCH_DIST_CKPT_QUANTIZED_B64,
+    _PATCH_ZERO_STD_METRICS_B64,
+    _PATCH_SGLANG_PARALLEL_ALIASES_B64,
+    _PATCH_SUBSTEP_TIMING_B64,
+)
+
 # A git overlay replaces only /root/slime, so reapply patches whose targets live
 # there. Patches for Megatron or site-packages remain intact from the base image.
 # Add new /root/slime patches here when they are added to the base image.
-_SLIME_SOURCE_PATCHES_B64 = (
+_SLIME_ROOT_PATCHES_B64 = (
     _PATCH_MEGATRON_BRIDGE_B64,
     _PATCH_ADVANTAGES_B64,
     _PATCH_STOP_TOKEN_DIAG_B64,
@@ -174,10 +191,10 @@ _SLIME_SOURCE_PATCHES_B64 = (
     _PATCH_QWEN3_VL_EXPORT_B64,
     _PATCH_QWEN3_VL_TORCH_DIST_B64,
     _PATCH_ROLLOUT_STATUS_B64,
-    _PATCH_SUBSTEP_TIMING_B64,
     _PATCH_ADVANTAGE_DIST_B64,
     _PATCH_ZERO_STD_METRICS_B64,
     _PATCH_SGLANG_PARALLEL_ALIASES_B64,
+    _PATCH_SUBSTEP_TIMING_B64,
 )
 
 
@@ -191,20 +208,7 @@ def _build_slime_base_image() -> "Image":
         .entrypoint([])
         .run_commands(
             "rm -rf /root/.cache/huggingface",
-            f"echo {_PATCH_MEGATRON_BRIDGE_B64} | base64 -d | python3",
-            f"echo {_PATCH_ADVANTAGES_B64} | base64 -d | python3",
-            f"echo {_PATCH_BRIDGE_NONE_TASK_B64} | base64 -d | python3",
-            f"echo {_PATCH_STOP_TOKEN_DIAG_B64} | base64 -d | python3",
-            f"echo {_PATCH_QWEN3_ASR_EXPORT_B64} | base64 -d | python3",
-            f"echo {_PATCH_QWEN3_VL_EXPORT_B64} | base64 -d | python3",
-            f"echo {_PATCH_QWEN3_VL_TORCH_DIST_B64} | base64 -d | python3",
-            f"echo {_PATCH_ROLLOUT_STATUS_B64} | base64 -d | python3",
-            f"echo {_PATCH_ADVANTAGE_DIST_B64} | base64 -d | python3",
-            f"echo {_PATCH_LOG_ELIDE_B64} | base64 -d | python3",
-            f"echo {_PATCH_DIST_CKPT_QUANTIZED_B64} | base64 -d | python3",
-            f"echo {_PATCH_ZERO_STD_METRICS_B64} | base64 -d | python3",
-            f"echo {_PATCH_SGLANG_PARALLEL_ALIASES_B64} | base64 -d | python3",
-            f"echo {_PATCH_SUBSTEP_TIMING_B64} | base64 -d | python3",
+            *_patch_commands(_SLIME_BASE_PATCHES_B64),
         )
     )
 
@@ -248,7 +252,7 @@ def _overlay_slime_source(image: "Image", slime: SlimeRecipe) -> "Image":
     # The pinned source replaced /root/slime after the base-image patches ran.
     # Fail if required patches no longer apply rather than run an incompatible
     # fork with silently missing Training Gym behavior.
-    return image.run_commands(*_patch_commands(_SLIME_SOURCE_PATCHES_B64))
+    return image.run_commands(*_patch_commands(_SLIME_ROOT_PATCHES_B64))
 
 
 def _build_conversion_config(slime_cfg: Any, model: Any = None) -> dict[str, Any]:

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -163,6 +163,9 @@ _PATCH_SGLANG_PARALLEL_ALIASES_B64 = encode_patch(
     "patch_sglang_parallel_aliases", _SLIME_PATCHES
 )
 
+# A git overlay replaces only /root/slime, so reapply patches whose targets live
+# there. Patches for Megatron or site-packages remain intact from the base image.
+# Add new /root/slime patches here when they are added to the base image.
 _SLIME_SOURCE_PATCHES_B64 = (
     _PATCH_MEGATRON_BRIDGE_B64,
     _PATCH_ADVANTAGES_B64,
@@ -227,22 +230,24 @@ def _slime_git_overlay_command(repository: str, revision: str) -> str:
 
 def _overlay_slime_source(image: "Image", slime: SlimeRecipe) -> "Image":
     if slime.local_slime:
-        image = image.add_local_dir(
+        # Preserve the local dev overlay's existing semantics: use the checkout
+        # exactly as supplied rather than requiring it to match patch anchors.
+        return image.add_local_dir(
             slime.local_slime,
             remote_path=SLIME_ROOT,
             copy=True,
             ignore=["**/__pycache__", "**/*.pyc", "**/.git", "**/.venv"],
         )
-    elif slime.slime_git_repository and slime.slime_git_revision:
-        image = image.run_commands(
-            _slime_git_overlay_command(
-                slime.slime_git_repository, slime.slime_git_revision
-            )
-        )
-    else:
+    if not (slime.slime_git_repository and slime.slime_git_revision):
         return image
 
-    # The source override replaced /root/slime after the base-image patches ran.
+    image = image.run_commands(
+        _slime_git_overlay_command(slime.slime_git_repository, slime.slime_git_revision)
+    )
+
+    # The pinned source replaced /root/slime after the base-image patches ran.
+    # Fail if required patches no longer apply rather than run an incompatible
+    # fork with silently missing Training Gym behavior.
     return image.run_commands(*_patch_commands(_SLIME_SOURCE_PATCHES_B64))
 
 

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -163,26 +163,9 @@ _PATCH_SGLANG_PARALLEL_ALIASES_B64 = encode_patch(
     "patch_sglang_parallel_aliases", _SLIME_PATCHES
 )
 
-_SLIME_BASE_PATCHES_B64 = (
-    _PATCH_MEGATRON_BRIDGE_B64,
-    _PATCH_ADVANTAGES_B64,
-    _PATCH_BRIDGE_NONE_TASK_B64,
-    _PATCH_STOP_TOKEN_DIAG_B64,
-    _PATCH_QWEN3_ASR_EXPORT_B64,
-    _PATCH_QWEN3_VL_EXPORT_B64,
-    _PATCH_QWEN3_VL_TORCH_DIST_B64,
-    _PATCH_ROLLOUT_STATUS_B64,
-    _PATCH_ADVANTAGE_DIST_B64,
-    _PATCH_LOG_ELIDE_B64,
-    _PATCH_DIST_CKPT_QUANTIZED_B64,
-    _PATCH_ZERO_STD_METRICS_B64,
-    _PATCH_SGLANG_PARALLEL_ALIASES_B64,
-    _PATCH_SUBSTEP_TIMING_B64,
-)
-
-# A git overlay replaces only /root/slime, so reapply patches whose targets live
-# there. Patches for Megatron or site-packages remain intact from the base image.
-# Add new /root/slime patches here when they are added to the base image.
+# Patches targeting /root/slime* — a git overlay replaces that directory, so
+# these are skipped in the base image when an overlay is configured and applied
+# after the replacement instead.
 _SLIME_ROOT_PATCHES_B64 = (
     _PATCH_MEGATRON_BRIDGE_B64,
     _PATCH_ADVANTAGES_B64,
@@ -197,19 +180,26 @@ _SLIME_ROOT_PATCHES_B64 = (
     _PATCH_SUBSTEP_TIMING_B64,
 )
 
+# Patches targeting Megatron-LM or site-packages — survive a git overlay.
+_SLIME_EXTERNAL_PATCHES_B64 = (
+    _PATCH_BRIDGE_NONE_TASK_B64,
+    _PATCH_LOG_ELIDE_B64,
+    _PATCH_DIST_CKPT_QUANTIZED_B64,
+)
+
 
 def _patch_commands(patches: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(f"echo {patch} | base64 -d | python3" for patch in patches)
 
 
-def _build_slime_base_image() -> "Image":
+def _build_slime_base_image(*, apply_root_patches: bool = True) -> "Image":
+    patches = _SLIME_EXTERNAL_PATCHES_B64
+    if apply_root_patches:
+        patches = patches + _SLIME_ROOT_PATCHES_B64
     return (
         Image.from_registry(SLIME_IMAGE)
         .entrypoint([])
-        .run_commands(
-            "rm -rf /root/.cache/huggingface",
-            *_patch_commands(_SLIME_BASE_PATCHES_B64),
-        )
+        .run_commands("rm -rf /root/.cache/huggingface", *_patch_commands(patches))
     )
 
 
@@ -395,7 +385,10 @@ def build_slime_app(
     _caller_module, caller_script = resolve_caller_context()
 
     # ── Image ────────────────────────────────────────────────────────────────
-    image = _build_slime_base_image()
+    # When a git overlay will replace /root/slime, skip root patches here so they
+    # run once after the replacement instead of being applied and then discarded.
+    _needs_git_overlay = bool(slime.slime_git_repository and slime.slime_git_revision)
+    image = _build_slime_base_image(apply_root_patches=not _needs_git_overlay)
 
     # Hybrid models have layers with different parameter sets (e.g. GDN
     # layers carry linear_attn.dt_bias that standard attention layers lack).

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -164,7 +164,8 @@ class SlimeRecipe(BaseTrainRecipe):
     slime_git_repository : str | None
         Public HTTPS Git repository to overlay onto the image's slime checkout.
         Must be paired with ``slime_git_revision`` and is intended for
-        reproducible fork-backed runs.
+        reproducible fork-backed runs. The selected source must remain compatible
+        with Training Gym's build-time Slime patches.
     slime_git_revision : str | None
         Full 40-character commit SHA fetched from ``slime_git_repository``.
         Branches and tags are rejected because they can move between runs.

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 from dataclasses import field
+import re
 from typing import Any, ClassVar, Literal
+from urllib.parse import urlparse
 
 from modal_training_gym.train_recipes.base import (
     BaseTrainRecipe,
@@ -43,6 +45,8 @@ _SLIME_SKIP = {
     "trace_sample_limit",
     "image_overlay",
     "local_slime",
+    "slime_git_repository",
+    "slime_git_revision",
     "memory",
     "cloud",
     "region",
@@ -157,6 +161,13 @@ class SlimeRecipe(BaseTrainRecipe):
     local_slime : str | None
         Path to a local slime checkout mounted over the image's copy — dev
         overlay for testing slime changes without an image rebuild.
+    slime_git_repository : str | None
+        Public HTTPS Git repository to overlay onto the image's slime checkout.
+        Must be paired with ``slime_git_revision`` and is intended for
+        reproducible fork-backed runs.
+    slime_git_revision : str | None
+        Full 40-character commit SHA fetched from ``slime_git_repository``.
+        Branches and tags are rejected because they can move between runs.
     memory : int | tuple[int, int] | None
         Modal Function memory request/limit in MiB.
     cloud : str | None
@@ -494,6 +505,8 @@ class SlimeRecipe(BaseTrainRecipe):
     wandb: WandbConfig | None = None
     image_overlay: Callable[[modal.Image], modal.Image] | None = None
     local_slime: str | None = None
+    slime_git_repository: str | None = None
+    slime_git_revision: str | None = None
     memory: int | tuple[int, int] | None = None
     cloud: str | None = None
     region: str | None = None
@@ -658,6 +671,35 @@ class SlimeRecipe(BaseTrainRecipe):
     # ── Validators ───────────────────────────────────────────────────────────
 
     _SKIP_FIELDS: ClassVar[frozenset[str]] = frozenset(_SLIME_SKIP)
+
+    @model_validator(mode="after")
+    def _validate_slime_source_overlay(self) -> "SlimeRecipe":
+        repository = self.slime_git_repository
+        revision = self.slime_git_revision
+        if bool(repository) != bool(revision):
+            raise TrainingGymConfigError(
+                "slime_git_repository and slime_git_revision must be set together"
+            )
+        if self.local_slime and repository:
+            raise TrainingGymConfigError(
+                "local_slime and slime_git_repository are mutually exclusive"
+            )
+        if repository:
+            parsed = urlparse(repository)
+            if parsed.scheme != "https" or not parsed.netloc:
+                raise TrainingGymConfigError(
+                    "slime_git_repository must be a public HTTPS URL"
+                )
+            if parsed.username or parsed.password:
+                raise TrainingGymConfigError(
+                    "slime_git_repository must not contain credentials"
+                )
+            if not re.fullmatch(r"[0-9a-fA-F]{40}", revision or ""):
+                raise TrainingGymConfigError(
+                    "slime_git_revision must be a full 40-character commit SHA"
+                )
+            object.__setattr__(self, "slime_git_revision", revision.lower())
+        return self
 
     @model_validator(mode="after")
     def _resolve_callable_paths(self) -> "SlimeRecipe":

--- a/tests/test_slime_git_overlay.py
+++ b/tests/test_slime_git_overlay.py
@@ -91,16 +91,12 @@ def test_git_overlay_reapplies_slime_source_patches_after_replacement() -> None:
         assert _patch_commands((patch,))[0] in image.operations[1][1]
 
 
-def test_local_overlay_reapplies_slime_source_patches_after_replacement() -> None:
+def test_local_overlay_preserves_unpatched_dev_checkout_behavior() -> None:
     recipe = Qwen3_6_27b_Recipe(local_slime="/tmp/local-slime")
     image = RecordingImage()
 
     assert _overlay_slime_source(image, recipe) is image
 
-    assert [operation[0] for operation in image.operations] == [
-        "add_local_dir",
-        "run_commands",
-    ]
+    assert [operation[0] for operation in image.operations] == ["add_local_dir"]
     assert image.operations[0][1] == ("/tmp/local-slime",)
     assert image.operations[0][2]["remote_path"] == SLIME_ROOT
-    assert image.operations[1][1] == _patch_commands(_SLIME_SOURCE_PATCHES_B64)

--- a/tests/test_slime_git_overlay.py
+++ b/tests/test_slime_git_overlay.py
@@ -2,7 +2,7 @@ import pytest
 
 from modal_training_gym.frameworks.slime.launcher import (
     SLIME_ROOT,
-    _SLIME_BASE_PATCHES_B64,
+    _SLIME_EXTERNAL_PATCHES_B64,
     _SLIME_ROOT_PATCHES_B64,
     _overlay_slime_source,
     _patch_commands,
@@ -30,8 +30,8 @@ class RecordingImage:
         return self
 
 
-def test_slime_root_patches_are_a_subset_of_base_image_patches() -> None:
-    assert set(_SLIME_ROOT_PATCHES_B64) <= set(_SLIME_BASE_PATCHES_B64)
+def test_root_and_external_patches_are_disjoint() -> None:
+    assert not (set(_SLIME_ROOT_PATCHES_B64) & set(_SLIME_EXTERNAL_PATCHES_B64))
 
 
 def test_slime_git_overlay_requires_repository_and_full_revision() -> None:

--- a/tests/test_slime_git_overlay.py
+++ b/tests/test_slime_git_overlay.py
@@ -2,11 +2,12 @@ import pytest
 
 from modal_training_gym.frameworks.slime.launcher import (
     SLIME_ROOT,
+    _SLIME_BASE_PATCHES_B64,
+    _SLIME_ROOT_PATCHES_B64,
     _overlay_slime_source,
     _patch_commands,
     _PATCH_SGLANG_PARALLEL_ALIASES_B64,
     _PATCH_SUBSTEP_TIMING_B64,
-    _SLIME_SOURCE_PATCHES_B64,
     _slime_git_overlay_command,
 )
 from modal_training_gym.train_recipes.slime_recipe import Qwen3_6_27b_Recipe
@@ -27,6 +28,10 @@ class RecordingImage:
     def run_commands(self, *commands: object) -> "RecordingImage":
         self.operations.append(("run_commands", commands, {}))
         return self
+
+
+def test_slime_root_patches_are_a_subset_of_base_image_patches() -> None:
+    assert set(_SLIME_ROOT_PATCHES_B64) <= set(_SLIME_BASE_PATCHES_B64)
 
 
 def test_slime_git_overlay_requires_repository_and_full_revision() -> None:
@@ -86,7 +91,7 @@ def test_git_overlay_reapplies_slime_source_patches_after_replacement() -> None:
     overlay_commands = image.operations[0][1]
     assert len(overlay_commands) == 1
     assert f"rm -rf /tmp/training-gym-slime/.git {SLIME_ROOT}" in overlay_commands[0]
-    assert image.operations[1][1] == _patch_commands(_SLIME_SOURCE_PATCHES_B64)
+    assert image.operations[1][1] == _patch_commands(_SLIME_ROOT_PATCHES_B64)
     for patch in (_PATCH_SGLANG_PARALLEL_ALIASES_B64, _PATCH_SUBSTEP_TIMING_B64):
         assert _patch_commands((patch,))[0] in image.operations[1][1]
 

--- a/tests/test_slime_git_overlay.py
+++ b/tests/test_slime_git_overlay.py
@@ -1,0 +1,106 @@
+import pytest
+
+from modal_training_gym.frameworks.slime.launcher import (
+    SLIME_ROOT,
+    _overlay_slime_source,
+    _patch_commands,
+    _PATCH_SGLANG_PARALLEL_ALIASES_B64,
+    _PATCH_SUBSTEP_TIMING_B64,
+    _SLIME_SOURCE_PATCHES_B64,
+    _slime_git_overlay_command,
+)
+from modal_training_gym.train_recipes.slime_recipe import Qwen3_6_27b_Recipe
+
+
+REPOSITORY = "https://github.com/modal-projects/slime.git"
+REVISION = "ba324bebdd3a3cbfc1946b58404a012ad607f38b"
+
+
+class RecordingImage:
+    def __init__(self) -> None:
+        self.operations: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+
+    def add_local_dir(self, *args: object, **kwargs: object) -> "RecordingImage":
+        self.operations.append(("add_local_dir", args, kwargs))
+        return self
+
+    def run_commands(self, *commands: object) -> "RecordingImage":
+        self.operations.append(("run_commands", commands, {}))
+        return self
+
+
+def test_slime_git_overlay_requires_repository_and_full_revision() -> None:
+    with pytest.raises(ValueError, match="must be set together"):
+        Qwen3_6_27b_Recipe(slime_git_repository=REPOSITORY)
+
+    with pytest.raises(ValueError, match="full 40-character"):
+        Qwen3_6_27b_Recipe(
+            slime_git_repository=REPOSITORY,
+            slime_git_revision="ba324beb",
+        )
+
+
+def test_slime_git_overlay_rejects_local_or_credentialed_sources() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        Qwen3_6_27b_Recipe(
+            local_slime="/tmp/slime",
+            slime_git_repository=REPOSITORY,
+            slime_git_revision=REVISION,
+        )
+
+    with pytest.raises(ValueError, match="must not contain credentials"):
+        Qwen3_6_27b_Recipe(
+            slime_git_repository="https://token@example.com/slime.git",
+            slime_git_revision=REVISION,
+        )
+
+
+def test_slime_git_overlay_command_is_revision_pinned() -> None:
+    recipe = Qwen3_6_27b_Recipe(
+        slime_git_repository=REPOSITORY,
+        slime_git_revision=REVISION.upper(),
+    )
+
+    assert recipe.slime_git_revision == REVISION
+    command = _slime_git_overlay_command(
+        recipe.slime_git_repository or "", recipe.slime_git_revision or ""
+    )
+    assert "fetch --depth=1 origin" in command
+    assert REVISION in command
+    assert "checkout --detach FETCH_HEAD" in command
+
+
+def test_git_overlay_reapplies_slime_source_patches_after_replacement() -> None:
+    recipe = Qwen3_6_27b_Recipe(
+        slime_git_repository=REPOSITORY,
+        slime_git_revision=REVISION,
+    )
+    image = RecordingImage()
+
+    assert _overlay_slime_source(image, recipe) is image
+
+    assert [operation[0] for operation in image.operations] == [
+        "run_commands",
+        "run_commands",
+    ]
+    overlay_commands = image.operations[0][1]
+    assert len(overlay_commands) == 1
+    assert f"rm -rf /tmp/training-gym-slime/.git {SLIME_ROOT}" in overlay_commands[0]
+    assert image.operations[1][1] == _patch_commands(_SLIME_SOURCE_PATCHES_B64)
+    for patch in (_PATCH_SGLANG_PARALLEL_ALIASES_B64, _PATCH_SUBSTEP_TIMING_B64):
+        assert _patch_commands((patch,))[0] in image.operations[1][1]
+
+
+def test_local_overlay_reapplies_slime_source_patches_after_replacement() -> None:
+    recipe = Qwen3_6_27b_Recipe(local_slime="/tmp/local-slime")
+    image = RecordingImage()
+
+    assert _overlay_slime_source(image, recipe) is image
+
+    assert [operation[0] for operation in image.operations] == [
+        "add_local_dir",
+        "run_commands",
+    ]
+    assert image.operations[0][1] == ("/tmp/local-slime",)
+    assert image.operations[0][2]["remote_path"] == SLIME_ROOT
+    assert image.operations[1][1] == _patch_commands(_SLIME_SOURCE_PATCHES_B64)


### PR DESCRIPTION
Currently we load a slime image and apply patches slime itself as well as external dependencies of slime. We have a second option to load a local slime branch from the client.

This PR adds a third option to load a slime branch from a specific git revision. It only applies the patches related to external dependencies of slime.

## Summary
- let Slime recipes select a public HTTPS fork at an immutable 40-character commit SHA
- replace the image's Slime checkout during image construction and verify the fetched revision
- reapply Training Gym's Slime source patches after either git or local source overlays

## Test plan
- [x] `uv run pytest tests/test_slime_git_overlay.py`
- [x] `uv run ruff check modal_training_gym/frameworks/slime/launcher.py modal_training_gym/train_recipes/slime_recipe/recipe.py tests/test_slime_git_overlay.py`
- [x] `uv run ruff format --check modal_training_gym/frameworks/slime/launcher.py modal_training_gym/train_recipes/slime_recipe/recipe.py tests/test_slime_git_overlay.py`
- [x] `uv run -m compileall modal_training_gym`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->