### PR TITLE
Terminalize launch() runs whose Modal app never starts

### DIFF
--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -18,7 +18,11 @@ from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.ids import create_hash
 from modal_training_gym.common.modal_urls import modal_app_dashboard_url
 from modal_training_gym.common.models import ModelConfig
-from modal_training_gym.common.run import TrainingRun, metric_run_id_for_attempt
+from modal_training_gym.common.run import (
+    TrainingRun,
+    TrainingRunStatus,
+    metric_run_id_for_attempt,
+)
 from modal_training_gym.common.status import (
     FrameworkStatus,
     MilesStatus,
@@ -39,6 +43,33 @@ def _try_validate_model_parallelism(
     # Not every framework recipe implements this preflight.
     if validate := getattr(recipe, "validate_model_parallelism", None):
         validate(model)
+
+
+def _terminalize_unlaunched_run(run_record: TrainingRun, exc: BaseException) -> None:
+    """Terminalize a recorded run whose Modal app never came up.
+
+    Without this the record sits in ``running`` with no app id until the
+    dashboard reconciler's pre-app timeout expires.
+    """
+    finished_at = int(time.time())
+    if isinstance(exc, KeyboardInterrupt):
+        run_record.status = TrainingRunStatus.STOPPED
+        reason = "launch_interrupted"
+    else:
+        run_record.status = TrainingRunStatus.FAILED
+        run_record.error_message = f"{type(exc).__name__}: {exc}"
+        reason = "launch_failed_before_modal_app"
+    run_record.ended_at = finished_at
+    run_record.completed_at = finished_at
+    run_record.duration_seconds = max(0, finished_at - run_record.started_at)
+    run_record.metadata = {**(run_record.metadata or {}), "terminal_reason": reason}
+    try:
+        run_record.save()
+    except Exception as save_exc:  # noqa: BLE001 — best-effort bookkeeping
+        print(
+            f"WARNING: could not mark {run_record.training_run_id} as "
+            f"{run_record.status.value}: {save_exc!r}"
+        )
 
 
 def _convert_checkpoint_on_cache_miss(
@@ -529,14 +560,11 @@ class TrainConfig:
         Returns:
             The launched training run.
         """
-        import modal
-
         from modal_training_gym.cli.setup import ensure_dashboard_deployed
         from modal_training_gym.common.config import (
             CONFIG_PATH,
             get_framework_status_url,
         )
-        from modal_training_gym.common.status_reporter import enqueue_framework_status
 
         training_run_id = self._generate_training_run_id()
         ensure_dashboard_deployed()
@@ -573,6 +601,49 @@ class TrainConfig:
         except RuntimeError:
             framework_status_token = ""
         print(f"TrainingRun recorded: {training_run_id}")
+
+        try:
+            function_call = self._start_detached_app(
+                run_record,
+                training_run_id=training_run_id,
+                framework_status_url=framework_status_url,
+                framework_status_token=framework_status_token,
+                status_display=status_display,
+                show_output=show_output,
+                prepare_inputs=prepare_inputs,
+            )
+        except BaseException as exc:
+            if not run_record.modal_app_id:
+                _terminalize_unlaunched_run(run_record, exc)
+            raise
+
+        run_record.function_call_id = function_call.object_id
+        run_record._function_call = function_call
+        run_record._status_display = status_display if show_output else None
+        try:
+            run_record.save()
+        except RuntimeError:
+            pass
+        print(
+            f"Launched training {run_record.training_run_id}: "
+            f"app={run_record.modal_app_id}, function_call={run_record.function_call_id}"
+        )
+        return run_record
+
+    def _start_detached_app(
+        self,
+        run_record: TrainingRun,
+        *,
+        training_run_id: str,
+        framework_status_url: str,
+        framework_status_token: str,
+        status_display: Any,
+        show_output: bool,
+        prepare_inputs: bool,
+    ) -> Any:
+        import modal
+
+        from modal_training_gym.common.status_reporter import enqueue_framework_status
 
         app = self._build_app(training_run_id)
         output_context = modal.enable_output() if show_output else nullcontext()
@@ -636,22 +707,9 @@ class TrainConfig:
                             framework_status_token=framework_status_token,
                         )
 
-                function_call = app.train.spawn(
+                return app.train.spawn(
                     modal_app_id=modal_app_id,
                     modal_app_url=modal_app_url,
                     framework_status_url=framework_status_url,
                     framework_status_token=framework_status_token,
                 )
-
-        run_record.function_call_id = function_call.object_id
-        run_record._function_call = function_call
-        run_record._status_display = status_display if show_output else None
-        try:
-            run_record.save()
-        except RuntimeError:
-            pass
-        print(
-            f"Launched training {run_record.training_run_id}: "
-            f"app={run_record.modal_app_id}, function_call={run_record.function_call_id}"
-        )
-        return run_record

--- a/tests/test_launch_terminalize.py
+++ b/tests/test_launch_terminalize.py
@@ -1,0 +1,57 @@
+"""``launch()`` must not leave a ``running`` record behind when the Modal app never starts."""
+
+from __future__ import annotations
+
+from modal_training_gym.common.run import TrainingRun, TrainingRunStatus
+from modal_training_gym.common.train import _terminalize_unlaunched_run
+
+
+def _record(monkeypatch, saved: list[TrainingRun]) -> TrainingRun:
+    monkeypatch.setattr(TrainingRun, "save", lambda self: saved.append(self))
+    return TrainingRun(
+        training_run_id="run-1",
+        framework="miles",
+        config={},
+        created_at=100,
+        started_at=100,
+    )
+
+
+def test_exception_marks_run_failed(monkeypatch):
+    saved: list[TrainingRun] = []
+    run = _record(monkeypatch, saved)
+
+    _terminalize_unlaunched_run(run, RuntimeError("image build failed"))
+
+    assert saved == [run]
+    assert run.status is TrainingRunStatus.FAILED
+    assert run.error_message == "RuntimeError: image build failed"
+    assert run.ended_at is not None and run.completed_at == run.ended_at
+    assert run.duration_seconds == run.ended_at - 100
+    assert run.metadata == {"terminal_reason": "launch_failed_before_modal_app"}
+
+
+def test_keyboard_interrupt_marks_run_stopped(monkeypatch):
+    saved: list[TrainingRun] = []
+    run = _record(monkeypatch, saved)
+
+    _terminalize_unlaunched_run(run, KeyboardInterrupt())
+
+    assert saved == [run]
+    assert run.status is TrainingRunStatus.STOPPED
+    assert run.error_message is None
+    assert run.metadata == {"terminal_reason": "launch_interrupted"}
+
+
+def test_save_failure_is_swallowed(monkeypatch, capsys):
+    run = _record(monkeypatch, [])
+
+    def _boom(self):
+        raise RuntimeError("volume unavailable")
+
+    monkeypatch.setattr(TrainingRun, "save", _boom)
+
+    _terminalize_unlaunched_run(run, RuntimeError("nope"))
+
+    assert run.status is TrainingRunStatus.FAILED
+    assert "could not mark run-1 as failed" in capsys.readouterr().out


### PR DESCRIPTION
Context: omkaar-dev's dashboard showed ~57 `Pending` runs created ~20s apart between 23:12–23:25 UTC, all `status=running`, `modal_app_id=""`, `framework_status=initializing`. They come from `TrainConfig.launch()`: the `TrainingRun` record is saved *before* `_build_app()` / `app.run(detach=True)`, so if either raises, the record is left in `running` with no app id. The reconciler only catches these via `stale_pre_active_no_modal_app` after `PRE_APP_TIMEOUT_SECONDS` (90 min).

Fix: `launch()` now wraps the app start and, if it fails before an app id was recorded, terminalizes the record immediately:

```
try:
    function_call = self._start_detached_app(run_record, ...)   # _build_app + app.run + spawn (moved, unchanged)
except BaseException as exc:
    if not run_record.modal_app_id:
        _terminalize_unlaunched_run(run_record, exc)   # FAILED (+error_message) / STOPPED on KeyboardInterrupt
    raise
```

`terminal_reason` is `launch_failed_before_modal_app` / `launch_interrupted`. Once the app id is recorded the existing reconciler path (`stale_modal_app_terminated`) is the right owner, so nothing changes there. Save failures are logged and swallowed, as with the other best-effort saves in `launch()`.

Not changed by this PR (findings from the omkaar-dev investigation): the cron reconciler itself works — it terminalized 6 app-backed orphans at 23:30 UTC, right after the dashboard app was redeployed at 23:11 (`modal app history` shows only v1 from 23:11, so the previous dashboard app — and its cron — was gone between ~20:40 and 23:11, which is why runs cancelled earlier in the day sat as Pending for hours). Stopping the dashboard app in the Modal UI kills the cleanup loop until the next `launch()` redeploys it.

## Checklist

N/A — library change, not an example.


Link to Devin session: https://modal.devinenterprise.com/sessions/14667a3b70a94561a404a7604b9da11a
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/14667a3b70a94561a404a7604b9da11a?variant=devin
Requested by: @joyliu-q