### PR TITLE
remove recipe_type field from TrainRecipe

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -6,15 +6,17 @@ import threading
 import time
 import warnings
 from contextlib import nullcontext
-from typing import Any
-from typing import TypeVar
-from typing import cast
+from typing import Any, TypeVar, cast
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
 
 from modal_training_gym.common.checkpoint import Checkpoint, CheckpointType
 from modal_training_gym.common.dataset import DatasetConfig
 from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.ids import create_hash
+from modal_training_gym.common.modal_urls import modal_app_dashboard_url
 from modal_training_gym.common.models import ModelConfig
 from modal_training_gym.common.run import TrainingRun, metric_run_id_for_attempt
 from modal_training_gym.common.status import (
@@ -23,16 +25,12 @@ from modal_training_gym.common.status import (
     SlimeStatus,
 )
 from modal_training_gym.common.train_result import TrainResult
-from modal_training_gym.common.modal_urls import modal_app_dashboard_url
-from modal_training_gym.utils.metadata import MetadataStore, vol_put
 from modal_training_gym.frameworks.miles import build_miles_app
 from modal_training_gym.frameworks.slime import build_slime_app
-from modal_training_gym.train_recipes.base import BaseTrainRecipe, RecipeType
+from modal_training_gym.train_recipes.base import BaseTrainRecipe
 from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
 from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
-from pydantic import ConfigDict
-from pydantic.dataclasses import dataclass
-
+from modal_training_gym.utils.metadata import MetadataStore, vol_put
 
 _RecipeT = TypeVar("_RecipeT", bound=BaseTrainRecipe)
 
@@ -357,7 +355,7 @@ class TrainConfig:
         The model to train. Carries model identity (``model_name``) and
         weight-download logic; weights are downloaded into the shared
         HuggingFace cache volume on first use and reused across runs.
-    recipe : BaseTrainRecipe
+    recipe : SlimeRecipe | MilesRecipe
         Framework recipe (``SlimeRecipe`` or ``MilesRecipe``). Selects the
         training framework and carries Modal infra settings (GPU type, node
         count, image) plus framework CLI flags.
@@ -397,7 +395,7 @@ class TrainConfig:
     # ── Composed configs (required) ─────────────────────────────────────────
     dataset: DatasetConfig
     model: ModelConfig
-    recipe: BaseTrainRecipe
+    recipe: SlimeRecipe | MilesRecipe
     checkpoint: Checkpoint | None = None
     # Known-model recipes are presets by default; complete recipes can opt out.
     merge_model_recipe: bool = True
@@ -418,12 +416,12 @@ class TrainConfig:
         return create_hash(
             self.model.model_name,
             self.checkpoint.path if self.checkpoint is not None else "",
-            f"{type(self.recipe).__name__}:{self.recipe.recipe_type.value}",
+            f"{type(self.recipe).__name__}:{self.framework.value}",
             self.dataset.dataset_id,
             self.model.model_path or "",
         )
 
-    def _prepare_recipe(self) -> BaseTrainRecipe:
+    def _prepare_recipe(self) -> SlimeRecipe | MilesRecipe:
         recipe = _resolve_recipe(
             self.model,
             self.recipe,
@@ -436,47 +434,39 @@ class TrainConfig:
                 "Training can only resume from a Megatron checkpoint; "
                 "Hugging Face exports are serving artifacts."
             )
-        if isinstance(recipe, (MilesRecipe, SlimeRecipe)):
-            recipe = _dc.replace(
-                recipe,
-                load=os.path.dirname(self.checkpoint.path.rstrip("/")),
-            )
-        return recipe
+        return _dc.replace(
+            recipe,
+            load=os.path.dirname(self.checkpoint.path.rstrip("/")),
+        )
 
     def _build_app(self, training_run_id: str | None = None):
         _warn_if_external_build_app()
         if training_run_id is None:
             training_run_id = self._generate_training_run_id()
-        recipe_type = self.recipe.recipe_type
-        if recipe_type == RecipeType.MILES:
-            if not isinstance(self.recipe, MilesRecipe):
-                raise TrainingGymConfigError(
-                    f"Recipe type {recipe_type} requires MilesRecipe, got {type(self.recipe).__name__}"
-                )
+        recipe = self._prepare_recipe()
+        if isinstance(recipe, MilesRecipe):
             return build_miles_app(
                 training_run_id=training_run_id,
-                miles=cast(MilesRecipe, self._prepare_recipe()),
+                miles=recipe,
                 model=self.model,
                 dataset=self.dataset,
                 checkpoint=self.checkpoint,
                 name=training_run_id,
                 group_id=self.group_id,
             )
-        if recipe_type == RecipeType.SLIME:
-            if not isinstance(self.recipe, SlimeRecipe):
-                raise TrainingGymConfigError(
-                    f"Recipe type {recipe_type} requires SlimeRecipe, got {type(self.recipe).__name__}"
-                )
+        if isinstance(recipe, SlimeRecipe):
             return build_slime_app(
                 training_run_id=training_run_id,
-                slime=cast(SlimeRecipe, self._prepare_recipe()),
+                slime=recipe,
                 model=self.model,
                 dataset=self.dataset,
                 checkpoint=self.checkpoint,
                 name=training_run_id,
                 group_id=self.group_id,
             )
-        raise TrainingGymConfigError(f"Unknown recipe type: {recipe_type}")
+        raise TrainingGymConfigError(
+            f"Unknown training recipe: {type(recipe).__name__}"
+        )
 
     # ── Run-record helpers ─────────────────────────────────────────────────
 
@@ -487,17 +477,15 @@ class TrainConfig:
         if isinstance(self.recipe, MilesRecipe):
             return Framework.MILES
         raise TrainingGymConfigError(
-            f"Unknown recipe type: {type(self.recipe).__name__}"
+            f"Unknown training recipe: {type(self.recipe).__name__}"
         )
 
     def _initializing_status(self) -> FrameworkStatus:
-        if isinstance(self.recipe, SlimeRecipe):
+        if self.framework is Framework.SLIME:
             return SlimeStatus.INITIALIZING
-        if isinstance(self.recipe, MilesRecipe):
+        if self.framework is Framework.MILES:
             return MilesStatus.INITIALIZING
-        raise TrainingGymConfigError(
-            f"Unknown recipe type: {type(self.recipe).__name__}"
-        )
+        raise TrainingGymConfigError(f"Unknown training framework: {self.framework}")
 
     def _build_config_summary(self, training_run_id: str) -> dict[str, Any]:
         """Framework-specific TrainingRun.config summary."""
@@ -582,7 +570,7 @@ class TrainConfig:
             config_path=str(config_path),
         )
 
-    def _resolved_recipe_for_logging(self) -> BaseTrainRecipe:
+    def _resolved_recipe_for_logging(self) -> SlimeRecipe | MilesRecipe:
         return _resolve_recipe(
             self.model, self.recipe, merge_model_recipe=self.merge_model_recipe
         )
@@ -625,12 +613,12 @@ class TrainConfig:
         """Start training in a detached Modal app and return immediately."""
         import modal
 
+        from modal_training_gym.cli.setup import ensure_dashboard_deployed
         from modal_training_gym.common.config import (
             CONFIG_PATH,
             get_framework_status_url,
         )
         from modal_training_gym.common.status_reporter import enqueue_framework_status
-        from modal_training_gym.cli.setup import ensure_dashboard_deployed
 
         training_run_id = self._generate_training_run_id()
         ensure_dashboard_deployed()

--- a/modal_training_gym/train_recipes/base.py
+++ b/modal_training_gym/train_recipes/base.py
@@ -3,7 +3,6 @@ import json
 import os
 from abc import ABC
 from collections.abc import Callable
-from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -27,13 +26,7 @@ CHECKPOINTS_PATH = Path("/checkpoints")
 JSON_CONFIG_FIELDS = ("train_env_vars", "apply_chat_template_kwargs", "multimodal_keys")
 
 
-class RecipeType(Enum):
-    SLIME = "slime"
-    MILES = "miles"
-
-
 class BaseTrainRecipe(ABC):
-    recipe_type: RecipeType
     model_config_class: ClassVar["type[ModelConfig] | None"] = None
 
     # Fields consumed by the Modal launcher (image build, cluster topology,

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -11,7 +11,6 @@ from modal_training_gym.common.metrics import MetricConfig
 from modal_training_gym.common.models import ModelConfig
 from modal_training_gym.train_recipes.base import (
     BaseTrainRecipe,
-    RecipeType,
     # Re-exported for backwards compatibility (e.g. frameworks/miles/launcher.py
     # imports the volume paths from this module).
     CHECKPOINTS_PATH as CHECKPOINTS_PATH,
@@ -25,7 +24,6 @@ from modal_training_gym.train_recipes.gpu_allocation import (
 )
 
 _MILES_SKIP = {
-    "recipe_type",
     "environment",
     "async_mode",
     "miles_model_script",
@@ -116,8 +114,6 @@ class MilesRecipe(BaseTrainRecipe):
 
     ## App Identity
 
-    recipe_type : RecipeType
-        Discriminator marking this recipe as Miles; never override.
     name : str
         Modal app title; empty lets the launcher derive one from the class.
     app_tags : dict
@@ -473,9 +469,6 @@ class MilesRecipe(BaseTrainRecipe):
     sglang_reasoning_parser : str | None
         Parser for reasoning/thinking output.
     """
-
-    # ── App identity ─────────────────────────────────────────────────────────
-    recipe_type: RecipeType = RecipeType.MILES
 
     # ── Launcher instructions (not Miles CLI flags) ─────────────────────────
     docker_image: str = "radixark/miles:dev-202608120325"

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -6,7 +6,6 @@ from urllib.parse import urlparse
 
 from modal_training_gym.train_recipes.base import (
     BaseTrainRecipe,
-    RecipeType,
     # Re-exported for backwards compatibility (e.g. frameworks/slime/launcher.py
     # imports the volume paths from this module).
     CHECKPOINTS_PATH as CHECKPOINTS_PATH,
@@ -35,7 +34,6 @@ import modal
 # ── Types ─────────────────────────────────────────────────────────────────────
 
 _SLIME_SKIP = {
-    "recipe_type",
     "environment",
     "async_mode",
     "metrics",
@@ -136,8 +134,6 @@ class SlimeRecipe(BaseTrainRecipe):
 
     ## App Identity
 
-    recipe_type : RecipeType
-        Discriminator marking this recipe as slime; never override.
     name : str
         Modal app title; when empty the launcher derives one from the recipe
         class.
@@ -492,7 +488,6 @@ class SlimeRecipe(BaseTrainRecipe):
     save_interval: int  # save a checkpoint every N rollout steps
 
     # ── App identity ─────────────────────────────────────────────────────────
-    recipe_type: RecipeType = RecipeType.SLIME
     name: str = ""
     app_tags: dict = field(default_factory=dict)
 

--- a/tests/test_readable_ids.py
+++ b/tests/test_readable_ids.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 from modal_training_gym.common import ids
 from modal_training_gym.common.dataset import DatasetConfig, HuggingFaceDataset
 from modal_training_gym.common.models import ModelConfig, Qwen3_4B
 from modal_training_gym.common.train import TrainConfig
-from modal_training_gym.train_recipes.base import BaseTrainRecipe, RecipeType
 from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_4b import Qwen3_4b_Recipe
 
 
 def test_create_hash_has_word_word_hash_shape() -> None:
@@ -40,16 +38,11 @@ def test_train_config_generates_fresh_run_id_per_call(monkeypatch) -> None:
     class DummyDataset(DatasetConfig):
         label_key = "label"
 
-    @dataclass
-    class DummyRecipe(BaseTrainRecipe):
-        recipe_type: RecipeType = field(default=RecipeType.SLIME)
-
-    calls = 0
+    descriptors: list[str] = []
 
     def fake_create_hash(*parts: str) -> str:
-        nonlocal calls
-        calls += 1
-        return f"brisk-river-{calls:08x}"
+        descriptors.append(parts[2])
+        return f"brisk-river-{len(descriptors):08x}"
 
     monkeypatch.setattr(
         "modal_training_gym.common.train.create_hash",
@@ -59,13 +52,14 @@ def test_train_config_generates_fresh_run_id_per_call(monkeypatch) -> None:
     config = TrainConfig(
         dataset=DummyDataset(),
         model=ModelConfig(model_name="Qwen/Qwen3-4B"),
-        recipe=DummyRecipe(),
+        recipe=Qwen3_4b_Recipe(),
     )
 
     first = config._generate_training_run_id()
     second = config._generate_training_run_id()
+
     assert first != second
-    assert calls == 2
+    assert descriptors == ["Qwen3_4b_Recipe:slime"] * 2
 
 
 def test_train_config_can_skip_model_recipe_merge() -> None:

--- a/tests/test_train_recipe_identity.py
+++ b/tests/test_train_recipe_identity.py
@@ -1,0 +1,62 @@
+import pytest
+
+from modal_training_gym.common.dataset import HuggingFaceDataset
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.models import ModelConfig, Qwen3_4B, Qwen3_5_4B
+from modal_training_gym.common.train import TrainConfig
+from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+from modal_training_gym.train_recipes.miles_recipe.qwen3_5_4b import (
+    Qwen3_5_4b_Miles_Recipe,
+)
+from modal_training_gym.train_recipes.slime_recipe import SlimeRecipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_4b import Qwen3_4b_Recipe
+
+
+def _config(recipe: SlimeRecipe | MilesRecipe, model: ModelConfig) -> TrainConfig:
+    return TrainConfig(
+        dataset=HuggingFaceDataset(
+            hf_repo="some/dataset",
+            input_column="prompt",
+            output_column="answer",
+        ),
+        model=model,
+        recipe=recipe,
+    )
+
+
+@pytest.mark.parametrize(
+    ("recipe", "model", "framework"),
+    [
+        (
+            Qwen3_4b_Recipe(),
+            Qwen3_4B(),
+            Framework.SLIME,
+        ),
+        (
+            Qwen3_5_4b_Miles_Recipe(),
+            Qwen3_5_4B(),
+            Framework.MILES,
+        ),
+    ],
+)
+def test_recipe_subclass_selects_framework_and_builder(
+    recipe, model, framework, monkeypatch
+) -> None:
+    calls: list[Framework] = []
+    monkeypatch.setattr(
+        "modal_training_gym.common.train._warn_if_external_build_app", lambda: None
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.train.build_slime_app",
+        lambda **kwargs: calls.append(Framework.SLIME),
+    )
+    monkeypatch.setattr(
+        "modal_training_gym.common.train.build_miles_app",
+        lambda **kwargs: calls.append(Framework.MILES),
+    )
+
+    config = _config(recipe, model)
+
+    assert config.framework is framework
+    config._build_app("run-id")
+    assert calls == [framework]


### PR DESCRIPTION
Removes `recipe_type` from train recipes and instead infers from their class.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->