### PR TITLE
fix redirect flicker for /guides and /tutorials

### DIFF
--- a/docs-next/docs_next_app.py
+++ b/docs-next/docs_next_app.py
@@ -44,6 +44,11 @@ image = (
 
 app = modal.App("training-gym-docs", image=image)
 
+_DIRECTORY_REDIRECTS = {
+    "/guides": "/guides/tools/observability-dashboard",
+    "/tutorials": "/tutorials/rl_basics",
+}
+
 
 def cache_control_value(path: str, content_type: str) -> str | None:
     if path.startswith("/_astro/"):
@@ -91,6 +96,17 @@ def serve():
         if value and response.status_code in (200, 206):
             response.headers["Cache-Control"] = value
         return response
+
+    @web.middleware("http")
+    async def directory_http_redirects(request: Request, call_next):
+        if request.method not in ("GET", "HEAD"):
+            return await call_next(request)
+        target = _DIRECTORY_REDIRECTS.get(request.url.path.rstrip("/") or "/")
+        if target is None:
+            return await call_next(request)
+        query = request.url.query
+        location = f"{target}?{query}" if query else target
+        return RedirectResponse(url=location, status_code=301)
 
     web.mount("/", StaticFiles(directory=REMOTE_DIST, html=True), name="static")
 


### PR DESCRIPTION
Fixes the flicker users see when they visit `/guides` and `/tutorials` as a result of redirecting to the first page.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->