### PR TITLE
Fix spelling and grammar in docs guides

### DIFF
--- a/docs-next/src/content/docs/guides/start/recipe.md
+++ b/docs-next/src/content/docs/guides/start/recipe.md
@@ -119,7 +119,7 @@ The simplest reward functions (like the above) return binary scores for correct 
 
 For logging purposes, you can attach metadata to each sample for more observability in the [dashboard](https://gym.modal.dev/guides/dashboard/).
 
-When you're task requires something beyond a single-turn interaction, all it takes is implementing a [custom generate](https://miles.radixark.com/docs/user-guide/generate-endpoint) function.
+When your task requires something beyond a single-turn interaction, all it takes is implementing a [custom generate](https://miles.radixark.com/docs/user-guide/generate-endpoint) function.
 
 For an in-depth example, see the [multi-turn RL tutorial](https://gym.modal.dev/tutorials/multiturn/#multi-turn-environment-and-reward).
 
@@ -182,7 +182,7 @@ recipe = Qwen3_5_4b_Recipe(
 
 Typically, your generation function will:
 
-1. Determine the URL of the internal SGLang server and sets up a tokenizer for later use.
+1. Determine the URL of the internal SGLang server and set up a tokenizer for later use.
 2. Make one or multiple calls against the SGLang endpoint to generate responses from the model.
 3. Tokenize the prompt and response with a corresponding loss mask.
 4. Set response fields on the sample.

--- a/docs-next/src/content/docs/guides/tools/agent.md
+++ b/docs-next/src/content/docs/guides/tools/agent.md
@@ -80,7 +80,7 @@ class RhymeInstructionDataset(HuggingFaceDataset):
         return ds
 ```
 
-Next, it defined the reward function. Here, we care about the model's ability to both rhyme and answer the user's question. As our [intro tutorial](https://gym.modal.dev/tutorials/rl_basics) shows, NLTK’s [CMU Pronouncing Dictionary](https://github.com/prosegrinder/python-cmudict) is a useful library for measure the former.
+Next, it defined the reward function. Here, we care about the model's ability to both rhyme and answer the user's question. As our [intro tutorial](https://gym.modal.dev/tutorials/rl_basics) shows, NLTK’s [CMU Pronouncing Dictionary](https://github.com/prosegrinder/python-cmudict) is a useful library for measuring the former.
 
 <details>
 <summary>What's going on here</summary>

--- a/docs-next/src/content/docs/guides/tools/dashboard.md
+++ b/docs-next/src/content/docs/guides/tools/dashboard.md
@@ -63,10 +63,10 @@ You can scroll to zoom and drag to pan for precise viewing.
 Some tips:
 
 - A healthy GRPO step is usually dominated by rollout generation and model training.
-- If rollout generation duration grows step over step, look at rollout lengths as responses may be hitting the max length
+- If rollout generation duration grows step over step, look at rollout lengths as responses may be hitting the max length.
 - If weight syncing or the offload substeps dominate, the cluster shape is likely misconfigured for the model size.
 
-Custom phases emitted by your code (e.g. a custom reward function) appear as their own markers for easy debugging and tracking.
+Custom phases emitted by your code (e.g., a custom reward function) appear as their own markers for easy debugging and tracking.
 
 ## Per rollout
 
@@ -76,7 +76,7 @@ You can even inspect each rollout to quickly debug poor performance:
 
 You'll see:
 
-1. Same timeline but for each step:
+1. Same timeline but for each step.
 2. Reward distribution across all rollouts. A healthy run is represented as a bimodal distribution for the majority of the run, while an unhealthy one will gravitate towards one end or the other before training has completed. Pictured above is one indicative of the end of a run, as most rollouts have already saturated the reward.
 3. Per-rollout trace that shows the full prompt, the system message, the model's thinking, every conversation turn, and the reward.
 


### PR DESCRIPTION
Copyedit pass over `docs-next/src/content/docs/guides/**` — spelling/grammar only, no content changes.

- recipe.md: "When you're task requires" → "your"; numbered step "Determine ... and sets up" → "and set up" (verb agreement with the rest of the list).
- agent.md: "a useful library for measure the former" → "for measuring".
- dashboard.md: missing period on a tip bullet, list item ending in a stray colon, and `e.g.` → `e.g.,` to match the rest of the guides.

Places where the content itself looks out of date were deliberately left alone.

## Checklist

Not applicable — docs copyedit, no example code changes.


Link to Devin session: https://modal.devinenterprise.com/sessions/03e38b09d09842f08a8fa5ecc8e38805
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/03e38b09d09842f08a8fa5ecc8e38805?variant=devin
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->