### PR TITLE
Document and validate DatasetConfig.output_format

### DIFF
--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -35,12 +35,23 @@ class DatasetConfig:
 
     Describes *what* the data is. Where it gets written on disk is decided
     by the recipe/launcher layer, not by the dataset itself.
+
+    output_format : str
+        On-disk format ``prepare()`` writes, ``"parquet"`` (default) or
+        ``"jsonl"``; it also picks the extension of the path the launcher
+        hands to ``prepare()``. Parquet is the default because it is compact,
+        carries a typed schema (so a ragged or mistyped column fails at write
+        time rather than inside a remote rollout actor), streams row-group by
+        row-group, and stores binary media without base64 inflation. Choose
+        ``"jsonl"`` for small or hand-inspected datasets — it stays greppable
+        on the data volume and tolerates rows whose schemas don't line up.
     """
 
     _type: DatasetType = DatasetType.DEFAULT
     dataset_id: str = ""
     input_key: str = ""
     label_key: str = ""
+    output_format: str = "parquet"
     apply_chat_template: bool = True
     always_prepare: bool = False
     # When True (default), ``prepare()`` is expected to materialize every path in
@@ -58,6 +69,11 @@ class DatasetConfig:
 
     def _validate(self) -> None:
         """Required-field check; subclasses call this at the end of their own ``__init__``."""
+        if self.output_format not in ("parquet", "jsonl"):
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} has output_format="
+                f"{self.output_format!r}; expected 'parquet' or 'jsonl'."
+            )
         if not self.label_key:
             raise TrainingGymConfigError(
                 f"{type(self).__name__} requires `label_key` to be set. "
@@ -156,7 +172,6 @@ class HuggingFaceDataset(DatasetConfig):
     hf_repo: str = ""
     hf_split: str = "train"
     hf_config: str | None = None
-    output_format: str = "parquet"
     input_column: str = ""
     output_column: str = ""
     system_prompt: str = ""
@@ -248,7 +263,6 @@ class HarborDataset(DatasetConfig):
     instruction_path: str = "instruction.md"
     label_metadata_path: str | None = None
     test_data_dir: str | None = None
-    output_format: str = "parquet"
     prompt_template: str = "{instruction}"
     system_prompt: str = ""
     train_size: int | None = None

--- a/modal_training_gym/common/environments/bfcl.py
+++ b/modal_training_gym/common/environments/bfcl.py
@@ -593,7 +593,7 @@ class BfclMultiTurnDataset(DatasetConfig):
 
     input_key: str = "messages"
     label_key: str = "label"
-    # JSON-lines output (slime default is parquet).
+    # JSON-lines output (the gym default is parquet).
     output_format: str = "jsonl"
     writes_eval_paths: bool = False
 

--- a/modal_training_gym/train_recipes/base.py
+++ b/modal_training_gym/train_recipes/base.py
@@ -110,8 +110,7 @@ class BaseTrainRecipe(ABC):
         """Derive on-volume file paths from a dataset's properties."""
         hf_repo = getattr(ds, "hf_repo", "")
         name = hf_repo.replace("/", "_") if hf_repo else type(ds).__name__
-        fmt = getattr(ds, "output_format", "parquet")
-        ext = "jsonl" if fmt == "jsonl" else "parquet"
+        ext = "jsonl" if ds.output_format == "jsonl" else "parquet"
         split = getattr(ds, "hf_split", "train")
         prompt_data = f"{DATA_PATH}/{name}/{split}.{ext}"
         if getattr(ds, "writes_eval_paths", True):

--- a/tutorials/rl_basics.py
+++ b/tutorials/rl_basics.py
@@ -118,11 +118,6 @@ def score_haiku(response: str) -> float:
 # example of creating your own dataset, or the
 # [DatasetConfig](https://gym.modal.dev/reference/core/datasetconfig) documentation
 # for a deeper dive.
-#
-# The tutorials set `output_format = "jsonl"` so the prepared file stays
-# readable with `head` on the data volume. Parquet is the default and the better
-# choice at real dataset sizes: it's compact, typed, and streams row group by
-# row group.
 
 class HaikuDataset(HuggingFaceDataset):
     hf_repo = "statworx/haiku"

--- a/tutorials/rl_basics.py
+++ b/tutorials/rl_basics.py
@@ -118,6 +118,11 @@ def score_haiku(response: str) -> float:
 # example of creating your own dataset, or the
 # [DatasetConfig](https://gym.modal.dev/reference/core/datasetconfig) documentation
 # for a deeper dive.
+#
+# The tutorials set `output_format = "jsonl"` so the prepared file stays
+# readable with `head` on the data volume. Parquet is the default and the better
+# choice at real dataset sizes: it's compact, typed, and streams row group by
+# row group.
 
 class HaikuDataset(HuggingFaceDataset):
     hf_repo = "statworx/haiku"


### PR DESCRIPTION
Keeps parquet as the default while making the choice explicit and documented, since every in-repo dataset overrides it to jsonl with no stated reason.

- `output_format` moves up to `DatasetConfig` (single declaration, `"parquet"`), replacing the duplicate defaults on `HuggingFaceDataset`/`HarborDataset` and the `getattr(ds, "output_format", "parquet")` fallback in `_resolve_data_paths`. Its docstring now states the tradeoff: parquet for compactness/typed schema/row-group streaming/binary media, jsonl for small or hand-inspected datasets with ragged schemas. The docstring uses the `field : type` form so it lands in the generated `DatasetConfig` API reference page.
- `_validate()` rejects anything other than `"parquet"`/`"jsonl"` — previously a typo (`"json"`, `"csv"`) silently wrote parquet, because both `_write_split` and the extension resolver were `== "jsonl"` else parquet.

## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies
  - [x] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [x] Example specifies a `python_version` for the base image, if it is used
  - [x] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [x] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/11763fb1faf647cd8b93a7cc86886ff8
Requested by: @andrewhinh
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->