### PR TITLE
Surface reward-function output images in the training dashboard

### DIFF
--- a/modal_training_gym/common/sample_extraction.py
+++ b/modal_training_gym/common/sample_extraction.py
@@ -447,10 +447,12 @@ def _image_to_data_uri(value: Any) -> str | None:
 
 
 def _image_candidates(sample: Any) -> list[Any]:
-    """Unencoded input-image references on a slime Sample, best first.
+    """Unencoded image references on a slime Sample, best first.
 
-    For image-modality runs slime's ``process_vision_info`` lifts the screenshot
-    into ``sample.multimodal_inputs['images']`` (even when ``apply_chat_template``
+    An image a reward/rollout function stashes on ``sample.metadata["image"]``
+    (e.g. a rendering of the model's output) comes first. For image-modality
+    runs slime's ``process_vision_info`` lifts the screenshot into
+    ``sample.multimodal_inputs['images']`` (even when ``apply_chat_template``
     collapses the prompt to a string). Falls back to image items in a
     conversation-list prompt. Returns ``[]`` for non-image samples.
     """
@@ -462,6 +464,10 @@ def _image_candidates(sample: Any) -> list[Any]:
             return getattr(sample, key, default)
 
     candidates: list[Any] = []
+    meta = get("metadata", None)
+    if isinstance(meta, dict) and meta.get("image") is not None:
+        candidates.append(meta["image"])
+
     mm = get("multimodal_inputs", None)
     if isinstance(mm, dict):
         imgs = mm.get("images") or mm.get("image")
@@ -519,7 +525,11 @@ def _raw_image_key(value: Any) -> Any:
 
 
 class RolloutImageStore:
-    """Deduplicates input images across one rollout's samples.
+    """Deduplicates images across one rollout's samples.
+
+    Covers both input images (multimodal prompts) and output images a reward
+    function attaches as ``sample.metadata["image"]``; every candidate is
+    thumbnailed and size-capped before it rides on the payload.
 
     The bytes ride on the first sample that uses them as ``metadata["image"]``; the
     rest of the prompt group carries only ``metadata["image_ref"]`` naming it. Both

--- a/tests/test_reward_output_images.py
+++ b/tests/test_reward_output_images.py
@@ -1,0 +1,75 @@
+"""An image a reward function stashes on ``sample.metadata["image"]`` (e.g. a
+rendering of the model's output) flows through rollout extraction: compacted by
+``RolloutImageStore`` and re-emitted as ``metadata["image"]``/``image_ref`` so
+the dashboard renders it per sample."""
+
+import base64
+
+from modal_training_gym.common.sample_extraction import (
+    RolloutImageStore,
+    _sample_to_dict,
+)
+
+# A 1x1 red PNG. Real bytes so the test exercises the same path whether PIL is
+# installed (decode + thumbnail) or not (small data-URI passthrough).
+_RED_PX = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/q842"
+    "iQAAAABJRU5ErkJggg=="
+)
+_BLUE_PX = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYPj/HwADAgH/p2/z"
+    "ngAAAABJRU5ErkJggg=="
+)
+
+
+def _data_uri(png: bytes) -> str:
+    return "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+
+
+def _sample(png: bytes, **extra) -> dict:
+    return {
+        "prompt": "draw an eye",
+        "response": "code",
+        "reward": 1.0,
+        "metadata": {"image": _data_uri(png), **extra},
+    }
+
+
+def test_reward_output_image_annotated():
+    store = RolloutImageStore(16)
+    meta = _sample_to_dict(_sample(_RED_PX), image_store=store)["metadata"]
+    assert meta["_metadata_type"] == "image"
+    assert meta["image"].startswith("data:image/")
+    assert meta["image_ref"]
+
+
+def test_distinct_output_images_get_distinct_refs():
+    store = RolloutImageStore(16)
+    a = _sample_to_dict(_sample(_RED_PX), image_store=store)["metadata"]
+    b = _sample_to_dict(_sample(_BLUE_PX), image_store=store)["metadata"]
+    assert a["image_ref"] != b["image_ref"]
+    assert "image" in a and "image" in b
+
+
+def test_duplicate_output_image_carries_bytes_once():
+    store = RolloutImageStore(16)
+    first = _sample_to_dict(_sample(_RED_PX), image_store=store)["metadata"]
+    second = _sample_to_dict(_sample(_RED_PX), image_store=store)["metadata"]
+    assert first["image_ref"] == second["image_ref"]
+    assert "image" in first and "image" not in second
+
+
+def test_other_metadata_still_passes_through():
+    store = RolloutImageStore(16)
+    meta = _sample_to_dict(_sample(_RED_PX, judge="pairwise"), image_store=store)[
+        "metadata"
+    ]
+    assert meta["judge"] == "pairwise"
+
+
+def test_no_image_metadata_untouched():
+    store = RolloutImageStore(16)
+    sample = {"prompt": "p", "response": "r", "reward": 0.0, "metadata": {"k": "v"}}
+    meta = _sample_to_dict(sample, image_store=store)["metadata"]
+    assert "image" not in meta and "image_ref" not in meta
+    assert meta.get("_metadata_type") != "image"


### PR DESCRIPTION
# reward-function can output images in the training dashboard

A reward function can now attach a rendering of the model's output to a sample:

```python
async def image_rm(args, sample, **kwargs) -> float:
    png = render_sketch(extract_code(sample.response))
    sample.metadata = {**(sample.metadata or {}), "image": png}  # bytes, PIL image, or data-URI
    return await judge(png)
```

and the image shows up per-sample in the run detail page's rollout viewer, letting you visually debug rollouts during image-generation RL runs.

Previously only *input* (prompt-side) images reached the dashboard: `RolloutImageStore` collected candidates from `multimodal_inputs`/conversation prompts, while `metadata["image"]` set by a reward function was a reserved key that extraction dropped.

Change: `_image_candidates()` now also yields the sample's own `metadata["image"]`.

Notes:
- Distinct images per rollout payload are still capped at 16 by default; override with `TRAINING_GYM_IMAGE_SAMPLE_LIMIT` if you want every sample's render captured.
- Eval-side images were already supported via `ImageEvalRowResult` — unchanged.