### PR TITLE
Make subclassing the documented path for HarborDataset

### DIFF
--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -252,6 +252,17 @@ class HarborDataset(DatasetConfig):
 
     Each task folder contains an instruction file and optional label metadata.
     Tasks are discovered by globbing the task_root directory.
+
+    Subclass and set the task source — ``dataset_name`` for a Harbor Hub
+    dataset, or ``path`` / ``task_root`` for a local task directory::
+
+        class HelloWorld(HarborDataset):
+            dataset_name = "harbor/hello-world"
+            label_metadata_path = "task.toml"
+
+        dataset = HelloWorld(train_repeats=20)
+
+    Any class attribute can still be overridden per instance as a kwarg.
     """
 
     _type: DatasetType = DatasetType.HARBOR
@@ -290,6 +301,17 @@ class HarborDataset(DatasetConfig):
                 slug = "harbor"
             self.dataset_id = f"{slug}-{uuid.uuid4()}"
         self._validate()
+
+    def _validate(self) -> None:
+        super()._validate()
+        if not (self.dataset_name or self.path or self.task_root):
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} requires a task source: set "
+                "`dataset_name` for a Harbor Hub dataset, or `path` / "
+                "`task_root` for a local task directory. Declare it as a class "
+                'attribute (`dataset_name = "harbor/hello-world"`) on your '
+                "subclass, or pass it as a kwarg."
+            )
 
     @property
     def name(self) -> str:

--- a/tests/test_harbor_dataset.py
+++ b/tests/test_harbor_dataset.py
@@ -1,0 +1,58 @@
+"""HarborDataset's encouraged path: subclass and declare the task source."""
+
+import json
+
+import pytest
+
+from modal_training_gym import HarborDataset
+from modal_training_gym.common.errors import TrainingGymConfigError
+
+
+def _write_task(root, name, instruction):
+    task_dir = root / name
+    task_dir.mkdir(parents=True)
+    (task_dir / "instruction.md").write_text(instruction)
+    (task_dir / "task.toml").write_text('difficulty = "easy"\n')
+    return task_dir
+
+
+def test_subclass_declares_task_source(tmp_path):
+    _write_task(tmp_path, "hello", "write hello.txt")
+
+    class HelloWorld(HarborDataset):
+        task_root = str(tmp_path)
+        label_metadata_path = "task.toml"
+        train_repeats = 2
+        system_prompt = "be brief"
+        output_format = "jsonl"
+
+    dataset = HelloWorld()
+    assert dataset.input_key == "messages"
+    assert dataset.label_key == "label"
+
+    path = tmp_path / "out" / "train.jsonl"
+    dataset.prepare(str(path))
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(rows) == 2
+    assert rows[0]["messages"][0] == {"role": "system", "content": "be brief"}
+    assert json.loads(rows[0]["label"])["difficulty"] == "easy"
+
+    dataset.validate_prepared(str(path))
+
+
+def test_kwargs_override_class_attrs(tmp_path):
+    _write_task(tmp_path, "hello", "write hello.txt")
+
+    class HelloWorld(HarborDataset):
+        task_root = str(tmp_path)
+        train_repeats = 2
+
+    assert HelloWorld(train_repeats=5).train_repeats == 5
+
+
+def test_missing_task_source_fails_at_config_time():
+    class NoSource(HarborDataset):
+        label_metadata_path = "task.toml"
+
+    with pytest.raises(TrainingGymConfigError, match="requires a task source"):
+        NoSource()

--- a/tutorials/sandboxes.py
+++ b/tutorials/sandboxes.py
@@ -29,7 +29,7 @@ from modal_training_gym import (
 
 # ## Load hello-world from Harbor Hub
 #
-# `HarborDataset` accepts a `dataset_name` to pull tasks from
+# Subclass `HarborDataset` and set `dataset_name` to pull tasks from
 # [Harbor Hub](https://hub.harborframework.com). Each task has:
 # - `instruction.md` — the problem statement (prompt)
 # - `task.toml` — metadata (difficulty, category)
@@ -45,18 +45,20 @@ from modal_training_gym import (
 
 EXPECTED_HELLO = "Hello, world!"
 
-dataset = HarborDataset(
-    dataset_name="harbor/hello-world",
-    label_metadata_path="task.toml",
-    train_repeats=20,
-    always_prepare=True,  # For the purpose of this tutorial, we want to prepare the dataset every time we run it, in case there is stale data from a previous run.
-    system_prompt=(
+class HelloWorldDataset(HarborDataset):
+    dataset_name = "harbor/hello-world"
+    label_metadata_path = "task.toml"
+    train_repeats = 20
+    always_prepare = True  # For the purpose of this tutorial, we want to prepare the dataset every time we run it, in case there is stale data from a previous run.
+    system_prompt = (
         "You are an expert Python programmer. "
         "Solve the given problem by writing a complete Python program. "
         "Your program may create or modify files as needed. "
         "Put your solution in a ```python code fence."
-    ),
-)
+    )
+
+
+dataset = HelloWorldDataset()
 
 # ## Evaluate with a file-based sandbox check
 #


### PR DESCRIPTION
Subclassing already worked mechanically (`HarborDataset.__init__` just setattrs kwargs over class attributes), but nothing said so and the only example instantiated it directly. Now `HarborDataset` matches `HuggingFaceDataset`: declare the task source on the subclass, override per instance with kwargs.

```python
class HelloWorldDataset(HarborDataset):
    dataset_name = "harbor/hello-world"
    label_metadata_path = "task.toml"

dataset = HelloWorldDataset(train_repeats=20)
```

- docstring documents the subclass pattern and the three task sources (`dataset_name` / `path` / `task_root`)
- `_validate()` now requires one of those sources at config time, with a message pointing at the class-attribute form. Previously an empty config only failed inside `_resolve_task_root()` during `prepare()` — i.e. after image build and cluster bringup.
- `tutorials/sandboxes.py` uses the subclass form

## Checklist

- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins its dependencies (unchanged by this PR)


Link to Devin session: https://modal.devinenterprise.com/sessions/6e8c19c64a294c27811e2715ab74fa7b
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/6e8c19c64a294c27811e2715ab74fa7b?variant=devin
Requested by: @andrewhinh
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->