### PR TITLE
allow accessing intermediate checkpoints

### DIFF
--- a/docs-next/src/content/docs/guides/start/training.md
+++ b/docs-next/src/content/docs/guides/start/training.md
@@ -31,16 +31,16 @@ Note that you can always access runs by their ID:
 run = TrainingRun.from_id("bristled-pine-a7c3e91d4b2")
 ```
 
-From there, we get the run's result after it has completed:
+While the run is in-progress, you can poll for the latest checkpoint:
 
 ```python
-result = run.result()
-```
+import time
 
-Then, get the latest checkpoint:
-
-```python
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 ```
 
 Now, we could do offline evals:
@@ -102,8 +102,11 @@ simple_config = TrainConfig(
 )
 
 simple_run = simple_config.launch()
-simple_result = simple_run.result()
-simple_checkpoint = simple_result.latest_checkpoint()
+while True:
+    simple_checkpoint = simple_run.latest_checkpoint()
+    if simple_run.done():
+        break
+    time.sleep(30)
 
 complex_config = TrainConfig(
     model=model,
@@ -113,6 +116,9 @@ complex_config = TrainConfig(
 )
 
 complex_run = complex_config.launch()
-complex_result = complex_run.result()
-complex_checkpoint = complex_result.latest_checkpoint()
+while True:
+    complex_checkpoint = complex_run.latest_checkpoint()
+    if complex_run.done():
+        break
+    time.sleep(30)
 ```

--- a/docs-next/src/content/docs/guides/start/training.md
+++ b/docs-next/src/content/docs/guides/start/training.md
@@ -31,16 +31,17 @@ Note that you can always access runs by their ID:
 run = TrainingRun.from_id("bristled-pine-a7c3e91d4b2")
 ```
 
-While the run is in-progress, you can poll for the latest checkpoint:
+While the run is in-progress, you can poll for the latest checkpoint. Leaving the `with` block stops the detached Modal app:
 
 ```python
 import time
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
+with config.launch() as run:
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
 ```
 
 Now, we could do offline evals:
@@ -101,12 +102,12 @@ simple_config = TrainConfig(
     recipe=simple_recipe,
 )
 
-simple_run = simple_config.launch()
-while True:
-    simple_checkpoint = simple_run.latest_checkpoint()
-    if simple_run.done():
-        break
-    time.sleep(30)
+with simple_config.launch() as simple_run:
+    while True:
+        simple_checkpoint = simple_run.latest_checkpoint()
+        if simple_run.done():
+            break
+        time.sleep(30)
 
 complex_config = TrainConfig(
     model=model,
@@ -115,10 +116,10 @@ complex_config = TrainConfig(
     recipe=complex_recipe,
 )
 
-complex_run = complex_config.launch()
-while True:
-    complex_checkpoint = complex_run.latest_checkpoint()
-    if complex_run.done():
-        break
-    time.sleep(30)
+with complex_config.launch() as complex_run:
+    while True:
+        complex_checkpoint = complex_run.latest_checkpoint()
+        if complex_run.done():
+            break
+        time.sleep(30)
 ```

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import posixpath
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -14,7 +15,12 @@ from modal.exception import NotFoundError
 from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.models import ModelConfig
 from modal_training_gym.common.run import TrainingRun
-from modal_training_gym.common.train_result import TrainResult
+from modal_training_gym.common.torch_dist_checkpoint import (
+    TORCH_DIST_TRACKER_NAME,
+    is_complete_torch_dist_checkpoint,
+    parse_torch_dist_iteration,
+    parse_torch_dist_tracker,
+)
 from modal_training_gym.deploy_recipes import SglangRecipe, VllmRecipe
 
 _CHECKPOINTS_MOUNT_FALLBACK = "/checkpoints"
@@ -30,7 +36,7 @@ class CheckpointType(Enum):
 
 @dataclass
 class Checkpoint:
-    """A single discovered checkpoint on the local filesystem.
+    """A complete training checkpoint discovered on a Modal Volume.
 
     Attributes:
         checkpoint_type: Hugging Face or Megatron layout.
@@ -55,55 +61,52 @@ class Checkpoint:
     @property
     def path_relative_to_volume(self) -> str:
         """Path relative to the checkpoints volume mount."""
-        return _to_volume_path(
+        return volume_relative_path(
             self.path, self.checkpoints_mount_path or _CHECKPOINTS_MOUNT_FALLBACK
         )
 
 
-def _to_volume_path(checkpoint_dir: str, checkpoints_mount_path: str) -> str:
-    checkpoint_dir_norm = os.path.normpath(checkpoint_dir)
-    checkpoints_mount_path_norm = os.path.normpath(checkpoints_mount_path)
-
-    if os.path.isabs(checkpoint_dir_norm):
-        if (
-            checkpoint_dir_norm == checkpoints_mount_path_norm
-            or checkpoint_dir_norm.startswith(checkpoints_mount_path_norm + os.sep)
-        ):
-            rel = os.path.relpath(checkpoint_dir_norm, checkpoints_mount_path_norm)
-            return "" if rel == "." else rel
-        return checkpoint_dir_norm.lstrip("/")
-
-    return checkpoint_dir_norm.lstrip("/")
+def require_within_volume_mount(path: str, mount_path: str) -> tuple[str, str]:
+    normalized_path = posixpath.normpath(path)
+    normalized_mount = posixpath.normpath(mount_path)
+    if not posixpath.isabs(normalized_path) or not posixpath.isabs(normalized_mount):
+        raise TrainingGymConfigError(
+            f"Path {path!r} and Volume mount {mount_path!r} must be absolute POSIX paths."
+        )
+    if posixpath.commonpath([normalized_path, normalized_mount]) != normalized_mount:
+        raise TrainingGymConfigError(
+            f"Path {path!r} is outside Volume mount {mount_path!r}."
+        )
+    return normalized_path, normalized_mount
 
 
-def _list_checkpoints(train_result: "TrainResult") -> list[Checkpoint]:
-    checkpoint_dir = train_result.checkpoint_dir.rstrip("/")
-    if checkpoint_dir == "":
-        return []
+def volume_relative_path(path: str, mount_path: str) -> str:
+    normalized_path, normalized_mount = require_within_volume_mount(path, mount_path)
+    relative_path = posixpath.relpath(normalized_path, normalized_mount)
+    return "" if relative_path == "." else relative_path
 
+
+def _read_tracker_iteration(volume: Volume, rel: str) -> int | None:
+    tracker_rel = f"{rel}/{TORCH_DIST_TRACKER_NAME}" if rel else TORCH_DIST_TRACKER_NAME
+    try:
+        raw = b"".join(volume.read_file(tracker_rel))
+    except (FileNotFoundError, NotFoundError):
+        return None
+    return parse_torch_dist_tracker(raw.decode())
+
+
+def _list_checkpoints(
+    checkpoint_dir: str,
+    checkpoints_volume_name: str,
+    checkpoints_mount_path: str,
+    *,
+    include_hf: bool,
+    fallback_without_tracker: bool,
+    training_run_id: str = "",
+    app_name: str = "",
+) -> list[Checkpoint]:
     def _entry_name(entry: object) -> str:
         return getattr(entry, "path", "").rstrip("/").rsplit("/", 1)[-1]
-
-    def _checkpoint_type(name: str) -> CheckpointType:
-        return CheckpointType.hf if name.endswith("_hf") else CheckpointType.megatron
-
-    checkpoints_volume_name = (
-        train_result.checkpoints_volume_name or f"{train_result.app_name}-checkpoints"
-    )
-    checkpoints_mount_path = (
-        train_result.checkpoints_mount_path or _CHECKPOINTS_MOUNT_FALLBACK
-    )
-    volume = Volume.from_name(checkpoints_volume_name, create_if_missing=True)
-    prefix = "iter_"
-    rel = _to_volume_path(checkpoint_dir, checkpoints_mount_path)
-
-    try:
-        entries = {
-            _entry_name(entry): entry
-            for entry in volume.iterdir(rel or "/", recursive=False)
-        }
-    except (FileNotFoundError, NotFoundError):
-        return []
 
     def _is_dir_entry(entry: object) -> bool:
         is_dir_fn = getattr(entry, "is_dir", None)
@@ -117,25 +120,60 @@ def _list_checkpoints(train_result: "TrainResult") -> list[Checkpoint]:
             return entry_type_name.upper() == "DIRECTORY"
         return False
 
+    checkpoint_dir = checkpoint_dir.rstrip("/")
+    if checkpoint_dir == "" or not checkpoints_volume_name:
+        return []
+    checkpoints_mount_path = checkpoints_mount_path or _CHECKPOINTS_MOUNT_FALLBACK
+
+    rel = volume_relative_path(checkpoint_dir, checkpoints_mount_path)
+    volume = Volume.from_name(checkpoints_volume_name, create_if_missing=False)
+
+    try:
+        entries = list(volume.iterdir(rel or "/", recursive=False))
+    except (FileNotFoundError, NotFoundError):
+        return []
+
+    tracker_iteration = _read_tracker_iteration(volume, rel)
     checkpoints: list[Checkpoint] = []
     for entry in sorted(
-        (entry for entry in entries.values() if _is_dir_entry(entry)),
-        key=lambda entry: _entry_name(entry),
+        (entry for entry in entries if _is_dir_entry(entry)),
+        key=_entry_name,
     ):
         name = _entry_name(entry)
-        if name.startswith(prefix):
-            checkpoints.append(
-                Checkpoint(
-                    checkpoint_type=_checkpoint_type(name),
-                    name=name,
-                    path=os.path.join(checkpoint_dir, name),
-                    timestamp=float(getattr(entry, "mtime", 0.0)),
-                    training_run_id=train_result.training_run_id,
-                    app_name=train_result.app_name,
-                    checkpoints_volume_name=checkpoints_volume_name,
-                    checkpoints_mount_path=checkpoints_mount_path,
-                )
+        if not name.startswith("iter_"):
+            continue
+        is_hf = name.endswith("_hf")
+        child_rel = f"{rel}/{name}" if rel else name
+        try:
+            child_names = {
+                _entry_name(child)
+                for child in volume.iterdir(child_rel, recursive=False)
+            }
+        except (FileNotFoundError, NotFoundError):
+            child_names = set()
+        if is_hf:
+            is_visible = include_hf and _CONVERT_COMPLETE_MARKER in child_names
+        elif not is_complete_torch_dist_checkpoint(child_names):
+            is_visible = False
+        elif tracker_iteration is None:
+            is_visible = fallback_without_tracker
+        else:
+            iteration = parse_torch_dist_iteration(name)
+            is_visible = iteration is not None and iteration <= tracker_iteration
+        if not is_visible:
+            continue
+        checkpoints.append(
+            Checkpoint(
+                checkpoint_type=CheckpointType.hf if is_hf else CheckpointType.megatron,
+                name=name,
+                path=posixpath.join(checkpoint_dir, name),
+                timestamp=float(getattr(entry, "mtime", 0.0)),
+                training_run_id=training_run_id,
+                app_name=app_name,
+                checkpoints_volume_name=checkpoints_volume_name,
+                checkpoints_mount_path=checkpoints_mount_path,
             )
+        )
     return checkpoints
 
 
@@ -183,8 +221,8 @@ def convert_megatron_checkpoint_to_hf(
         checkpoint.checkpoints_mount_path or _CHECKPOINTS_MOUNT_FALLBACK
     )
     output_path = f"{checkpoint.path}_hf"
-    volume = Volume.from_name(checkpoints_volume_name, create_if_missing=True)
-    rel = _to_volume_path(output_path, checkpoints_mount_path)
+    volume = Volume.from_name(checkpoints_volume_name, create_if_missing=False)
+    rel = volume_relative_path(output_path, checkpoints_mount_path)
     marker_rel = (
         f"{rel}/{_CONVERT_COMPLETE_MARKER}" if rel else _CONVERT_COMPLETE_MARKER
     )
@@ -211,10 +249,7 @@ def convert_megatron_checkpoint_to_hf(
         )
 
     hf_cache_volume = Volume.from_name("huggingface-cache", create_if_missing=True)
-    checkpoints_volume = Volume.from_name(
-        checkpoints_volume_name,
-        create_if_missing=True,
-    )
+    checkpoints_volume = volume
     from modal_training_gym.common import hf_secrets
     from modal_training_gym.frameworks.slime.launcher import _build_slime_base_image
 

--- a/modal_training_gym/common/checkpoint.py
+++ b/modal_training_gym/common/checkpoint.py
@@ -100,7 +100,6 @@ def _list_checkpoints(
     checkpoints_volume_name: str,
     checkpoints_mount_path: str,
     *,
-    include_hf: bool,
     fallback_without_tracker: bool,
     training_run_id: str = "",
     app_name: str = "",
@@ -140,9 +139,8 @@ def _list_checkpoints(
         key=_entry_name,
     ):
         name = _entry_name(entry)
-        if not name.startswith("iter_"):
+        if not name.startswith("iter_") or name.endswith("_hf"):
             continue
-        is_hf = name.endswith("_hf")
         child_rel = f"{rel}/{name}" if rel else name
         try:
             child_names = {
@@ -151,9 +149,7 @@ def _list_checkpoints(
             }
         except (FileNotFoundError, NotFoundError):
             child_names = set()
-        if is_hf:
-            is_visible = include_hf and _CONVERT_COMPLETE_MARKER in child_names
-        elif not is_complete_torch_dist_checkpoint(child_names):
+        if not is_complete_torch_dist_checkpoint(child_names):
             is_visible = False
         elif tracker_iteration is None:
             is_visible = fallback_without_tracker
@@ -164,7 +160,7 @@ def _list_checkpoints(
             continue
         checkpoints.append(
             Checkpoint(
-                checkpoint_type=CheckpointType.hf if is_hf else CheckpointType.megatron,
+                checkpoint_type=CheckpointType.megatron,
                 name=name,
                 path=posixpath.join(checkpoint_dir, name),
                 timestamp=float(getattr(entry, "mtime", 0.0)),

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -36,7 +36,9 @@ from modal_training_gym.common.run import (
     metric_run_id_for_attempt,
     record_metric_attempt,
     run_scoped_save_root,
+    set_checkpoint_location,
 )
+from modal_training_gym.common.checkpoint import require_within_volume_mount
 from modal_training_gym.common.train_result import TrainResult
 from modal_training_gym.common.metrics import MetricConfig, metric_metadata
 from modal_training_gym.utils.metadata import MetadataStore, vol_put
@@ -245,6 +247,9 @@ async def init_training_run_record(
     metric_cfg: "MetricConfig | None",
     metric_entity: str,
     framework_status_token: str,
+    checkpoint_dir: str,
+    checkpoints_volume_name: str,
+    checkpoints_mount_path: str,
 ) -> tuple[Any, str, str]:
     """Create or resume the ``TrainingRun`` record for this attempt and persist
     the framework-status token. Returns
@@ -272,6 +277,12 @@ async def init_training_run_record(
             created_at=created_at,
             started_at=created_at,
         )
+    set_checkpoint_location(
+        run_record,
+        checkpoint_dir=checkpoint_dir,
+        checkpoints_volume_name=checkpoints_volume_name,
+        checkpoints_mount_path=checkpoints_mount_path,
+    )
     attempt_count = mark_training_attempt_started(
         run_record, started_at=int(time.time())
     )
@@ -312,18 +323,19 @@ def compute_save_root(
     mounted_save_root: str,
     training_run_id: str,
 ) -> str:
-    """Resolve the run-scoped checkpoint save root and ensure it exists. A
-    configured ``save`` equal to the recipe default is redirected to the mounted
-    volume path so checkpoints land on the checkpoints Volume."""
+    """Resolve the run-scoped checkpoint save root. A configured ``save`` equal
+    to the recipe default is redirected to the mounted volume path so checkpoints
+    land on the checkpoints Volume."""
     configured_save_root = str(save).rstrip("/") if save else mounted_save_root
-    save_root = run_scoped_save_root(
+    save_root = (
         mounted_save_root
         if configured_save_root == recipe_default_save_root
-        else configured_save_root,
-        training_run_id,
+        else configured_save_root
     )
-    os.makedirs(save_root, exist_ok=True)
-    return save_root
+    return require_within_volume_mount(
+        run_scoped_save_root(save_root, training_run_id),
+        mounted_save_root,
+    )[0]
 
 
 def build_train_result(

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -338,6 +338,35 @@ def compute_save_root(
     )[0]
 
 
+def compute_recipe_save_root(
+    recipe: Any,
+    *,
+    recipe_default_save_root: str,
+    mounted_save_root: str,
+    training_run_id: str,
+) -> str:
+    """Resolve the run-scoped save root after ``extra_config`` save precedence.
+
+    Keys in ``extra_config`` drop the matching CLI flag, so a ``save`` override
+    is the path training writes. The live listing directory must match, and the
+    override is rewritten to the scoped root so later YAML materialization
+    writes there too.
+    """
+    extra = getattr(recipe, "extra_config", None)
+    save = extra.get("save") if isinstance(extra, dict) else None
+    if not save:
+        save = getattr(recipe, "save", None)
+    root = compute_save_root(
+        save,
+        recipe_default_save_root=recipe_default_save_root,
+        mounted_save_root=mounted_save_root,
+        training_run_id=training_run_id,
+    )
+    if isinstance(extra, dict) and extra.get("save"):
+        object.__setattr__(recipe, "extra_config", {**extra, "save": root})
+    return root
+
+
 def build_train_result(
     *,
     app_name: str,

--- a/modal_training_gym/common/megatron_patches/patch_checkpoint_commit.py
+++ b/modal_training_gym/common/megatron_patches/patch_checkpoint_commit.py
@@ -1,0 +1,82 @@
+"""Commit the checkpoints Volume after a durable megatron save.
+
+Sync saves commit after ``save_checkpoint`` returns. Async saves commit after
+``maybe_finalize_async_save`` only when the queue had work. Empty-queue
+finalizes (slime's first ``save_model`` call, Miles rank-0 post-save hook)
+must not run Volume collectives. Non-coordinator node leaders commit first;
+rank 0 commits last so ``latest_checkpointed_iteration.txt`` becomes visible
+only after those shard commits.
+"""
+
+from pathlib import Path
+
+_CHECKPOINTING = Path("/root/Megatron-LM/megatron/training/checkpointing.py")
+_ASYNC_UTILS = Path("/root/Megatron-LM/megatron/training/async_utils.py")
+_SAVE_MARKER = "PATCHED_TRAINING_GYM_CHECKPOINT_COMMIT"
+_FINALIZE_MARKER = "PATCHED_TRAINING_GYM_ASYNC_FINALIZE_COMMIT"
+_SAVE_WRAP = """
+
+# PATCHED_TRAINING_GYM_CHECKPOINT_COMMIT
+def save_checkpoint(*args, **kwargs):
+    from megatron.training import get_args
+    from modal_training_gym.common.torch_dist_checkpoint import (
+        commit_latest_checkpoint_volume,
+    )
+
+    result = _training_gym_save_checkpoint(*args, **kwargs)
+    if not getattr(get_args(), "async_save", False):
+        commit_latest_checkpoint_volume()
+    return result
+"""
+_FINALIZE_WRAP = """
+
+# PATCHED_TRAINING_GYM_ASYNC_FINALIZE_COMMIT
+def maybe_finalize_async_save(*args, **kwargs):
+    from modal_training_gym.common.torch_dist_checkpoint import (
+        commit_latest_checkpoint_volume,
+    )
+
+    had_pending = not is_empty_async_queue()
+    result = _training_gym_maybe_finalize_async_save(*args, **kwargs)
+    if had_pending:
+        commit_latest_checkpoint_volume()
+    return result
+"""
+
+
+def _wrap(path: Path, original: str, renamed: str, marker: str, wrap: str) -> None:
+    if not path.is_file():
+        print(f"WARNING: {path} is absent; skipping {marker}")
+        return
+    source = path.read_text()
+    if marker in source:
+        print(f"{path.name} already has {marker}")
+        return
+    if f"def {original}(" not in source:
+        raise RuntimeError(f"Megatron {original} not found in {path}")
+    source = source.replace(f"def {original}(", f"def {renamed}(", 1)
+    source += wrap
+    compile(source, str(path), "exec")
+    path.write_text(source)
+    print(f"Patched {path} ({original})")
+
+
+def main() -> None:
+    _wrap(
+        _CHECKPOINTING,
+        "save_checkpoint",
+        "_training_gym_save_checkpoint",
+        _SAVE_MARKER,
+        _SAVE_WRAP,
+    )
+    _wrap(
+        _ASYNC_UTILS,
+        "maybe_finalize_async_save",
+        "_training_gym_maybe_finalize_async_save",
+        _FINALIZE_MARKER,
+        _FINALIZE_WRAP,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -197,7 +197,6 @@ class TrainingRun(BaseModel):
             directory,
             volume,
             mount,
-            include_hf=False,
             fallback_without_tracker=False,
             training_run_id=self.training_run_id,
         )

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -146,6 +146,7 @@ class TrainingRun(BaseModel):
     _status_display: Any = PrivateAttr(default=None)
     _metadata_removed_keys: set[str] = PrivateAttr(default_factory=set)
     _metadata_loaded_keys: set[str] | None = PrivateAttr(default=None)
+    _closed: bool = PrivateAttr(default=False)
 
     @computed_field
     @property
@@ -227,7 +228,6 @@ class TrainingRun(BaseModel):
         Returns:
             The completed training result.
         """
-        from modal_training_gym.common.modal_lifecycle import stop_app
         from modal_training_gym.common.status_reporter import (
             flush as flush_status_reporter,
         )
@@ -258,11 +258,26 @@ class TrainingRun(BaseModel):
                 self._status_display.stop_polling()
             flush_status_reporter(timeout_seconds=2.0)
 
-        if stop_app_on_success and self.modal_app_id:
-            stop_app(self.modal_app_id)
+        if stop_app_on_success:
+            self.close()
         result = TrainResult(**TrainResult._parse_model_config(result_dict))
         print(f"Training complete: {result.training_run_id}")
         return result
+
+    def close(self) -> None:
+        """Stop the detached Modal app. Safe to call more than once."""
+        if self._closed:
+            return
+        self._closed = True
+        from modal_training_gym.common.modal_lifecycle import stop_app
+
+        stop_app(self.modal_app_id)
+
+    def __enter__(self) -> "TrainingRun":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.close()
 
     def __await__(self):
         import asyncio

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -13,10 +13,16 @@ from collections.abc import Awaitable, Callable
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+from modal.exception import NotFoundError
 from pydantic import BaseModel, PrivateAttr, computed_field, field_validator
 
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.status import FrameworkStatus, resolve_framework_status
+from modal_training_gym.common.torch_dist_checkpoint import (
+    TORCH_DIST_TRACKER_NAME,
+    parse_torch_dist_iteration,
+    parse_torch_dist_tracker,
+)
 from modal_training_gym.utils.metadata import (
     MetadataStore,
     vol_get,
@@ -24,10 +30,12 @@ from modal_training_gym.utils.metadata import (
 )
 
 if TYPE_CHECKING:
+    from modal_training_gym.common.checkpoint import Checkpoint
     from modal_training_gym.common.train_result import TrainResult
     from modal_training_gym.common.training_rollout import TrainingRolloutResult
 
 TRAINING_RUNS_STORE_NAME = MetadataStore.TRAINING_RUNS.value
+CHECKPOINT_LOCATION_METADATA_KEY = "checkpoint_location"
 
 
 class FrameworkStatusUpdate(BaseModel):
@@ -161,6 +169,46 @@ class TrainingRun(BaseModel):
         import modal
 
         return modal.FunctionCall.from_id(self.function_call_id)
+
+    def _reload(self) -> None:
+        try:
+            stored = TrainingRun.from_id(self.training_run_id)
+        except (KeyError, NotFoundError):
+            return
+        self.status = stored.status
+        self.metadata = stored.metadata
+        self._metadata_loaded_keys = stored._metadata_loaded_keys
+
+    def checkpoints(self) -> list["Checkpoint"]:
+        """Snapshot of committed megatron ``iter_*`` directories.
+
+        Miles LoRA adapters are not listed. Serving needs
+        ``convert_megatron_checkpoint_to_hf``.
+        """
+        from modal_training_gym.common.checkpoint import _list_checkpoints
+
+        self._reload()
+        location = checkpoint_location(self)
+        if location is None:
+            return []
+        directory, volume, mount = location
+        return _list_checkpoints(
+            directory,
+            volume,
+            mount,
+            include_hf=False,
+            fallback_without_tracker=False,
+            training_run_id=self.training_run_id,
+        )
+
+    def latest_checkpoint(self) -> "Checkpoint | None":
+        checkpoints = self.checkpoints()
+        return checkpoints[-1] if checkpoints else None
+
+    def done(self) -> bool:
+        """Return True when status is COMPLETED, FAILED, STOPPED, or CANCELLED."""
+        self._reload()
+        return self.status is not TrainingRunStatus.RUNNING
 
     def result(
         self,
@@ -437,6 +485,39 @@ class TrainingRun(BaseModel):
         return run
 
 
+def checkpoint_location(
+    run: TrainingRun,
+) -> tuple[str, str, str] | None:
+    loc = (run.metadata or {}).get(CHECKPOINT_LOCATION_METADATA_KEY)
+    if not isinstance(loc, dict):
+        return None
+    directory = loc.get("checkpoint_dir")
+    volume = loc.get("checkpoints_volume_name")
+    mount = loc.get("checkpoints_mount_path")
+    if not (
+        isinstance(directory, str) and directory and isinstance(volume, str) and volume
+    ):
+        return None
+    mount_path = mount if isinstance(mount, str) and mount else "/checkpoints"
+    return directory, volume, mount_path
+
+
+def set_checkpoint_location(
+    run: TrainingRun,
+    *,
+    checkpoint_dir: str,
+    checkpoints_volume_name: str,
+    checkpoints_mount_path: str,
+) -> None:
+    metadata = dict(run.metadata or {})
+    metadata[CHECKPOINT_LOCATION_METADATA_KEY] = {
+        "checkpoint_dir": checkpoint_dir,
+        "checkpoints_volume_name": checkpoints_volume_name,
+        "checkpoints_mount_path": checkpoints_mount_path,
+    }
+    run.metadata = metadata
+
+
 def _resume_checkpoint(path: str, name: str, iteration: int | None) -> dict[str, Any]:
     return {
         "resume_checkpoint_path": path,
@@ -462,25 +543,24 @@ def torch_dist_resume_checkpoint(
         return None
 
     is_complete = is_complete or os.path.isdir
-    tracker_path = os.path.join(save_path, "latest_checkpointed_iteration.txt")
+    tracker_path = os.path.join(save_path, TORCH_DIST_TRACKER_NAME)
     if os.path.isfile(tracker_path):
         try:
             with open(tracker_path) as f:
-                marker = f.read().strip()
+                tracker = f.read()
         except OSError:
-            marker = ""
-        if marker == "release":
+            tracker = ""
+        if tracker.strip() == "release":
             path = os.path.join(save_path, "release")
             return (
                 _resume_checkpoint(path, "release", None) if is_complete(path) else None
             )
-        if marker.isdigit():
-            name = f"iter_{int(marker):07d}"
+        iteration = parse_torch_dist_tracker(tracker)
+        if iteration is not None:
+            name = f"iter_{iteration:07d}"
             path = os.path.join(save_path, name)
             return (
-                _resume_checkpoint(path, name, int(marker))
-                if is_complete(path)
-                else None
+                _resume_checkpoint(path, name, iteration) if is_complete(path) else None
             )
 
     try:
@@ -492,9 +572,8 @@ def torch_dist_resume_checkpoint(
             if entry.name == "release":
                 release_path = entry.path
             elif entry.name.startswith("iter_"):
-                try:
-                    iteration = int(entry.name.removeprefix("iter_"))
-                except ValueError:
+                iteration = parse_torch_dist_iteration(entry.name)
+                if iteration is None:
                     continue
                 candidates.append((iteration, entry.name, entry.path))
     except OSError:

--- a/modal_training_gym/common/torch_dist_checkpoint.py
+++ b/modal_training_gym/common/torch_dist_checkpoint.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Collection
+from pathlib import Path
+from typing import Any, Callable
+
+from modal import Volume
+
+TORCH_DIST_TRACKER_NAME = "latest_checkpointed_iteration.txt"
+
+
+def is_complete_torch_dist_checkpoint(names: Collection[str]) -> bool:
+    return (
+        ".metadata" in names
+        and "common.pt" in names
+        and any(name.endswith(".distcp") for name in names)
+    )
+
+
+def is_complete_torch_dist_checkpoint_dir(
+    checkpoint_dir: str | os.PathLike[str],
+) -> bool:
+    try:
+        names = {entry.name for entry in Path(checkpoint_dir).iterdir()}
+    except OSError:
+        return False
+    return is_complete_torch_dist_checkpoint(names)
+
+
+def parse_torch_dist_iteration(name: str) -> int | None:
+    if not name.startswith("iter_"):
+        return None
+    try:
+        return int(name.removeprefix("iter_"))
+    except ValueError:
+        return None
+
+
+def parse_torch_dist_tracker(text: str) -> int | None:
+    text = text.strip()
+    if text == "release" or not text.isdigit():
+        return None
+    return int(text)
+
+
+def _is_node_leader() -> bool:
+    local_rank = os.environ.get("LOCAL_RANK")
+    return local_rank is None or int(local_rank) == 0
+
+
+def _error_text(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _raise_gathered_errors(
+    dist_wrapper: Any,
+    error: str | None,
+    message: str,
+) -> None:
+    errors = dist_wrapper.all_gather_object(error)
+    if any(errors):
+        raise RuntimeError(f"{message}: {errors}")
+
+
+def _commit_volume(volume_name: str) -> None:
+    Volume.from_name(volume_name, create_if_missing=False).commit()
+
+
+def commit_checkpoint_volume_across_ranks(
+    volume_name: str | None,
+    dist_wrapper: Any,
+    barrier: Callable[[], None],
+) -> None:
+    if not volume_name:
+        return
+
+    shard_commit_error = None
+    if _is_node_leader() and not dist_wrapper.is_coordinator:
+        try:
+            _commit_volume(volume_name)
+        except Exception as exc:
+            shard_commit_error = _error_text(exc)
+    _raise_gathered_errors(
+        dist_wrapper,
+        shard_commit_error,
+        "Checkpoint Volume shard commit failed",
+    )
+    barrier()
+
+    coordinator_commit_error = None
+    if _is_node_leader() and dist_wrapper.is_coordinator:
+        try:
+            _commit_volume(volume_name)
+        except Exception as exc:
+            coordinator_commit_error = _error_text(exc)
+    _raise_gathered_errors(
+        dist_wrapper,
+        coordinator_commit_error,
+        "Checkpoint Volume coordinator commit failed",
+    )
+    barrier()
+
+
+class _TorchDistributed:
+    @property
+    def is_coordinator(self) -> bool:
+        import torch.distributed as dist
+
+        return not dist.is_initialized() or dist.get_rank() == 0
+
+    def all_gather_object(self, error: str | None) -> list[str | None]:
+        import torch.distributed as dist
+
+        if not dist.is_initialized():
+            return [error]
+        gathered: list[str | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(gathered, error)
+        return gathered
+
+
+def commit_latest_checkpoint_volume() -> None:
+    import torch.distributed as dist
+
+    volume_name = os.environ.get("TRAINING_GYM_CHECKPOINTS_VOLUME_NAME")
+    barrier = dist.barrier if dist.is_initialized() else lambda: None
+    commit_checkpoint_volume_across_ranks(
+        volume_name,
+        _TorchDistributed(),
+        barrier,
+    )

--- a/modal_training_gym/common/train_result.py
+++ b/modal_training_gym/common/train_result.py
@@ -180,10 +180,10 @@ class TrainResult:
         return Volume.from_name(volume_name, create_if_missing=False)
 
     def checkpoints(self) -> list["Checkpoint"]:
-        """List this run's checkpoints.
+        """Snapshot of committed megatron ``iter_*`` directories.
 
-        Returns:
-            This run's ``Checkpoint`` objects.
+        Miles LoRA adapters are not listed. Serving needs
+        ``convert_megatron_checkpoint_to_hf``.
         """
         from modal_training_gym.common.checkpoint import _list_checkpoints
         from modal_training_gym.common.errors import TrainingGymConfigError
@@ -198,7 +198,6 @@ class TrainResult:
                 self.checkpoint_dir,
                 self.checkpoints_volume_name or f"{self.app_name}-checkpoints",
                 self.checkpoints_mount_path or "/checkpoints",
-                include_hf=True,
                 fallback_without_tracker=True,
                 training_run_id=self.training_run_id,
                 app_name=self.app_name,
@@ -206,15 +205,8 @@ class TrainResult:
         raise TrainingGymConfigError(f"Unsupported framework: {self.framework}")
 
     def latest_checkpoint(self) -> "Checkpoint | None":
-        """Return the last megatron ``iter_*`` checkpoint, if any."""
-        from modal_training_gym.common.checkpoint import CheckpointType
-
-        megatron = [
-            checkpoint
-            for checkpoint in self.checkpoints()
-            if checkpoint.checkpoint_type is CheckpointType.megatron
-        ]
-        return megatron[-1] if megatron else None
+        checkpoints = self.checkpoints()
+        return checkpoints[-1] if checkpoints else None
 
     @property
     def model(self) -> "ModelConfig":

--- a/modal_training_gym/common/train_result.py
+++ b/modal_training_gym/common/train_result.py
@@ -20,8 +20,8 @@ Typical flow:
 
     result = TrainResult.load(training_run_id)
 
-    print(result.checkpoint_dir)            # /checkpoints/my-app_train_...
-    print(result.checkpoints()[-1].path)    # .../iter_0000050
+    print(result.checkpoint_dir)                 # /checkpoints/my-app_train_...
+    print(result.latest_checkpoint().path)       # .../iter_0000050
 
     from modal_training_gym import CustomDeployment
     from modal_training_gym.deploy_recipes import SglangRecipe
@@ -48,6 +48,8 @@ from dataclasses import asdict, dataclass, field, fields
 import copy
 from typing import TYPE_CHECKING, Any
 
+from modal import Volume
+
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.utils.metadata import (
     MetadataStore,
@@ -56,8 +58,6 @@ from modal_training_gym.utils.metadata import (
 )
 
 if TYPE_CHECKING:
-    from modal import Volume
-
     from modal_training_gym.common.checkpoint import Checkpoint
     from modal_training_gym.common.models import ModelConfig
 
@@ -171,13 +171,13 @@ class TrainResult:
         return cls.from_training_run_id(training_run_id)
 
     def volume(self) -> "Volume":
-        """Open or create the checkpoints volume.
+        """Open the checkpoints volume.
 
         Returns:
             The Modal checkpoints ``Volume``.
         """
         volume_name = self.checkpoints_volume_name or f"{self.app_name}-checkpoints"
-        return Volume.from_name(volume_name, create_if_missing=True)
+        return Volume.from_name(volume_name, create_if_missing=False)
 
     def checkpoints(self) -> list["Checkpoint"]:
         """List this run's checkpoints.
@@ -194,8 +194,27 @@ class TrainResult:
             Framework.MILES,
             Framework.MILES.value,
         }:
-            return _list_checkpoints(self)
+            return _list_checkpoints(
+                self.checkpoint_dir,
+                self.checkpoints_volume_name or f"{self.app_name}-checkpoints",
+                self.checkpoints_mount_path or "/checkpoints",
+                include_hf=True,
+                fallback_without_tracker=True,
+                training_run_id=self.training_run_id,
+                app_name=self.app_name,
+            )
         raise TrainingGymConfigError(f"Unsupported framework: {self.framework}")
+
+    def latest_checkpoint(self) -> "Checkpoint | None":
+        """Return the last megatron ``iter_*`` checkpoint, if any."""
+        from modal_training_gym.common.checkpoint import CheckpointType
+
+        megatron = [
+            checkpoint
+            for checkpoint in self.checkpoints()
+            if checkpoint.checkpoint_type is CheckpointType.megatron
+        ]
+        return megatron[-1] if megatron else None
 
     @property
     def model(self) -> "ModelConfig":
@@ -212,9 +231,9 @@ class TrainResult:
             )
 
         model = copy.copy(self.model_config)
-        checkpoints = self.checkpoints()
-        if checkpoints:
-            model.model_path = checkpoints[-1].path
+        checkpoint = self.latest_checkpoint()
+        if checkpoint is not None:
+            model.model_path = checkpoint.path
         elif self.checkpoint_dir:
             model.model_path = self.checkpoint_dir
 

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -52,7 +52,7 @@ from modal_training_gym.common.launcher_helpers import (
     build_app_tags,
     build_terminal_run_record,
     build_train_result,
-    compute_save_root,
+    compute_recipe_save_root,
     init_training_run_record,
     mark_run_failed,
     mark_run_stopped,
@@ -585,8 +585,8 @@ def build_miles_app(
             default_mount_path=str(CHECKPOINTS_PATH),
         )
     )
-    checkpoint_dir = compute_save_root(
-        miles.save,
+    checkpoint_dir = compute_recipe_save_root(
+        miles,
         recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
         mounted_save_root=checkpoints_mount_path,
         training_run_id=training_run_id,

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -64,6 +64,9 @@ from modal_training_gym.common.launcher_helpers import (
     write_dataset_if_needed,
 )
 from modal_training_gym.common.status import MilesStatus
+from modal_training_gym.common.torch_dist_checkpoint import (
+    is_complete_torch_dist_checkpoint_dir,
+)
 from modal_training_gym.train_recipes.miles_recipe.recipe import (
     CHECKPOINTS_PATH,
     DATA_PATH,
@@ -123,16 +126,14 @@ _REPORTING_PATCH_COMMANDS = (
     f"echo {_PATCH_ADVANTAGE_DIST_B64} | base64 -d | python3",
 )
 
-# Megatron-level torch_dist save fixes, shared with the slime image. Both no-op when
-# their target source doesn't match, so they are safe for every miles image; the
-# checkpoint-save one is skipped in the shell below when its target is absent
-# entirely, since guarding inside the script would change the bytes the slime image
-# already builds from.
 _PATCH_DIST_CKPT_QUANTIZED_B64 = encode_patch(
     "patch_dist_ckpt_quantized", _MEGATRON_PATCHES
 )
 _PATCH_DIST_CKPT_NOFORK_B64 = encode_patch("patch_dist_ckpt_nofork", _MEGATRON_PATCHES)
 _PATCH_CHECKPOINT_SAVE_B64 = encode_patch("patch_checkpoint_save", _MEGATRON_PATCHES)
+_PATCH_CHECKPOINT_COMMIT_B64 = encode_patch(
+    "patch_checkpoint_commit", _MEGATRON_PATCHES
+)
 _MEGATRON_TORCH_STRATEGY_PY = (
     "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/torch.py"
 )
@@ -290,12 +291,13 @@ def _release_convert_lock(run_id: str, volume_name: str, save_path: str) -> None
 def _is_resumable_checkpoint(path: str) -> bool:
     """Whether ``path`` holds a training save that can be resumed from.
 
-    Looser than ``_is_complete_torch_dist_checkpoint`` because miles writes more than
-    one save shape: a LoRA run stores ``adapter/`` with per-rank ``.pt`` files and no
-    ``.metadata``/``common.pt``/``.distcp`` at all, so the conversion predicate would
-    report every adapter checkpoint as absent and silently restart from ``ref_load``.
-    Only the crashed-torch_dist signature is rejected — ``.distcp`` shards present but
-    the ``.metadata`` that is written last missing.
+    Looser than ``is_complete_torch_dist_checkpoint_dir`` because miles writes
+    more than one save shape: a LoRA run stores ``adapter/`` with per-rank
+    ``.pt`` files and no ``.metadata``/``common.pt``/``.distcp`` at all, so the
+    conversion predicate would report every adapter checkpoint as absent and
+    silently restart from ``ref_load``. Only the crashed-torch_dist signature is
+    rejected: ``.distcp`` shards present but the ``.metadata`` written last
+    missing.
     """
     try:
         names = os.listdir(path)
@@ -320,29 +322,6 @@ def _unresumable_save_dirs(save_root: str) -> list[str]:
         if (name == "release" or name.startswith("iter_"))
         and os.path.isdir(os.path.join(save_root, name))
         and not _is_resumable_checkpoint(os.path.join(save_root, name))
-    )
-
-
-def _is_complete_torch_dist_checkpoint(path: str) -> bool:
-    """Whether ``path`` holds a *finished* torch_dist checkpoint.
-
-    ``.metadata`` is written last, by ``save_state_dict_async_finalize``, so its
-    presence is what separates a completed save from a crashed one. Without this
-    check ``torch_dist_resume_checkpoint``'s ``iter_*`` scan accepts any directory
-    (its default ``is_complete`` is ``os.path.isdir``), so a conversion that died
-    mid-write is reported as a cache hit and silently skips re-conversion — which
-    then feeds partial weights to training. A crashed conversion does leave
-    ``common.pt`` and the ``.distcp`` shards behind, so those alone are not enough
-    to tell the two apart.
-    """
-    try:
-        names = os.listdir(path)
-    except OSError:
-        return False
-    return (
-        ".metadata" in names
-        and "common.pt" in names
-        and any(name.endswith(".distcp") for name in names)
     )
 
 
@@ -420,11 +399,11 @@ def build_ray_runtime_env(
         "LD_LIBRARY_PATH": _compose_ld_library_path(),
         "TRAINING_GYM_SUBSTEP_TIMING": substep_timing,
     }
-    env_vars.update(extra_env or {})
     env_vars.update(environment)
     # Tracker identity and credentials must match the preflight configuration.
     env_vars.update(metric_env)
     env_vars.update(timing_debug_env())
+    env_vars.update(extra_env or {})
     if framework_status_token:
         # Applied after `environment` so a recipe override can't blank the
         # dashboard auth token by accident.
@@ -593,6 +572,10 @@ def build_miles_app(
         )
         setattr(miles, attr, None)
 
+    image = image.run_commands(
+        f"echo {_PATCH_CHECKPOINT_COMMIT_B64} | base64 -d | python3"
+    )
+
     hf_cache_volume = Volume.from_name("huggingface-cache", create_if_missing=True)
     data_volume = Volume.from_name(f"{volume_prefix}-data", create_if_missing=True)
     checkpoints_volume_name, checkpoints_mount_path, checkpoints_volume = (
@@ -601,6 +584,12 @@ def build_miles_app(
             volume_prefix=volume_prefix,
             default_mount_path=str(CHECKPOINTS_PATH),
         )
+    )
+    checkpoint_dir = compute_save_root(
+        miles.save,
+        recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
+        mounted_save_root=checkpoints_mount_path,
+        training_run_id=training_run_id,
     )
     all_volumes: dict[str | PurePosixPath, Any] = {
         str(HF_CACHE_PATH): hf_cache_volume,
@@ -709,7 +698,7 @@ def build_miles_app(
 
         save_path = str(miles.ref_load)
         if has_torch_dist_checkpoint(
-            save_path, is_complete=_is_complete_torch_dist_checkpoint
+            save_path, is_complete=is_complete_torch_dist_checkpoint_dir
         ):
             print(
                 f"Found existing torch_dist checkpoint at {save_path}; "
@@ -745,7 +734,7 @@ def build_miles_app(
                     for name in sorted(os.listdir(save_path))
                     if (name == "release" or name.startswith("iter_"))
                     and os.path.isdir(os.path.join(save_path, name))
-                    and not _is_complete_torch_dist_checkpoint(
+                    and not is_complete_torch_dist_checkpoint_dir(
                         os.path.join(save_path, name)
                     )
                 ]
@@ -882,7 +871,7 @@ def build_miles_app(
                     # Fail loudly here rather than leaving a partial checkpoint for a later
                     # run to mistake for a cache hit.
                     if not has_torch_dist_checkpoint(
-                        save_path, is_complete=_is_complete_torch_dist_checkpoint
+                        save_path, is_complete=is_complete_torch_dist_checkpoint_dir
                     ):
                         raise RuntimeError(
                             f"Conversion finished but {save_path} holds no complete "
@@ -1033,6 +1022,9 @@ def build_miles_app(
                 metric_cfg=miles.metrics,
                 metric_entity=metric_entity,
                 framework_status_token=framework_status_token,
+                checkpoint_dir=checkpoint_dir,
+                checkpoints_volume_name=checkpoints_volume_name,
+                checkpoints_mount_path=checkpoints_mount_path,
             )
 
         # In-flight status updates are fire-and-forget HTTP POSTs to the
@@ -1148,12 +1140,8 @@ def build_miles_app(
             extra_config = miles.extra_config or {}
             prepare_miles_config(miles, model, tempfile.mkdtemp())
 
-            save_root = compute_save_root(
-                miles.save,
-                recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
-                mounted_save_root=checkpoints_mount_path,
-                training_run_id=training_run_id,
-            )
+            save_root = checkpoint_dir
+            os.makedirs(save_root, exist_ok=True)
 
             original_save = miles.save
             original_load = miles.load
@@ -1226,6 +1214,7 @@ def build_miles_app(
                 extra_env={
                     "TRAINING_GYM_TRAINING_RUN_ID": training_run_id,
                     "TRAINING_GYM_APP_NAME": app_name,
+                    "TRAINING_GYM_CHECKPOINTS_VOLUME_NAME": checkpoints_volume_name,
                     "TRAINING_GYM_TOTAL_STEPS": str(miles.num_rollout),
                     "TRAINING_GYM_RESPONSE_PARSER_PATH": _response_parser_path(model),
                     "TRAINING_GYM_CAPTURE_TRACE": (

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -51,7 +51,7 @@ from modal_training_gym.common.launcher_helpers import (
     build_app_tags,
     build_terminal_run_record,
     build_train_result,
-    compute_save_root,
+    compute_recipe_save_root,
     init_training_run_record,
     mark_run_failed,
     mark_run_stopped,
@@ -639,8 +639,8 @@ def build_slime_app(
             default_mount_path=str(CHECKPOINTS_PATH),
         )
     )
-    checkpoint_dir = compute_save_root(
-        slime.save,
+    checkpoint_dir = compute_recipe_save_root(
+        slime,
         recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
         mounted_save_root=checkpoints_mount_path,
         training_run_id=training_run_id,

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -77,6 +77,9 @@ from modal_training_gym.common.metrics import (
 from modal_training_gym.common.trackio import resolve_trackio_destination
 from modal_training_gym.common.wandb import WandbConfig
 from modal_training_gym.common.status import SlimeStatus
+from modal_training_gym.common.torch_dist_checkpoint import (
+    is_complete_torch_dist_checkpoint_dir,
+)
 
 from modal_training_gym.train_recipes.slime_recipe.recipe import (
     CHECKPOINTS_PATH,
@@ -126,6 +129,9 @@ _PATCH_MEGATRON_BRIDGE_B64 = encode_patch("patch_megatron_bridge", _SLIME_PATCHE
 _PATCH_TORCH_LOAD_B64 = encode_patch("patch_torch_load", _MEGATRON_PATCHES)
 _PATCH_GLOBAL_PLAN_B64 = encode_patch("patch_global_plan", _SLIME_PATCHES)
 _PATCH_CHECKPOINT_SAVE_B64 = encode_patch("patch_checkpoint_save", _MEGATRON_PATCHES)
+_PATCH_CHECKPOINT_COMMIT_B64 = encode_patch(
+    "patch_checkpoint_commit", _MEGATRON_PATCHES
+)
 _PATCH_ADVANTAGES_B64 = encode_patch("patch_advantages", _SLIME_PATCHES)
 _PATCH_BRIDGE_NONE_TASK_B64 = encode_patch("patch_bridge_none_task", _SLIME_PATCHES)
 _PATCH_GDN_PACKED_SEQ_B64 = encode_patch("patch_gdn_packed_seq", _MEGATRON_PATCHES)
@@ -294,14 +300,6 @@ def _response_parser_path(model: Any) -> str:
     return f"{module}.{qualname}" if module and qualname else ""
 
 
-def _is_complete_torch_dist_checkpoint(path: str) -> bool:
-    try:
-        names = os.listdir(path)
-    except OSError:
-        return False
-    return "common.pt" in names and any(name.endswith(".distcp") for name in names)
-
-
 _PIPELINE_SPLIT_FLAGS = (
     "--decoder-first-pipeline-num-layers",
     "--decoder-last-pipeline-num-layers",
@@ -341,7 +339,7 @@ def _checkpoint_conversion_cache_status(
     if not os.path.exists(save_path):
         return "missing", None
     if not has_torch_dist_checkpoint(
-        save_path, is_complete=_is_complete_torch_dist_checkpoint
+        save_path, is_complete=is_complete_torch_dist_checkpoint_dir
     ):
         return "incomplete", None
 
@@ -611,7 +609,6 @@ def build_slime_app(
             )
         object.__setattr__(slime, "extra_config", cfg)
 
-    # Build train_image AFTER _ship_callable so shipped modules are included.
     train_image = image
     if _has_hybrid_spec:
         train_image = image.run_commands(
@@ -619,6 +616,9 @@ def build_slime_app(
             f"echo {_PATCH_GLOBAL_PLAN_B64} | base64 -d | python3",
             f"echo {_PATCH_CHECKPOINT_SAVE_B64} | base64 -d | python3",
         )
+    train_image = train_image.run_commands(
+        f"echo {_PATCH_CHECKPOINT_COMMIT_B64} | base64 -d | python3"
+    )
     if _has_gdn:
         train_image = train_image.run_commands(
             f"echo {_PATCH_GDN_PACKED_SEQ_B64} | base64 -d | python3",
@@ -638,6 +638,12 @@ def build_slime_app(
             volume_prefix=volume_prefix,
             default_mount_path=str(CHECKPOINTS_PATH),
         )
+    )
+    checkpoint_dir = compute_save_root(
+        slime.save,
+        recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
+        mounted_save_root=checkpoints_mount_path,
+        training_run_id=training_run_id,
     )
     metadata_volume = Volume.from_name("training-gym-metadata", create_if_missing=True)
     all_volumes: dict[str | PurePosixPath, Any] = {
@@ -1047,6 +1053,9 @@ def build_slime_app(
             metric_cfg=slime.metrics,
             metric_entity=metric_entity,
             framework_status_token=framework_status_token,
+            checkpoint_dir=checkpoint_dir,
+            checkpoints_volume_name=checkpoints_volume_name,
+            checkpoints_mount_path=checkpoints_mount_path,
         )
 
         try:  # Wraps all post-setup work so any failure marks the run terminal.
@@ -1100,12 +1109,8 @@ def build_slime_app(
             await _set_framework_status_async(SlimeStatus.CONVERT_MODEL)
             prepare_slime_config(slime, model, tempfile.mkdtemp())
 
-            save_root = compute_save_root(
-                slime.save,
-                recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
-                mounted_save_root=checkpoints_mount_path,
-                training_run_id=training_run_id,
-            )
+            save_root = checkpoint_dir
+            os.makedirs(save_root, exist_ok=True)
 
             original_save = slime.save
             original_load = slime.load
@@ -1126,7 +1131,7 @@ def build_slime_app(
                 )
 
             resume_checkpoint = torch_dist_resume_checkpoint(
-                save_root, is_complete=_is_complete_torch_dist_checkpoint
+                save_root, is_complete=is_complete_torch_dist_checkpoint_dir
             )
             record_resume_checkpoint(run_record, resume_checkpoint)
             await run_record.save(is_async=True)
@@ -1212,6 +1217,7 @@ def build_slime_app(
                         entity=metric_entity,
                     ),
                     **timing_debug_env(),
+                    "TRAINING_GYM_CHECKPOINTS_VOLUME_NAME": checkpoints_volume_name,
                     "TRAINING_GYM_FRAMEWORK_STATUS_TOKEN": framework_status_token,
                 }
             }

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,12 +1,22 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
 import modal
 import pytest
 
 from modal_training_gym.common import checkpoint as checkpoint_mod
+from modal_training_gym.common import torch_dist_checkpoint as torch_dist
+from modal_training_gym.common.megatron_patches import patch_checkpoint_commit
 from modal_training_gym.common.checkpoint import (
     Checkpoint,
     CheckpointType,
     convert_megatron_checkpoint_to_hf,
+    volume_relative_path,
 )
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.launcher_helpers import compute_save_root
 from modal_training_gym.common.models import ModelConfig
 
 
@@ -56,11 +66,43 @@ def test_convert_megatron_checkpoint_to_hf_returns_hf_checkpoints_unchanged() ->
     assert result is checkpoint
 
 
+def test_save_root_must_stay_inside_checkpoint_volume() -> None:
+    with pytest.raises(TrainingGymConfigError, match="outside Volume mount"):
+        compute_save_root(
+            "/tmp/checkpoints",
+            recipe_default_save_root="/checkpoints",
+            mounted_save_root="/checkpoints",
+            training_run_id="run-1",
+        )
+
+
+@pytest.mark.parametrize("training_run_id", ["../outside", "/tmp/outside"])
+def test_training_run_id_cannot_escape_checkpoint_volume(
+    training_run_id: str,
+) -> None:
+    with pytest.raises(TrainingGymConfigError, match="outside Volume mount"):
+        compute_save_root(
+            "/checkpoints",
+            recipe_default_save_root="/checkpoints",
+            mounted_save_root="/checkpoints",
+            training_run_id=training_run_id,
+        )
+
+
+def test_relative_checkpoint_path_is_rejected() -> None:
+    with pytest.raises(TrainingGymConfigError, match="must be absolute POSIX paths"):
+        volume_relative_path("run/iter_10", "/checkpoints")
+
+
 def test_convert_reuses_when_marker_present(monkeypatch) -> None:
     _patch_volume(
         monkeypatch,
         _CheckpointVolume(
-            ["config.json", "model.safetensors", ".training_gym_convert_complete"]
+            [
+                "config.json",
+                "model.safetensors",
+                checkpoint_mod._CONVERT_COMPLETE_MARKER,
+            ]
         ),
     )
 
@@ -71,6 +113,23 @@ def test_convert_reuses_when_marker_present(monkeypatch) -> None:
     assert result.checkpoint_type is CheckpointType.hf
     assert result.path == "/checkpoints/run/iter_10_hf"
     assert result.name == "iter_10_hf"
+
+
+def test_convert_requires_existing_checkpoint_volume(monkeypatch) -> None:
+    lookups: list[tuple[str, bool]] = []
+
+    def lookup(name: str, *, create_if_missing: bool):
+        lookups.append((name, create_if_missing))
+        raise RuntimeError("missing-volume")
+
+    monkeypatch.setattr(checkpoint_mod.Volume, "from_name", lookup)
+
+    with pytest.raises(RuntimeError, match="missing-volume"):
+        convert_megatron_checkpoint_to_hf(
+            _megatron_checkpoint(), ModelConfig(model_name="Qwen/Qwen3-4B")
+        )
+
+    assert lookups == [("gym-checkpoints", False)]
 
 
 @pytest.mark.parametrize(
@@ -93,3 +152,119 @@ def test_convert_runs_without_marker(monkeypatch, names: list[str]) -> None:
         convert_megatron_checkpoint_to_hf(
             _megatron_checkpoint(), ModelConfig(model_name="Qwen/Qwen3-4B")
         )
+
+
+def _apply_commit_wraps(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    checkpointing = tmp_path / "checkpointing.py"
+    checkpointing.write_text("def save_checkpoint(iteration):\n    return iteration\n")
+    async_utils = tmp_path / "async_utils.py"
+    async_utils.write_text(
+        "def is_empty_async_queue():\n"
+        "    return True\n"
+        "def maybe_finalize_async_save(blocking=False):\n"
+        "    return blocking\n"
+    )
+    monkeypatch.setattr(patch_checkpoint_commit, "_CHECKPOINTING", checkpointing)
+    monkeypatch.setattr(patch_checkpoint_commit, "_ASYNC_UTILS", async_utils)
+    patch_checkpoint_commit.main()
+    return checkpointing, async_utils
+
+
+def _load_patched(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checkpoint_commit_wraps_save_and_async_finalize_once(
+    monkeypatch, tmp_path: Path
+) -> None:
+    checkpointing, async_utils = _apply_commit_wraps(monkeypatch, tmp_path)
+    patched_save = checkpointing.read_text()
+    patched_finalize = async_utils.read_text()
+
+    compile(patched_save, str(checkpointing), "exec")
+    compile(patched_finalize, str(async_utils), "exec")
+    assert patched_save.count(patch_checkpoint_commit._SAVE_MARKER) == 1
+    assert 'if not getattr(get_args(), "async_save", False):' in patched_save
+    assert "commit_latest_checkpoint_volume()" in patched_save
+    assert patched_finalize.count(patch_checkpoint_commit._FINALIZE_MARKER) == 1
+    assert "had_pending = not is_empty_async_queue()" in patched_finalize
+    assert "if had_pending:" in patched_finalize
+    assert "commit_latest_checkpoint_volume()" in patched_finalize
+
+    patch_checkpoint_commit.main()
+
+    assert checkpointing.read_text() == patched_save
+    assert async_utils.read_text() == patched_finalize
+
+
+def test_save_wrap_commits_only_for_sync_save(monkeypatch, tmp_path: Path) -> None:
+    checkpointing, _ = _apply_commit_wraps(monkeypatch, tmp_path)
+    events: list[str] = []
+    args = types.SimpleNamespace(async_save=True)
+    megatron = types.ModuleType("megatron")
+    megatron_training = types.ModuleType("megatron.training")
+    megatron_training.get_args = lambda: args
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.training", megatron_training)
+    monkeypatch.setattr(
+        torch_dist, "commit_latest_checkpoint_volume", lambda: events.append("commit")
+    )
+
+    save_mod = _load_patched(checkpointing, "patched_save_checkpoint")
+    assert save_mod.save_checkpoint(1) == 1
+    assert events == []
+
+    args.async_save = False
+    assert save_mod.save_checkpoint(2) == 2
+    assert events == ["commit"]
+
+
+def test_save_wrap_does_not_swallow_get_args_failure(
+    monkeypatch, tmp_path: Path
+) -> None:
+    checkpointing, _ = _apply_commit_wraps(monkeypatch, tmp_path)
+    megatron = types.ModuleType("megatron")
+    megatron_training = types.ModuleType("megatron.training")
+
+    def boom():
+        raise RuntimeError("args unset")
+
+    megatron_training.get_args = boom
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.training", megatron_training)
+
+    save_mod = _load_patched(checkpointing, "patched_save_checkpoint_args")
+    with pytest.raises(RuntimeError, match="args unset"):
+        save_mod.save_checkpoint(1)
+
+
+def test_finalize_wrap_skips_commit_when_queue_empty(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _, async_utils = _apply_commit_wraps(monkeypatch, tmp_path)
+    events: list[str] = []
+    monkeypatch.setattr(
+        torch_dist, "commit_latest_checkpoint_volume", lambda: events.append("commit")
+    )
+
+    finalize_mod = _load_patched(async_utils, "patched_finalize_empty")
+    assert finalize_mod.maybe_finalize_async_save(True) is True
+    assert events == []
+
+
+def test_finalize_wrap_commits_when_queue_had_work(monkeypatch, tmp_path: Path) -> None:
+    _, async_utils = _apply_commit_wraps(monkeypatch, tmp_path)
+    events: list[str] = []
+    monkeypatch.setattr(
+        torch_dist, "commit_latest_checkpoint_volume", lambda: events.append("commit")
+    )
+
+    finalize_mod = _load_patched(async_utils, "patched_finalize_pending")
+    finalize_mod.is_empty_async_queue = lambda: False
+    assert finalize_mod.maybe_finalize_async_save(True) is True
+    assert events == ["commit"]

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -16,7 +16,10 @@ from modal_training_gym.common.checkpoint import (
     volume_relative_path,
 )
 from modal_training_gym.common.errors import TrainingGymConfigError
-from modal_training_gym.common.launcher_helpers import compute_save_root
+from modal_training_gym.common.launcher_helpers import (
+    compute_recipe_save_root,
+    compute_save_root,
+)
 from modal_training_gym.common.models import ModelConfig
 
 
@@ -74,6 +77,42 @@ def test_save_root_must_stay_inside_checkpoint_volume() -> None:
             mounted_save_root="/checkpoints",
             training_run_id="run-1",
         )
+
+
+def test_extra_config_save_wins_and_is_pinned_to_scoped_root() -> None:
+    recipe = types.SimpleNamespace(
+        save="/checkpoints",
+        extra_config={"save": "/checkpoints/custom", "qkv_format": "bshd"},
+    )
+
+    root = compute_recipe_save_root(
+        recipe,
+        recipe_default_save_root="/checkpoints",
+        mounted_save_root="/checkpoints",
+        training_run_id="run-1",
+    )
+
+    assert root == "/checkpoints/custom/run-1"
+    assert recipe.extra_config == {
+        "save": "/checkpoints/custom/run-1",
+        "qkv_format": "bshd",
+    }
+
+
+def test_recipe_save_is_used_when_extra_config_omits_save() -> None:
+    recipe = types.SimpleNamespace(
+        save="/checkpoints", extra_config={"qkv_format": "thd"}
+    )
+
+    root = compute_recipe_save_root(
+        recipe,
+        recipe_default_save_root="/checkpoints",
+        mounted_save_root="/checkpoints",
+        training_run_id="run-1",
+    )
+
+    assert root == "/checkpoints/run-1"
+    assert recipe.extra_config == {"qkv_format": "thd"}
 
 
 @pytest.mark.parametrize("training_run_id", ["../outside", "/tmp/outside"])

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -227,7 +227,6 @@ def _checkpoint(
         ("/checkpoints/run-1/iter_10_hf", "/checkpoints", "run-1/iter_10_hf"),
         ("/checkpoints/run-1/iter_10_hf/", "/checkpoints", "run-1/iter_10_hf"),
         ("/data/ckpt/iter_5_hf", "/data/ckpt", "iter_5_hf"),
-        ("run-1/iter_10_hf", "/checkpoints", "run-1/iter_10_hf"),
         ("/checkpoints", "/checkpoints", ""),
     ],
 )

--- a/tests/test_miles_runtime_env.py
+++ b/tests/test_miles_runtime_env.py
@@ -74,6 +74,21 @@ def test_recipe_environment_still_wins(monkeypatch):
     assert env_vars["PYTHONPATH"] == "/root/Megatron-LM/"
 
 
+def test_reserved_checkpoint_environment_wins(monkeypatch):
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+
+    env_vars = build_ray_runtime_env(
+        head_addr="10.0.0.1",
+        metric_env={},
+        environment={"TRAINING_GYM_CHECKPOINTS_VOLUME_NAME": "wrong-volume"},
+        extra_env={
+            "TRAINING_GYM_CHECKPOINTS_VOLUME_NAME": "miles-checkpoints",
+        },
+    )["env_vars"]
+
+    assert env_vars["TRAINING_GYM_CHECKPOINTS_VOLUME_NAME"] == "miles-checkpoints"
+
+
 def test_unset_container_path_yields_only_the_system_lib_dir(monkeypatch):
     """No empty entry, which the loader would read as the working directory."""
     monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)

--- a/tests/test_torch_dist_checkpoint.py
+++ b/tests/test_torch_dist_checkpoint.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modal_training_gym.common import torch_dist_checkpoint as checkpoint
+
+
+class _DistWrapper:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        is_coordinator: bool,
+        gathered: list[list[str | None]] | None = None,
+    ) -> None:
+        self.events = events
+        self.is_coordinator = is_coordinator
+        self.gathered = list(gathered or [])
+
+    def all_gather_object(self, error: str | None) -> list[str | None]:
+        self.events.append(f"gather:{error}")
+        return self.gathered.pop(0) if self.gathered else [error]
+
+
+class _Volume:
+    def __init__(self, events: list[str], *, fail_commit: bool = False) -> None:
+        self.events = events
+        self.fail_commit = fail_commit
+
+    def commit(self) -> None:
+        self.events.append("commit")
+        if self.fail_commit:
+            raise RuntimeError("commit")
+
+
+def _patch_volume(monkeypatch: pytest.MonkeyPatch, volume: _Volume) -> None:
+    def from_name(name: str, *, create_if_missing: bool) -> _Volume:
+        assert name == "checkpoints"
+        assert not create_if_missing
+        return volume
+
+    monkeypatch.setattr(checkpoint.Volume, "from_name", from_name)
+
+
+def _write_complete_checkpoint(path: Path) -> None:
+    path.mkdir()
+    for name in (".metadata", "common.pt", "shard.distcp"):
+        (path / name).touch()
+
+
+def test_checkpoint_completeness_requires_full_layout(tmp_path: Path) -> None:
+    checkpoint_dir = tmp_path / "iter_0000001"
+
+    assert not checkpoint.is_complete_torch_dist_checkpoint(
+        {"common.pt", "shard.distcp"}
+    )
+    assert not checkpoint.is_complete_torch_dist_checkpoint_dir(checkpoint_dir)
+
+    _write_complete_checkpoint(checkpoint_dir)
+
+    assert checkpoint.is_complete_torch_dist_checkpoint(
+        {".metadata", "common.pt", "shard.distcp"}
+    )
+    assert checkpoint.is_complete_torch_dist_checkpoint_dir(checkpoint_dir)
+
+
+def test_checkpoint_completeness_treats_unreadable_directory_as_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_permission_error(_path: Path):
+        raise PermissionError("unreadable")
+
+    monkeypatch.setattr(Path, "iterdir", raise_permission_error)
+
+    assert not checkpoint.is_complete_torch_dist_checkpoint_dir("/checkpoints/run")
+
+
+def test_parse_tracker_and_iteration() -> None:
+    assert checkpoint.parse_torch_dist_tracker("1\n") == 1
+    assert checkpoint.parse_torch_dist_tracker("release") is None
+    assert checkpoint.parse_torch_dist_iteration("iter_0000007") == 7
+    assert checkpoint.parse_torch_dist_iteration("iter_0000007_hf") is None
+
+
+def test_commit_across_ranks_commits_noncoordinator_leaders_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    _patch_volume(monkeypatch, _Volume(events))
+
+    checkpoint.commit_checkpoint_volume_across_ranks(
+        "checkpoints",
+        _DistWrapper(events, is_coordinator=False),
+        lambda: events.append("barrier"),
+    )
+
+    assert events == ["commit", "gather:None", "barrier", "gather:None", "barrier"]
+
+
+def test_commit_across_ranks_commits_coordinator_last(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    _patch_volume(monkeypatch, _Volume(events))
+
+    checkpoint.commit_checkpoint_volume_across_ranks(
+        "checkpoints",
+        _DistWrapper(events, is_coordinator=True),
+        lambda: events.append("barrier"),
+    )
+
+    assert events == ["gather:None", "barrier", "commit", "gather:None", "barrier"]
+
+
+def test_commit_across_ranks_skips_non_leaders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    monkeypatch.setenv("LOCAL_RANK", "1")
+
+    checkpoint.commit_checkpoint_volume_across_ranks(
+        "checkpoints",
+        _DistWrapper(events, is_coordinator=False),
+        lambda: events.append("barrier"),
+    )
+
+    assert events == ["gather:None", "barrier", "gather:None", "barrier"]
+
+
+def test_commit_across_ranks_noop_without_volume_name() -> None:
+    events: list[str] = []
+
+    checkpoint.commit_checkpoint_volume_across_ranks(
+        None,
+        _DistWrapper(events, is_coordinator=True),
+        lambda: events.append("barrier"),
+    )
+    checkpoint.commit_checkpoint_volume_across_ranks(
+        "",
+        _DistWrapper(events, is_coordinator=True),
+        lambda: events.append("barrier"),
+    )
+
+    assert events == []
+
+
+def test_commit_across_ranks_stops_after_shard_commit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    _patch_volume(monkeypatch, _Volume(events, fail_commit=True))
+
+    with pytest.raises(RuntimeError, match="shard commit"):
+        checkpoint.commit_checkpoint_volume_across_ranks(
+            "checkpoints",
+            _DistWrapper(events, is_coordinator=False),
+            lambda: events.append("barrier"),
+        )
+
+    assert events == ["commit", "gather:RuntimeError: commit"]
+
+
+def test_commit_across_ranks_propagates_peer_failure() -> None:
+    events: list[str] = []
+    dist_wrapper = _DistWrapper(
+        events,
+        is_coordinator=True,
+        gathered=[["RuntimeError: peer commit"]],
+    )
+
+    with pytest.raises(RuntimeError, match="shard commit"):
+        checkpoint.commit_checkpoint_volume_across_ranks(
+            "checkpoints",
+            dist_wrapper,
+            lambda: events.append("barrier"),
+        )
+
+    assert events == ["gather:None"]

--- a/tests/test_training_run_checkpoints.py
+++ b/tests/test_training_run_checkpoints.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+import modal_training_gym.common.checkpoint as checkpoint_mod
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.launcher_helpers import init_training_run_record
+from modal_training_gym.common.models import Qwen3_5_4B
+from modal_training_gym.common.run import (
+    CHECKPOINT_LOCATION_METADATA_KEY,
+    TrainingRun,
+    set_checkpoint_location,
+)
+from modal_training_gym.common.train_result import TrainResult
+
+
+@dataclass
+class _DirEntry:
+    path: str
+    mtime: float = 1.0
+    is_directory: bool = False
+
+    def is_dir(self) -> bool:
+        return self.is_directory
+
+
+class _ListingVolume:
+    def __init__(
+        self,
+        tree: dict[str, list[_DirEntry]],
+        files: dict[str, bytes] | None = None,
+    ) -> None:
+        self.tree = tree
+        self.files = files or {}
+
+    def iterdir(self, path: str, *, recursive: bool = False):
+        del recursive
+        key = path.rstrip("/") or "."
+        return list(self.tree.get(key, []))
+
+    def read_file(self, path: str):
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return [self.files[path]]
+
+
+def _complete_iter_files(name: str) -> list[_DirEntry]:
+    child_key = f"run-1/{name}"
+    return [
+        _DirEntry(f"{child_key}/common.pt"),
+        _DirEntry(f"{child_key}/shard.distcp"),
+        _DirEntry(f"{child_key}/.metadata"),
+    ]
+
+
+def _complete_hf_files(name: str) -> list[_DirEntry]:
+    return [
+        _DirEntry(f"run-1/{name}/config.json"),
+        _DirEntry(f"run-1/{name}/model.safetensors"),
+        _DirEntry(f"run-1/{name}/{checkpoint_mod._CONVERT_COMPLETE_MARKER}"),
+    ]
+
+
+def _run_with_checkpoint_location() -> TrainingRun:
+    run = TrainingRun(
+        training_run_id="run-1",
+        framework=Framework.SLIME,
+        config={},
+    )
+    set_checkpoint_location(
+        run,
+        checkpoint_dir="/checkpoints/run-1",
+        checkpoints_volume_name="slime-slime4brecipe-checkpoints",
+        checkpoints_mount_path="/checkpoints",
+    )
+    return run
+
+
+def _train_result() -> TrainResult:
+    return TrainResult(
+        app_name="slime",
+        framework=Framework.SLIME,
+        training_run_id="run-1",
+        checkpoint_dir="/checkpoints/run-1",
+        checkpoints_volume_name="slime-slime4brecipe-checkpoints",
+        checkpoints_mount_path="/checkpoints",
+        model_config=Qwen3_5_4B(),
+    )
+
+
+def test_live_run_lists_complete_iter_at_or_before_tracker(
+    monkeypatch, fake_volume
+) -> None:
+    run = _run_with_checkpoint_location()
+    volume = _ListingVolume(
+        {
+            "run-1": [
+                _DirEntry("iter_0000001", is_directory=True),
+                _DirEntry("iter_0000002", is_directory=True),
+                _DirEntry("iter_0000003", is_directory=True),
+                _DirEntry("iter_0000004_hf", is_directory=True),
+            ],
+            "run-1/iter_0000001": _complete_iter_files("iter_0000001"),
+            "run-1/iter_0000002": [
+                _DirEntry("run-1/iter_0000002/common.pt"),
+                _DirEntry("run-1/iter_0000002/shard.distcp"),
+            ],
+            "run-1/iter_0000003": _complete_iter_files("iter_0000003"),
+            "run-1/iter_0000004_hf": _complete_hf_files("iter_0000004_hf"),
+        },
+        files={"run-1/latest_checkpointed_iteration.txt": b"1\n"},
+    )
+    monkeypatch.setattr(
+        checkpoint_mod.Volume, "from_name", lambda *args, **kwargs: volume
+    )
+
+    assert [checkpoint.name for checkpoint in run.checkpoints()] == ["iter_0000001"]
+    assert run.latest_checkpoint() is not None
+    assert run.latest_checkpoint().name == "iter_0000001"
+
+
+def test_live_run_hides_checkpoints_without_tracker(monkeypatch, fake_volume) -> None:
+    run = _run_with_checkpoint_location()
+    volume = _ListingVolume(
+        {
+            "run-1": [_DirEntry("iter_0000001", is_directory=True)],
+            "run-1/iter_0000001": _complete_iter_files("iter_0000001"),
+        }
+    )
+    monkeypatch.setattr(
+        checkpoint_mod.Volume, "from_name", lambda *args, **kwargs: volume
+    )
+
+    assert run.checkpoints() == []
+
+
+def test_train_result_lists_complete_dirs_without_tracker(monkeypatch) -> None:
+    volume = _ListingVolume(
+        {
+            "run-1": [_DirEntry("iter_0000001", is_directory=True)],
+            "run-1/iter_0000001": _complete_iter_files("iter_0000001"),
+        }
+    )
+    monkeypatch.setattr(
+        checkpoint_mod.Volume, "from_name", lambda *args, **kwargs: volume
+    )
+
+    assert [checkpoint.name for checkpoint in _train_result().checkpoints()] == [
+        "iter_0000001"
+    ]
+
+
+def test_train_result_lists_hf_and_latest_checkpoint_stays_megatron(
+    monkeypatch,
+) -> None:
+    volume = _ListingVolume(
+        {
+            "run-1": [
+                _DirEntry("iter_0000001", is_directory=True),
+                _DirEntry("iter_0000001_hf", is_directory=True),
+                _DirEntry("iter_0000002_hf", is_directory=True),
+            ],
+            "run-1/iter_0000001": _complete_iter_files("iter_0000001"),
+            "run-1/iter_0000001_hf": _complete_hf_files("iter_0000001_hf"),
+            "run-1/iter_0000002_hf": [
+                _DirEntry("run-1/iter_0000002_hf/model.safetensors")
+            ],
+        }
+    )
+    monkeypatch.setattr(
+        checkpoint_mod.Volume, "from_name", lambda *args, **kwargs: volume
+    )
+    result = _train_result()
+
+    checkpoints = result.checkpoints()
+
+    assert [
+        (checkpoint.name, checkpoint.checkpoint_type) for checkpoint in checkpoints
+    ] == [
+        ("iter_0000001", checkpoint_mod.CheckpointType.megatron),
+        ("iter_0000001_hf", checkpoint_mod.CheckpointType.hf),
+    ]
+    assert result.latest_checkpoint() is not None
+    assert result.latest_checkpoint().name == "iter_0000001"
+    assert result.model.model_path == "/checkpoints/run-1/iter_0000001"
+
+
+def test_checkpoint_reads_do_not_create_missing_volume(
+    monkeypatch, fake_volume
+) -> None:
+    calls: list[bool] = []
+
+    def _missing_volume(_name: str, *, create_if_missing: bool):
+        calls.append(create_if_missing)
+        raise RuntimeError("missing-volume")
+
+    monkeypatch.setattr(checkpoint_mod.Volume, "from_name", _missing_volume)
+
+    with pytest.raises(RuntimeError, match="missing-volume"):
+        _run_with_checkpoint_location().checkpoints()
+
+    result = TrainResult(
+        app_name="slime",
+        framework=Framework.SLIME,
+        training_run_id="run-1",
+        checkpoints_volume_name="checkpoints",
+    )
+
+    with pytest.raises(RuntimeError, match="missing-volume"):
+        result.volume()
+
+    assert calls == [False, False]
+
+
+def test_listing_without_checkpoint_location_is_empty(fake_volume) -> None:
+    run = TrainingRun(
+        training_run_id="run-1",
+        framework=Framework.SLIME,
+        config={},
+    )
+
+    assert run.checkpoints() == []
+
+
+def test_latest_checkpoint_sees_location_written_after_launch(
+    monkeypatch, fake_volume
+) -> None:
+    live = TrainingRun(
+        training_run_id="run-1",
+        framework=Framework.SLIME,
+        config={},
+    )
+    stored = _run_with_checkpoint_location()
+    stored.save()
+    volume = _ListingVolume(
+        {
+            "run-1": [_DirEntry("iter_0000001", is_directory=True)],
+            "run-1/iter_0000001": _complete_iter_files("iter_0000001"),
+        },
+        files={"run-1/latest_checkpointed_iteration.txt": b"1\n"},
+    )
+    monkeypatch.setattr(
+        checkpoint_mod.Volume, "from_name", lambda *args, **kwargs: volume
+    )
+    handle = id(live)
+
+    checkpoint = live.latest_checkpoint()
+
+    assert id(live) == handle
+    assert checkpoint is not None
+    assert checkpoint.name == "iter_0000001"
+
+
+@pytest.mark.anyio
+async def test_direct_train_initialization_persists_checkpoint_location(
+    fake_volume,
+) -> None:
+    run, _, _ = await init_training_run_record(
+        training_run_id="run-1",
+        modal_app_id="ap-test",
+        modal_app_url="https://modal.com/apps/test",
+        framework=Framework.SLIME,
+        initializing_status=None,
+        config_summary={},
+        metric_cfg=None,
+        metric_entity="",
+        framework_status_token="token",
+        checkpoint_dir="/checkpoints/run-1",
+        checkpoints_volume_name="slime-checkpoints",
+        checkpoints_mount_path="/checkpoints",
+    )
+
+    stored = TrainingRun.from_id("run-1")
+    expected = {
+        "checkpoint_dir": "/checkpoints/run-1",
+        "checkpoints_volume_name": "slime-checkpoints",
+        "checkpoints_mount_path": "/checkpoints",
+    }
+
+    assert (run.metadata or {})[CHECKPOINT_LOCATION_METADATA_KEY] == expected
+    assert (stored.metadata or {})[CHECKPOINT_LOCATION_METADATA_KEY] == expected
+    assert "checkpoint_dir" not in stored.model_dump()

--- a/tests/test_training_run_checkpoints.py
+++ b/tests/test_training_run_checkpoints.py
@@ -156,7 +156,7 @@ def test_train_result_lists_complete_dirs_without_tracker(monkeypatch) -> None:
     ]
 
 
-def test_train_result_lists_hf_and_latest_checkpoint_stays_megatron(
+def test_train_result_skips_hf_and_latest_checkpoint_stays_megatron(
     monkeypatch,
 ) -> None:
     volume = _ListingVolume(
@@ -184,7 +184,6 @@ def test_train_result_lists_hf_and_latest_checkpoint_stays_megatron(
         (checkpoint.name, checkpoint.checkpoint_type) for checkpoint in checkpoints
     ] == [
         ("iter_0000001", checkpoint_mod.CheckpointType.megatron),
-        ("iter_0000001_hf", checkpoint_mod.CheckpointType.hf),
     ]
     assert result.latest_checkpoint() is not None
     assert result.latest_checkpoint().name == "iter_0000001"

--- a/tests/test_training_run_checkpoints.py
+++ b/tests/test_training_run_checkpoints.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
 
 import modal_training_gym.common.checkpoint as checkpoint_mod
 from modal_training_gym.common.framework import Framework
-from modal_training_gym.common.launcher_helpers import init_training_run_record
+from modal_training_gym.common.launcher_helpers import (
+    compute_recipe_save_root,
+    init_training_run_record,
+)
 from modal_training_gym.common.models import Qwen3_5_4B
 from modal_training_gym.common.run import (
     CHECKPOINT_LOCATION_METADATA_KEY,
@@ -212,6 +216,53 @@ def test_checkpoint_reads_do_not_create_missing_volume(
         result.volume()
 
     assert calls == [False, False]
+
+
+def test_latest_checkpoint_reads_extra_config_save_override(
+    monkeypatch, fake_volume
+) -> None:
+    recipe = SimpleNamespace(
+        save="/checkpoints",
+        extra_config={"save": "/checkpoints/custom"},
+    )
+    checkpoint_dir = compute_recipe_save_root(
+        recipe,
+        recipe_default_save_root="/checkpoints",
+        mounted_save_root="/checkpoints",
+        training_run_id="run-1",
+    )
+    run = TrainingRun(
+        training_run_id="run-1",
+        framework=Framework.SLIME,
+        config={},
+    )
+    set_checkpoint_location(
+        run,
+        checkpoint_dir=checkpoint_dir,
+        checkpoints_volume_name="slime-slime4brecipe-checkpoints",
+        checkpoints_mount_path="/checkpoints",
+    )
+    volume = _ListingVolume(
+        {
+            "custom/run-1": [_DirEntry("iter_0000001", is_directory=True)],
+            "custom/run-1/iter_0000001": [
+                _DirEntry("custom/run-1/iter_0000001/common.pt"),
+                _DirEntry("custom/run-1/iter_0000001/shard.distcp"),
+                _DirEntry("custom/run-1/iter_0000001/.metadata"),
+            ],
+        },
+        files={"custom/run-1/latest_checkpointed_iteration.txt": b"1\n"},
+    )
+    monkeypatch.setattr(
+        checkpoint_mod.Volume, "from_name", lambda *args, **kwargs: volume
+    )
+
+    latest = run.latest_checkpoint()
+
+    assert checkpoint_dir == "/checkpoints/custom/run-1"
+    assert latest is not None
+    assert latest.name == "iter_0000001"
+    assert latest.path == "/checkpoints/custom/run-1/iter_0000001"
 
 
 def test_listing_without_checkpoint_location_is_empty(fake_volume) -> None:

--- a/tests/test_training_run_done.py
+++ b/tests/test_training_run_done.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from modal.exception import NotFoundError
+
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.run import TrainingRun, TrainingRunStatus
+
+
+def _run(status: TrainingRunStatus) -> TrainingRun:
+    return TrainingRun(
+        training_run_id="run-1",
+        framework=Framework.SLIME,
+        config={},
+        status=status,
+    )
+
+
+def test_done_is_false_while_running(fake_volume):
+    assert _run(TrainingRunStatus.RUNNING).done() is False
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        TrainingRunStatus.COMPLETED,
+        TrainingRunStatus.FAILED,
+        TrainingRunStatus.STOPPED,
+        TrainingRunStatus.CANCELLED,
+    ],
+)
+def test_done_is_true_for_terminal_status(status: TrainingRunStatus, fake_volume):
+    assert _run(status).done() is True
+
+
+def test_done_sees_status_written_after_launch(fake_volume):
+    live = _run(TrainingRunStatus.RUNNING)
+    _run(TrainingRunStatus.COMPLETED).save()
+    handle = id(live)
+
+    assert live.done() is True
+    assert id(live) == handle
+    assert live.status is TrainingRunStatus.COMPLETED
+
+
+@pytest.mark.parametrize("exc", [KeyError("run-1"), NotFoundError("run-1")])
+def test_reload_swallows_missing_run(exc: Exception, monkeypatch, fake_volume):
+    live = _run(TrainingRunStatus.RUNNING)
+
+    def missing(_run_id: str, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr(TrainingRun, "from_id", missing)
+    assert live.done() is False
+    assert live.status is TrainingRunStatus.RUNNING
+
+
+def test_reload_reraises_non_miss_errors(monkeypatch, fake_volume):
+    live = _run(TrainingRunStatus.RUNNING)
+
+    def boom(_run_id: str, **_kwargs):
+        raise RuntimeError("corrupt metadata")
+
+    monkeypatch.setattr(TrainingRun, "from_id", boom)
+    with pytest.raises(RuntimeError, match="corrupt metadata"):
+        live.done()

--- a/tests/test_training_run_done.py
+++ b/tests/test_training_run_done.py
@@ -64,3 +64,59 @@ def test_reload_reraises_non_miss_errors(monkeypatch, fake_volume):
     monkeypatch.setattr(TrainingRun, "from_id", boom)
     with pytest.raises(RuntimeError, match="corrupt metadata"):
         live.done()
+
+
+def test_context_manager_stops_app(monkeypatch):
+    stopped: list[str] = []
+    monkeypatch.setattr(
+        "modal_training_gym.common.modal_lifecycle.stop_app", stopped.append
+    )
+    run = _run(TrainingRunStatus.RUNNING)
+    run.modal_app_id = "ap-1"
+
+    with run as entered:
+        assert entered is run
+        assert stopped == []
+
+    assert stopped == ["ap-1"]
+
+
+def test_exit_closes_after_exception(monkeypatch):
+    stopped: list[str] = []
+    monkeypatch.setattr(
+        "modal_training_gym.common.modal_lifecycle.stop_app", stopped.append
+    )
+    run = _run(TrainingRunStatus.RUNNING)
+    run.modal_app_id = "ap-1"
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with run:
+            raise RuntimeError("boom")
+
+    assert stopped == ["ap-1"]
+
+
+def test_close_is_idempotent(monkeypatch):
+    stopped: list[str] = []
+    monkeypatch.setattr(
+        "modal_training_gym.common.modal_lifecycle.stop_app", stopped.append
+    )
+    run = _run(TrainingRunStatus.COMPLETED)
+    run.modal_app_id = "ap-1"
+
+    run.close()
+    run.close()
+
+    assert stopped == ["ap-1"]
+
+
+def test_done_does_not_stop_app(monkeypatch, fake_volume):
+    stopped: list[str] = []
+    monkeypatch.setattr(
+        "modal_training_gym.common.modal_lifecycle.stop_app", stopped.append
+    )
+    run = _run(TrainingRunStatus.COMPLETED)
+    run.modal_app_id = "ap-1"
+
+    assert run.done() is True
+    assert stopped == []

--- a/tutorials/audio_asr.py
+++ b/tutorials/audio_asr.py
@@ -23,6 +23,7 @@ from datasets import Audio, load_dataset
 
 import base64
 import io
+import time
 from concurrent.futures import ThreadPoolExecutor
 
 from modal_training_gym import (
@@ -178,8 +179,11 @@ print(f"run id: {run.training_run_id}")
 #
 # Let's run the same eval on the trained checkpoint.
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = CustomDeployment.launch(

--- a/tutorials/audio_asr.py
+++ b/tutorials/audio_asr.py
@@ -172,19 +172,18 @@ config = TrainConfig(
         custom_rm_function=wer_rm,
     ),
 )
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Evaluate the trained checkpoint
 #
 # Let's run the same eval on the trained checkpoint.
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
-print(f"checkpoint: {checkpoint.path}")
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
+    print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = CustomDeployment.launch(
     model,

--- a/tutorials/computer_use.py
+++ b/tutorials/computer_use.py
@@ -299,19 +299,18 @@ config = TrainConfig(
         metrics=WandbConfig(project="computer-use-grounding"),
     ),
 )
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Evaluate the trained model
 #
 # Let's run the same eval on the trained checkpoint and compare accuracy.
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
-print(f"Checkpoint: {checkpoint.path}")
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
+    print(f"Checkpoint: {checkpoint.path}")
 
 trained_deployment = CustomDeployment.launch(
     model,

--- a/tutorials/computer_use.py
+++ b/tutorials/computer_use.py
@@ -22,6 +22,7 @@
 # toward −1 over a margin scaled to the element's own size.
 
 import re
+import time
 
 from modal_training_gym import (
     CustomDeployment,
@@ -305,8 +306,11 @@ print(f"run id: {run.training_run_id}")
 #
 # Let's run the same eval on the trained checkpoint and compare accuracy.
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 print(f"Checkpoint: {checkpoint.path}")
 
 trained_deployment = CustomDeployment.launch(

--- a/tutorials/cross_tokenizer_distillation.py
+++ b/tutorials/cross_tokenizer_distillation.py
@@ -30,6 +30,7 @@
 import asyncio
 import json
 import re
+import time
 
 from modal_training_gym import (
     CustomDeployment,
@@ -1044,9 +1045,12 @@ print(f"run id: {run.training_run_id}")
 #
 # Deploy the last checkpoint and re-run the held-out BFCL ids with the same evaluator from our earlier baseline.
 
-result = run.result()
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 print("--- Training complete ---")
-checkpoint = result.checkpoints()[-1]
 print(f"Checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(

--- a/tutorials/cross_tokenizer_distillation.py
+++ b/tutorials/cross_tokenizer_distillation.py
@@ -1038,20 +1038,19 @@ print("  Teacher: DeepSeek V4 Flash")
 print("  Student: Qwen3.6-35B-A3B")
 print("  Dataset: BFCL multi_turn_base, prefix-conditioned (task, K) rows")
 print("  Reward: schema + live exec + structural match + terminal state/response verdict")
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Evaluate the trained student
 #
 # Deploy the last checkpoint and re-run the held-out BFCL ids with the same evaluator from our earlier baseline.
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
-print("--- Training complete ---")
-print(f"Checkpoint: {checkpoint.path}")
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
+    print("--- Training complete ---")
+    print(f"Checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True

--- a/tutorials/dapo.py
+++ b/tutorials/dapo.py
@@ -15,6 +15,7 @@
 # You can read more about the algorithm in [the paper](https://arxiv.org/abs/2503.14476).
 
 import re
+import time
 
 from modal_training_gym import (
     Endpoint,
@@ -205,8 +206,11 @@ print(f"run id: {run.training_run_id}")
 #
 # Let's run the same eval on the trained checkpoint.
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(

--- a/tutorials/dapo.py
+++ b/tutorials/dapo.py
@@ -199,19 +199,18 @@ config = TrainConfig(
     ),
 )
 
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Evaluate the trained model
 #
 # Let's run the same eval on the trained checkpoint.
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
-print(f"checkpoint: {checkpoint.path}")
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
+    print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True

--- a/tutorials/multinode.py
+++ b/tutorials/multinode.py
@@ -61,19 +61,18 @@ config = TrainConfig(
     recipe=recipe,
 )
 
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Test out the trained model
 #
 # Spin up an [Endpoint](https://modal.com/docs/guide/endpoints) and try a prompt.
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
-print(f"checkpoint: {checkpoint.path}")
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
+    print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True

--- a/tutorials/multinode.py
+++ b/tutorials/multinode.py
@@ -16,6 +16,8 @@
 # on
 # [zhuzilin/dapo-math-17k](https://huggingface.co/datasets/zhuzilin/dapo-math-17k).
 
+import time
+
 from modal_training_gym import (
     Endpoint,
     GLM_4_7,
@@ -66,8 +68,11 @@ print(f"run id: {run.training_run_id}")
 #
 # Spin up an [Endpoint](https://modal.com/docs/guide/endpoints) and try a prompt.
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(

--- a/tutorials/multiturn.py
+++ b/tutorials/multiturn.py
@@ -20,6 +20,7 @@
 
 import json
 import re
+import time
 
 from modal_training_gym import (
     DatasetConfig,
@@ -390,8 +391,11 @@ print(f"run id: {run.training_run_id}")
 
 # ## Evaluate trained checkpoint
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True
 )

--- a/tutorials/multiturn.py
+++ b/tutorials/multiturn.py
@@ -386,16 +386,15 @@ config = TrainConfig(
     ),
 )
 print("Starting training...")
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Evaluate trained checkpoint
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True
 )

--- a/tutorials/on_policy_distillation.py
+++ b/tutorials/on_policy_distillation.py
@@ -37,6 +37,7 @@
 # [this tutorial](https://gym.modal.dev/tutorials/cross_tokenizer_distillation).
 
 import re
+import time
 
 from modal_training_gym import (
     CustomDeployment,
@@ -285,8 +286,11 @@ print(f"run id: {run.training_run_id}")
 # We'll deploy our trained student and compare it
 # to our baseline evaluation from earlier.
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 print(f"checkpoint: {checkpoint.path}")
 
 trained_student_deployment = Endpoint.launch(

--- a/tutorials/on_policy_distillation.py
+++ b/tutorials/on_policy_distillation.py
@@ -278,20 +278,19 @@ config = TrainConfig(
     ),
 )
 
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Evaluate the trained student
 #
 # We'll deploy our trained student and compare it
 # to our baseline evaluation from earlier.
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
-print(f"checkpoint: {checkpoint.path}")
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
+    print(f"checkpoint: {checkpoint.path}")
 
 trained_student_deployment = Endpoint.launch(
     student_model, checkpoint, unauthenticated=True, recreate_if_existing=True

--- a/tutorials/param_sweep.py
+++ b/tutorials/param_sweep.py
@@ -82,11 +82,12 @@ if group.failures:
 
 results = []
 for launch in launches:
-    while True:
-        if launch.done():
-            break
-        time.sleep(30)
-    results.append(launch)
-    print(f"completed {launch.training_run_id} (group_id={launch.group_id})")
+    with launch:
+        while True:
+            if launch.done():
+                break
+            time.sleep(30)
+        results.append(launch)
+        print(f"completed {launch.training_run_id} (group_id={launch.group_id})")
 
 print(f"group {group.group_id}: {len(results)} runs completed")

--- a/tutorials/param_sweep.py
+++ b/tutorials/param_sweep.py
@@ -8,6 +8,8 @@
 # and error-prone if not properly guided or documented. This is made a first-class
 # operation in the Gym so you can move faster and spend less.
 
+import time
+
 from modal_training_gym import (
     HuggingFaceDataset,
     Qwen3_5_4B,
@@ -80,8 +82,11 @@ if group.failures:
 
 results = []
 for launch in launches:
-    result = launch.result()
-    results.append(result)
-    print(f"completed {result.training_run_id} (group_id={result.group_id})")
+    while True:
+        if launch.done():
+            break
+        time.sleep(30)
+    results.append(launch)
+    print(f"completed {launch.training_run_id} (group_id={launch.group_id})")
 
 print(f"group {group.group_id}: {len(results)} runs completed")

--- a/tutorials/rl_basics.py
+++ b/tutorials/rl_basics.py
@@ -16,6 +16,7 @@ import nltk
 from nltk.corpus import cmudict
 
 import re
+import time
 
 from modal_training_gym import (
     Endpoint,
@@ -217,8 +218,11 @@ print(f"run id: {run.training_run_id}")
 #
 # We'll get the latest checkpoint and create a new Endpoint so we may evaluate it.
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(
@@ -262,8 +266,11 @@ print(f"run id: {new_run.training_run_id}")
 #
 # Once again, we'll create a new Endpoint for the new checkpoint and run evals on it.
 
-new_result = new_run.result()
-new_checkpoint = new_result.checkpoints()[-1]
+while True:
+    new_checkpoint = new_run.latest_checkpoint()
+    if new_run.done():
+        break
+    time.sleep(30)
 print(new_checkpoint.path)
 
 new_deployment = Endpoint.launch(

--- a/tutorials/rl_basics.py
+++ b/tutorials/rl_basics.py
@@ -211,19 +211,18 @@ config = TrainConfig(
     ),
 )
 
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Serve and evaluate the trained checkpoint
 #
 # We'll get the latest checkpoint and create a new Endpoint so we may evaluate it.
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
-print(f"checkpoint: {checkpoint.path}")
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
+    print(f"checkpoint: {checkpoint.path}")
 
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True
@@ -259,19 +258,18 @@ new_config = TrainConfig(
     ),
 )
 
-new_run = new_config.launch()
-print(f"run id: {new_run.training_run_id}")
-
 # ## Evals Evals Evals
 #
 # Once again, we'll create a new Endpoint for the new checkpoint and run evals on it.
 
-while True:
-    new_checkpoint = new_run.latest_checkpoint()
-    if new_run.done():
-        break
-    time.sleep(30)
-print(new_checkpoint.path)
+with new_config.launch() as new_run:
+    print(f"run id: {new_run.training_run_id}")
+    while True:
+        new_checkpoint = new_run.latest_checkpoint()
+        if new_run.done():
+            break
+        time.sleep(30)
+    print(new_checkpoint.path)
 
 new_deployment = Endpoint.launch(
     model, new_checkpoint, unauthenticated=True, recreate_if_existing=True

--- a/tutorials/sandboxes.py
+++ b/tutorials/sandboxes.py
@@ -172,16 +172,15 @@ config = TrainConfig(
     ),
 )
 print("Starting training...")
-run = config.launch()
-print(f"run id: {run.training_run_id}")
-
 # ## Evaluate the trained checkpoint
 
-while True:
-    checkpoint = run.latest_checkpoint()
-    if run.done():
-        break
-    time.sleep(30)
+with config.launch() as run:
+    print(f"run id: {run.training_run_id}")
+    while True:
+        checkpoint = run.latest_checkpoint()
+        if run.done():
+            break
+        time.sleep(30)
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True
 )

--- a/tutorials/sandboxes.py
+++ b/tutorials/sandboxes.py
@@ -16,6 +16,8 @@
 # 3. Reuse the same scorer as a SLIME `custom_rm_function`.
 # 4. Train and compare base vs. trained behavior.
 
+import time
+
 import modal
 
 from modal_training_gym import (
@@ -175,8 +177,11 @@ print(f"run id: {run.training_run_id}")
 
 # ## Evaluate the trained checkpoint
 
-result = run.result()
-checkpoint = result.checkpoints()[-1]
+while True:
+    checkpoint = run.latest_checkpoint()
+    if run.done():
+        break
+    time.sleep(30)
 trained_deployment = Endpoint.launch(
     model, checkpoint, unauthenticated=True, recreate_if_existing=True
 )


### PR DESCRIPTION
Adds an API to get checkpoints during a run. Before, you could only get the full list of checkpoints after a run has been completed via:

```python
run = config.launch()
result = run.result()
checkpoints = result.checkpoints()[-1]
```

Now, you can (i.e., are recommended to) do:

```python
with config.launch() as run:
    checkpoint = None
    while not run.done():
        checkpoint = run.latest_checkpoint() or checkpoint
        # offline evals
# run.close() here
```

Which implies the use of the `TrainResult` class is not the happy path, akin to the use of `TrainConfig.train()`.

<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->