### PR TITLE
add skill install as an explicit step

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Authenticate with Modal:
 modal setup
 ```
 
+Set up the [dashboard](https://gym.modal.dev/guides/dashboard):
+
+```bash
+training-gym setup
+```
+
+And empower your agents with the Gym's skill bundle:
+
+```bash
+training-gym skills install
+```
+
 Then, it's as easy as:
 
 ```python
@@ -76,19 +88,6 @@ config = TrainConfig(
 )
 run = config.launch()
 print(run.training_run_id)
-```
-
-While you're at it, empower your agents with the Gym's skill bundle:
-
-```bash
-training-gym skills install
-```
-
-And watch your training runs in the [dashboard](https://gym.modal.dev/guides/dashboard):
-
-```bash
-training-gym setup  # first-time deploy
-training-gym open  # opens in your browser
 ```
 
 <div class="tg-dashboard-previews">

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Set up the [dashboard](https://gym.modal.dev/guides/dashboard):
 training-gym setup
 ```
 
+<div class="tg-dashboard-previews">
+  <span>
+    <img src="./assets/homepage.gif" alt="Training runs list in the Training Gym dashboard" width="100%" />
+  </span>
+  <span>
+    <img src="./assets/longrun.gif" alt="Long-running training run details in the Training Gym dashboard" width="100%" />
+  </span>
+</div>
+
 And empower your agents with the Gym's skill bundle:
 
 ```bash
@@ -89,15 +98,6 @@ config = TrainConfig(
 run = config.launch()
 print(run.training_run_id)
 ```
-
-<div class="tg-dashboard-previews">
-  <span>
-    <img src="./assets/homepage.gif" alt="Training runs list in the Training Gym dashboard" width="100%" />
-  </span>
-  <span>
-    <img src="./assets/longrun.gif" alt="Long-running training run details in the Training Gym dashboard" width="100%" />
-  </span>
-</div>
 
 ## Supported models
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ run = config.launch()
 print(run.training_run_id)
 ```
 
-And you can view in-progress training runs in the [dashboard](https://gym.modal.dev/guides/dashboard):
+While you're at it, empower your agents with the Gym's skill bundle:
+
+```bash
+training-gym skills install
+```
+
+And watch your training runs in the [dashboard](https://gym.modal.dev/guides/dashboard):
 
 ```bash
 training-gym setup  # first-time deploy


### PR DESCRIPTION
Add install skills step back to readme/docs.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->