### PR TITLE
Page the dashboard's training run list instead of shipping every run to the phone

### DIFF
--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -7,13 +7,31 @@
   import TrainingPage from "./pages/TrainingPage.svelte";
   import TrainingRunDetailPage from "./pages/TrainingRunDetailPage.svelte";
   import EvalsPage from "./pages/EvalsPage.svelte";
-  import { fetchRuns, fetchEvals, fetchEvalDetail } from "./lib/api.js";
+  import {
+    fetchRuns,
+    fetchRunCounts,
+    fetchEvals,
+    fetchEvalDetail,
+  } from "./lib/api.js";
   import logoSvg from "./lib/logo.svg";
   import { fmtDuration } from "./lib/format.js";
 
   const DOCS_URL = "https://gym.modal.dev";
 
-  let allRuns = $state([]);
+  // The server filters, sorts and pages the run list: `runs` only ever holds
+  // the rows the page has asked for. Every total on the page comes from
+  // `runCounts` instead — the whole history is far too much JSON for a phone to
+  // download and keep resident just to count it.
+  const RUNS_PAGE_SIZE = 100;
+  let runs = $state([]);
+  let loadedRunCount = $state(RUNS_PAGE_SIZE);
+  let runCounts = $state({
+    total: 0,
+    matching: 0,
+    status: {},
+    recipe: {},
+    group: {},
+  });
   let allEvals = $state([]);
   let loading = $state(true);
   let loadingEvals = $state(false);
@@ -117,10 +135,8 @@
     };
   });
 
-  function getRecipe(run) {
-    return run.recipe || run.framework || "(untagged)";
-  }
-
+  // Mirrors the server's facet buckets (`run_facet_values`), which is what the
+  // filter chips and counts are keyed by.
   const NO_GROUP = "(no group)";
 
   function getGroup(run) {
@@ -153,10 +169,6 @@
     return value != null ? String(value) : "";
   }
 
-  function includesText(value, query) {
-    return safeText(value).toLowerCase().includes(query);
-  }
-
   function getErrorMessage(value) {
     if (value instanceof Error) return value.message;
     if (typeof value === "string") return value;
@@ -179,6 +191,56 @@
       });
   }
 
+  // A chip group with every value selected is the same query as no filter at
+  // all, and leaving it out of the request keeps the URL (and the response
+  // cache key) stable while the user is only toggling within one group.
+  function requestFacets() {
+    const universes = { status: statuses, recipe: recipes, group: groups };
+    const selections = {
+      status: activeStatuses,
+      recipe: activeRecipes,
+      group: activeGroups,
+    };
+    const facets = {};
+    for (const [name, selected] of Object.entries(selections)) {
+      const universe = universes[name];
+      if (!universe.length) continue;
+      if (universe.every((value) => selected.has(value))) continue;
+      facets[name] = [...selected];
+    }
+    return facets;
+  }
+
+  // Nothing selected in a chip group matches nothing, and an empty repeated
+  // query param reads as "unfiltered" on the server — so answer it here.
+  let matchesNothing = $derived.by(() =>
+    Object.values(requestFacets()).some((values) => !values.length),
+  );
+
+  function adoptFacetValues(counts) {
+    // Auto-enable newly-seen recipes/statuses/groups without resetting the
+    // user's current filter selection on every refresh.
+    const seen = {
+      recipe: [seenRecipes, activeRecipes],
+      status: [seenStatuses, activeStatuses],
+      group: [seenGroups, activeGroups],
+    };
+    for (const [facet, [seenValues, active]] of Object.entries(seen)) {
+      const next = new Set(active);
+      let changed = false;
+      for (const value of Object.keys(counts[facet] || {})) {
+        if (seenValues.has(value)) continue;
+        seenValues.add(value);
+        next.add(value);
+        changed = true;
+      }
+      if (!changed) continue;
+      if (facet === "recipe") activeRecipes = next;
+      else if (facet === "status") activeStatuses = next;
+      else activeGroups = next;
+    }
+  }
+
   async function loadRuns() {
     const requestId = ++runsRequestId;
     const isStale = () => requestId !== runsRequestId;
@@ -189,47 +251,38 @@
     if (!hasLoadedRuns) loading = true;
     error = null;
 
+    const query = search.trim();
+    const facets = requestFacets();
+    // Refetch the whole loaded window rather than only the newest page: it is
+    // the rows that are actually on screen, so the payload stays proportional
+    // to what the user has scrolled through, and everything visible stays live.
+    const limit = Math.max(loadedRunCount, RUNS_PAGE_SIZE);
+
     try {
-      const runs = await fetchWithTimeout(fetchRuns, 30000, "runs");
+      const [page, counts] = await Promise.all([
+        matchesNothing
+          ? Promise.resolve([])
+          : fetchWithTimeout(
+              (options) => fetchRuns({ ...options, limit, query, facets }),
+              30000,
+              "runs",
+            ),
+        fetchWithTimeout(
+          (options) => fetchRunCounts({ ...options, query, facets }),
+          15000,
+          "run counts",
+        ),
+      ]);
       if (isStale()) return;
-      allRuns = runs;
-      // Auto-enable newly-seen recipes/statuses without resetting the user's
-      // current filter selection on every refresh.
-      const nextRecipes = new Set(activeRecipes);
-      const nextStatuses = new Set(activeStatuses);
-      const nextGroups = new Set(activeGroups);
-      let recipesChanged = false;
-      let statusesChanged = false;
-      let groupsChanged = false;
-      for (const run of allRuns) {
-        const recipe = getRecipe(run);
-        if (!seenRecipes.has(recipe)) {
-          seenRecipes.add(recipe);
-          nextRecipes.add(recipe);
-          recipesChanged = true;
-        }
-        const status = getStatus(run);
-        if (!seenStatuses.has(status)) {
-          seenStatuses.add(status);
-          nextStatuses.add(status);
-          statusesChanged = true;
-        }
-        const group = getGroup(run);
-        if (!seenGroups.has(group)) {
-          seenGroups.add(group);
-          nextGroups.add(group);
-          groupsChanged = true;
-        }
-      }
-      if (recipesChanged) activeRecipes = nextRecipes;
-      if (statusesChanged) activeStatuses = nextStatuses;
-      if (groupsChanged) activeGroups = nextGroups;
+      runs = page;
+      runCounts = counts;
+      adoptFacetValues(counts);
     } catch (e) {
       if (isStale()) return;
       // Keep the data we already have on a transient refresh failure — only
       // surface the error (and clear) when there's nothing to show yet.
       // Otherwise the page flickers to "Loading…"/empty on every flaky poll.
-      if (!allRuns.length) {
+      if (!runs.length) {
         error = getErrorMessage(e);
         activeRecipes = new Set();
         activeStatuses = new Set();
@@ -295,71 +348,53 @@
     }
   });
 
-  let recipes = $derived([...new Set(allRuns.map(getRecipe))].sort());
-  let statuses = $derived([...new Set(allRuns.map(getStatus))].sort());
+  let recipeCounts = $derived(runCounts.recipe || {});
+  let statusCounts = $derived(runCounts.status || {});
+  let groupCounts = $derived(runCounts.group || {});
+
+  let recipes = $derived(Object.keys(recipeCounts).sort());
+  let statuses = $derived(Object.keys(statusCounts).sort());
   // Real group ids first (alphabetical), with "(no group)" pinned last so the
   // sweep groups are what you see at the top of the filter.
   let groups = $derived(
-    [...new Set(allRuns.map(getGroup))].sort((a, b) => {
+    Object.keys(groupCounts).sort((a, b) => {
       if (a === NO_GROUP) return 1;
       if (b === NO_GROUP) return -1;
       return a.localeCompare(b);
     }),
   );
 
-  let recipeCounts = $derived(
-    allRuns.reduce((acc, run) => {
-      const recipe = getRecipe(run);
-      acc[recipe] = (acc[recipe] || 0) + 1;
-      return acc;
-    }, {}),
-  );
+  // Runs arrive already filtered and sorted newest-first by the server.
+  let filteredRuns = $derived(runs);
+  let matchingRunCount = $derived(matchesNothing ? 0 : runCounts.matching || 0);
+  let hasMoreRuns = $derived(runs.length < matchingRunCount);
 
-  let statusCounts = $derived(
-    allRuns.reduce((acc, run) => {
-      const status = getStatus(run);
-      acc[status] = (acc[status] || 0) + 1;
-      return acc;
-    }, {}),
-  );
+  function loadMoreRuns() {
+    if (!hasMoreRuns || refreshing) return;
+    loadedRunCount = runs.length + RUNS_PAGE_SIZE;
+    void load();
+  }
 
-  let groupCounts = $derived(
-    allRuns.reduce((acc, run) => {
-      const group = getGroup(run);
-      acc[group] = (acc[group] || 0) + 1;
-      return acc;
-    }, {}),
+  // Changing the query means a different result set, so paging restarts at the
+  // first page. Debounced: typing in the search box shouldn't be one request
+  // per keystroke.
+  let runQueryKey = $derived(
+    JSON.stringify({ q: search.trim(), facets: requestFacets() }),
   );
-
-  let filteredRuns = $derived(
-    allRuns
-      .filter((run) => {
-        if (!activeRecipes.has(getRecipe(run))) return false;
-        if (!activeStatuses.has(getStatus(run))) return false;
-        if (!activeGroups.has(getGroup(run))) return false;
-        if (search) {
-          const q = search.toLowerCase();
-          if (
-            !includesText(run.run_id, q) &&
-            !includesText(run.modal_app_id, q) &&
-            !includesText(run.group_id, q) &&
-            !includesText(JSON.stringify(run.group_tags || {}), q) &&
-            !includesText(run.model, q) &&
-            !includesText(run.dataset, q) &&
-            !includesText(run.train_result?.training_run_id, q) &&
-            !includesText(run.train_result?.checkpoint_dir, q) &&
-            !includesText(run.train_result?.model_name, q) &&
-            !includesText(run.train_result?.model_path, q) &&
-            !includesText(run.framework_status, q) &&
-            !includesText(run.deployment_id, q)
-          ) {
-            return false;
-          }
-        }
-        return true;
-      })
-      .sort((a, b) => (b.created_at || 0) - (a.created_at || 0)),
-  );
+  let lastRunQueryKey = "";
+  $effect(() => {
+    const key = runQueryKey;
+    if (!hasLoadedRuns || key === lastRunQueryKey) {
+      lastRunQueryKey = key;
+      return;
+    }
+    lastRunQueryKey = key;
+    const timer = window.setTimeout(() => {
+      loadedRunCount = RUNS_PAGE_SIZE;
+      void loadRuns();
+    }, 250);
+    return () => window.clearTimeout(timer);
+  });
 
   const trainingGroupKeyFns = {
     group: getGroup,
@@ -374,19 +409,20 @@
   let trainingRunGroups = $derived.by(() => {
     if (trainingGroupBy === "none") return [];
     const buckets = Map.groupBy(filteredRuns, (run) => trainingGroupKey(run, trainingGroupBy));
-    return [...buckets].map(([key, runs]) => ({
+    return [...buckets].map(([key, bucketRuns]) => ({
       key,
-      runs,
-      latestCreatedAt: runs[0]?.created_at || null,
+      runs: bucketRuns,
+      latestCreatedAt: bucketRuns[0]?.created_at || null,
     }));
   });
 
-  let completedTotal = $derived(allRuns.filter((run) => getStatus(run) === "completed").length);
-  let cancelledTotal = $derived(allRuns.filter((run) => getStatus(run) === "cancelled").length);
-  let stoppedTotal = $derived(allRuns.filter((run) => getStatus(run) === "stopped").length);
-  let failedTotal = $derived(allRuns.filter((run) => getStatus(run) === "failed").length);
+  let totalRuns = $derived(runCounts.total || 0);
+  let completedTotal = $derived(statusCounts.completed || 0);
+  let cancelledTotal = $derived(statusCounts.cancelled || 0);
+  let stoppedTotal = $derived(statusCounts.stopped || 0);
+  let failedTotal = $derived(statusCounts.failed || 0);
   let runningTotal = $derived(
-    allRuns.length - completedTotal - cancelledTotal - stoppedTotal - failedTotal,
+    totalRuns - completedTotal - cancelledTotal - stoppedTotal - failedTotal,
   );
 
   function evalAccuracy(ev) {
@@ -611,7 +647,7 @@
     allEvals.filter((ev) => getEvalStatus(ev) === "Failed").length,
   );
   let activeTrainingRun = $derived(
-    allRuns.find((run) => run.run_id === activeTrainingRunId) || null,
+    runs.find((run) => run.run_id === activeTrainingRunId) || null,
   );
 
   let statusText = $derived.by(() => {
@@ -621,8 +657,8 @@
     if (error) return "error";
     if (activePage === "evals")
       return `${allEvals.length} eval${allEvals.length === 1 ? "" : "s"}`;
-    if (!allRuns.length) return "0 runs";
-    return `${filteredRuns.length} of ${allRuns.length} runs`;
+    if (!totalRuns) return "0 runs";
+    return `${matchingRunCount} of ${totalRuns} runs`;
   });
 
   function toggleRecipe(recipe) {
@@ -762,7 +798,10 @@
       />
     {:else if activePage === "training"}
       <TrainingPage
-        {allRuns}
+        {totalRuns}
+        {matchingRunCount}
+        {hasMoreRuns}
+        onLoadMore={loadMoreRuns}
         {completedTotal}
         {runningTotal}
         {stoppedTotal}

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -428,9 +428,11 @@
   let hasMoreRuns = $derived(runs.length < matchingRunCount);
 
   function loadMoreRuns() {
-    if (!hasMoreRuns || refreshing) return;
+    if (!hasMoreRuns) return;
     loadedRunCount = runs.length + RUNS_PAGE_SIZE;
-    void load();
+    // Queued, so asking for the next page during a refresh grows the window
+    // once that refresh lands instead of being dropped.
+    void load({ queue: true });
   }
 
   // Changing the query means a different result set, so paging restarts at the

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -429,7 +429,11 @@
 
   function loadMoreRuns() {
     if (!hasMoreRuns) return;
-    loadedRunCount = runs.length + RUNS_PAGE_SIZE;
+    const nextCount = runs.length + RUNS_PAGE_SIZE;
+    // Scrolling fires this on every event, so the page already asked for is
+    // not asked for again: one queued page per set of rows on screen.
+    if (loadedRunCount >= nextCount) return;
+    loadedRunCount = nextCount;
     // Queued, so asking for the next page during a refresh grows the window
     // once that refresh lands instead of being dropped.
     void load({ queue: true });

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -344,14 +344,21 @@
 
   let reloadQueued = false;
 
-  async function load() {
+  // `queue`: this load asks for data the current one won't return (a new query
+  // or facet selection), so it waits its turn instead of being dropped. Polls
+  // pass it up — a request slower than the 5s interval would otherwise queue a
+  // successor on every tick and refresh without pause.
+  async function load({ queue = false } = {}) {
     // One refresh at a time. The runs payload can take longer to arrive than
     // the 5s interval, and overlapping fetches stack whole copies of it in
-    // memory for a response that gets thrown away as stale anyway. A request
-    // that arrives mid-flight is queued rather than dropped, so a search or
-    // facet change still lands even while a poll is running.
+    // memory for a response that gets thrown away as stale anyway.
     if (refreshing) {
+      if (!queue) return;
       reloadQueued = true;
+      // The in-flight request carries the previous query, so retire it: its
+      // rows would otherwise land as the current ones until the queued load
+      // answers.
+      runsRequestId++;
       return;
     }
     refreshing = true;
@@ -428,7 +435,7 @@
     lastRunQueryKey = key;
     const timer = window.setTimeout(() => {
       loadedRunCount = RUNS_PAGE_SIZE;
-      void load();
+      void load({ queue: true });
     }, 250);
     return () => window.clearTimeout(timer);
   });
@@ -818,7 +825,7 @@
         title={pageMeta[activePage].title}
         {statusText}
         {refreshing}
-        onRefresh={load}
+        onRefresh={() => load()}
       />
 
     {#if activePage === "training" && activeTrainingRunId}

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -430,9 +430,10 @@
   function loadMoreRuns() {
     if (!hasMoreRuns) return;
     const nextCount = runs.length + RUNS_PAGE_SIZE;
-    // Scrolling fires this on every event, so the page already asked for is
-    // not asked for again: one queued page per set of rows on screen.
-    if (loadedRunCount >= nextCount) return;
+    // Scrolling fires this on every event, so while the fetch for this page is
+    // in flight or queued it isn't asked for again. Once nothing is in flight a
+    // page that failed can be retried.
+    if (loadedRunCount >= nextCount && (refreshing || reloadQueued)) return;
     loadedRunCount = nextCount;
     // Queued, so asking for the next page during a refresh grows the window
     // once that refresh lands instead of being dropped.

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -18,10 +18,8 @@
 
   const DOCS_URL = "https://gym.modal.dev";
 
-  // The server filters, sorts and pages the run list: `runs` only ever holds
-  // the rows the page has asked for. Every total on the page comes from
-  // `runCounts` instead — the whole history is far too much JSON for a phone to
-  // download and keep resident just to count it.
+  // The server filters, sorts and pages the run list, so `runs` only holds the
+  // rows the page asked for and every total comes from `runCounts`.
   const RUNS_PAGE_SIZE = 100;
   let runs = $state([]);
   let loadedRunCount = $state(RUNS_PAGE_SIZE);
@@ -112,26 +110,42 @@
     // their status/stage and rollouts stay live. Current data stays on screen
     // (no skeleton) and only the refresh button spins while fetching. A run
     // detail page refreshes its own run, so skip the full list there.
-    // A backgrounded tab refreshes nothing and catches up on the way back:
-    // polling a hidden tab only burns memory and battery, and mobile browsers
-    // discard tabs that keep working while off-screen.
-    const refresh = window.setInterval(() => {
-      if (document.hidden) return;
-      if (activePage === "training" && activeTrainingRunId) return;
-      void load();
-    }, 5000);
+    // A hidden tab polls nothing — mobile browsers discard tabs that keep
+    // working off-screen — and catches up once on the way back.
+    let refresh = null;
+
+    const shouldRefresh = () =>
+      !(activePage === "training" && activeTrainingRunId);
+
+    const startPolling = () => {
+      if (refresh !== null) return;
+      refresh = window.setInterval(() => {
+        if (shouldRefresh()) void load();
+      }, 5000);
+    };
+
+    const stopPolling = () => {
+      if (refresh === null) return;
+      window.clearInterval(refresh);
+      refresh = null;
+    };
 
     const onVisibilityChange = () => {
-      if (document.hidden) return;
-      if (activePage === "training" && activeTrainingRunId) return;
-      void load();
+      if (document.hidden) {
+        stopPolling();
+        return;
+      }
+      startPolling();
+      if (shouldRefresh()) void load();
     };
+
+    if (!document.hidden) startPolling();
     document.addEventListener("visibilitychange", onVisibilityChange);
 
     return () => {
       window.removeEventListener("popstate", syncPageWithPath);
       document.removeEventListener("visibilitychange", onVisibilityChange);
-      window.clearInterval(refresh);
+      stopPolling();
     };
   });
 

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -94,13 +94,25 @@
     // their status/stage and rollouts stay live. Current data stays on screen
     // (no skeleton) and only the refresh button spins while fetching. A run
     // detail page refreshes its own run, so skip the full list there.
+    // A backgrounded tab refreshes nothing and catches up on the way back:
+    // polling a hidden tab only burns memory and battery, and mobile browsers
+    // discard tabs that keep working while off-screen.
     const refresh = window.setInterval(() => {
+      if (document.hidden) return;
       if (activePage === "training" && activeTrainingRunId) return;
       void load();
     }, 5000);
 
+    const onVisibilityChange = () => {
+      if (document.hidden) return;
+      if (activePage === "training" && activeTrainingRunId) return;
+      void load();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
     return () => {
       window.removeEventListener("popstate", syncPageWithPath);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       window.clearInterval(refresh);
     };
   });
@@ -251,6 +263,10 @@
   }
 
   async function load() {
+    // One refresh at a time. The runs payload can take longer to arrive than
+    // the 5s interval, and overlapping fetches stack whole copies of it in
+    // memory for a response that gets thrown away as stale anyway.
+    if (refreshing) return;
     refreshing = true;
     try {
       const tasks = [loadRuns()];

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -342,18 +342,28 @@
     if (!isStale()) loadingEvals = false;
   }
 
+  let reloadQueued = false;
+
   async function load() {
     // One refresh at a time. The runs payload can take longer to arrive than
     // the 5s interval, and overlapping fetches stack whole copies of it in
-    // memory for a response that gets thrown away as stale anyway.
-    if (refreshing) return;
+    // memory for a response that gets thrown away as stale anyway. A request
+    // that arrives mid-flight is queued rather than dropped, so a search or
+    // facet change still lands even while a poll is running.
+    if (refreshing) {
+      reloadQueued = true;
+      return;
+    }
     refreshing = true;
     try {
-      const tasks = [loadRuns()];
-      if (activePage === "evals") {
-        tasks.push(loadEvals());
-      }
-      await Promise.all(tasks);
+      do {
+        reloadQueued = false;
+        const tasks = [loadRuns()];
+        if (activePage === "evals") {
+          tasks.push(loadEvals());
+        }
+        await Promise.all(tasks);
+      } while (reloadQueued);
     } finally {
       refreshing = false;
     }
@@ -418,7 +428,7 @@
     lastRunQueryKey = key;
     const timer = window.setTimeout(() => {
       loadedRunCount = RUNS_PAGE_SIZE;
-      void loadRuns();
+      void load();
     }, 250);
     return () => window.clearTimeout(timer);
   });

--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -138,6 +138,7 @@
   // Mirrors the server's facet buckets (`run_facet_values`), which is what the
   // filter chips and counts are keyed by.
   const NO_GROUP = "(no group)";
+  const UNTAGGED_RECIPE = "(untagged)";
 
   function getGroup(run) {
     return safeText(run.group_id) || NO_GROUP;
@@ -241,6 +242,26 @@
     }
   }
 
+  // The counts endpoint is the only source of whole-history totals, so losing
+  // it (a preview build talking to an older backend, a slow volume read) must
+  // not take the rows down with it: count the loaded window instead. Exact
+  // once everything is paged in, an undercount before that.
+  function countsFromPage(page) {
+    const buckets = { status: {}, recipe: {}, group: {} };
+    for (const run of page) {
+      const values = {
+        status: getStatus(run),
+        recipe:
+          safeText(run.recipe) || safeText(run.framework) || UNTAGGED_RECIPE,
+        group: getGroup(run),
+      };
+      for (const [name, value] of Object.entries(values)) {
+        buckets[name][value] = (buckets[name][value] || 0) + 1;
+      }
+    }
+    return { total: page.length, matching: page.length, ...buckets };
+  }
+
   async function loadRuns() {
     const requestId = ++runsRequestId;
     const isStale = () => requestId !== runsRequestId;
@@ -259,7 +280,7 @@
     const limit = Math.max(loadedRunCount, RUNS_PAGE_SIZE);
 
     try {
-      const [page, counts] = await Promise.all([
+      const [pageResult, countsResult] = await Promise.allSettled([
         matchesNothing
           ? Promise.resolve([])
           : fetchWithTimeout(
@@ -274,6 +295,12 @@
         ),
       ]);
       if (isStale()) return;
+      if (pageResult.status === "rejected") throw pageResult.reason;
+      const page = pageResult.value;
+      const counts =
+        countsResult.status === "fulfilled"
+          ? countsResult.value
+          : countsFromPage(page);
       runs = page;
       runCounts = counts;
       adoptFacetValues(counts);

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -1420,6 +1420,29 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   font-size: 0.84rem;
 }
 
+.load-more-button {
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-bright);
+  padding: 6px 14px;
+  font-size: 0.84rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.load-more-button:hover {
+  background: color-mix(in srgb, var(--border-strong) 22%, transparent);
+}
+
+.load-more-button:focus {
+  outline: none;
+}
+
+.load-more-button:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--border-strong) 55%, transparent);
+}
+
 .open-modal-link-disabled {
   opacity: 0.5;
   pointer-events: none;

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -1420,11 +1420,6 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   font-size: 0.84rem;
 }
 
-/* Sits at the bottom of a table's scrollport; revealing it loads the next page. */
-.table-page-sentinel {
-  height: 1px;
-}
-
 .open-modal-link-disabled {
   opacity: 0.5;
   pointer-events: none;

--- a/dashboards/frontend/src/app.css
+++ b/dashboards/frontend/src/app.css
@@ -1420,6 +1420,11 @@ table.resizable-table.sticky-first-column tr.row-selected td:first-child {
   font-size: 0.84rem;
 }
 
+/* Sits at the bottom of a table's scrollport; revealing it loads the next page. */
+.table-page-sentinel {
+  height: 1px;
+}
+
 .open-modal-link-disabled {
   opacity: 0.5;
   pointer-events: none;

--- a/dashboards/frontend/src/components/TimeAgo.svelte
+++ b/dashboards/frontend/src/components/TimeAgo.svelte
@@ -1,11 +1,10 @@
 <script>
   import { formatDistance } from "date-fns";
-  import { readable } from "svelte/store";
+  import { nowMs } from "../lib/clock.js";
   import { fmtDate, toEpochSeconds } from "../lib/format.js";
 
   let {
     timestamp,
-    updateInterval = 5000,
     allowFuture = false,
     falsyRepresentation = "",
     showJustNow = false,
@@ -21,15 +20,6 @@
     return date.toISOString();
   });
 
-  const now = readable(Date.now(), (set) => {
-    if (typeof window !== "undefined") {
-      const id = window.setInterval(() => {
-        set(Date.now());
-      }, updateInterval);
-      return () => window.clearInterval(id);
-    }
-  });
-
   $effect(() => {
     if (!hasTimestamp) {
       text = falsyRepresentation;
@@ -37,16 +27,16 @@
     }
 
     let valueMs = normalizedSeconds * 1000;
-    if (!allowFuture && valueMs > $now) {
-      valueMs = $now;
+    if (!allowFuture && valueMs > $nowMs) {
+      valueMs = $nowMs;
     }
 
-    if (showJustNow && valueMs > $now - 60 * 1000) {
+    if (showJustNow && valueMs > $nowMs - 60 * 1000) {
       text = "just now";
       return;
     }
 
-    text = formatDistance(valueMs, $now, {
+    text = formatDistance(valueMs, $nowMs, {
       addSuffix: true,
       includeSeconds: true,
     });

--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -12,11 +12,37 @@ async function getErrorFromResponse(res) {
   return detail ? `HTTP ${res.status}: ${detail}` : `HTTP ${res.status}`;
 }
 
-export async function fetchRuns({ signal } = {}) {
-  const response = await fetch(`${SERVER}/runs`, { signal });
+// The run list is paged and filtered server-side: `facets` maps a facet name
+// ("status", "recipe", "group") to the selected buckets, and a facet left out
+// means every bucket. Totals and per-bucket counts come from `fetchRunCounts`,
+// which sees every run rather than the page the client holds.
+function runQueryParams({ limit, offset, query, facets }) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (offset) params.set("offset", String(offset));
+  if (query) params.set("q", query);
+  for (const [facet, values] of Object.entries(facets || {})) {
+    for (const value of values) params.append(facet, value);
+  }
+  const search = params.toString();
+  return search ? `?${search}` : "";
+}
+
+export async function fetchRuns({ signal, limit, offset, query, facets } = {}) {
+  const search = runQueryParams({ limit, offset, query, facets });
+  const response = await fetch(`${SERVER}/runs${search}`, { signal });
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   const runs = await response.json();
   return Array.isArray(runs) ? runs : [];
+}
+
+// Per-bucket counts cover every run; `matching` counts the given query, so the
+// page knows how many rows are still reachable by paging.
+export async function fetchRunCounts({ signal, query, facets } = {}) {
+  const search = runQueryParams({ query, facets });
+  const res = await fetch(`${SERVER}/runs/counts${search}`, { signal });
+  if (!res.ok) throw new Error(await getErrorFromResponse(res));
+  return await res.json();
 }
 
 export async function fetchRun(trainingRunId, { signal } = {}) {

--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -12,6 +12,23 @@ async function getErrorFromResponse(res) {
   return detail ? `HTTP ${res.status}: ${detail}` : `HTTP ${res.status}`;
 }
 
+// `Response.json()` on a non-JSON body throws a parser error that says nothing
+// about the request — on WebKit it's the famously opaque "The string did not
+// match the expected pattern" — so a proxy login page, an edge error page or a
+// truncated response all surface as the same riddle. Parse the text ourselves
+// and say what came back instead.
+async function readJson(res, what) {
+  const body = await res.text();
+  try {
+    return JSON.parse(body);
+  } catch {
+    const contentType = res.headers.get("content-type") || "unknown type";
+    throw new Error(
+      `${what}: expected JSON, got ${contentType} (HTTP ${res.status}, ${body.length} bytes)`,
+    );
+  }
+}
+
 // The run list is paged and filtered server-side: `facets` maps a facet name
 // ("status", "recipe", "group") to the selected buckets, and a facet left out
 // means every bucket. Totals and per-bucket counts come from `fetchRunCounts`,
@@ -32,7 +49,7 @@ export async function fetchRuns({ signal, limit, offset, query, facets } = {}) {
   const search = runQueryParams({ limit, offset, query, facets });
   const response = await fetch(`${SERVER}/runs${search}`, { signal });
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const runs = await response.json();
+  const runs = await readJson(response, "runs");
   return Array.isArray(runs) ? runs : [];
 }
 
@@ -42,7 +59,7 @@ export async function fetchRunCounts({ signal, query, facets } = {}) {
   const search = runQueryParams({ query, facets });
   const res = await fetch(`${SERVER}/runs/counts${search}`, { signal });
   if (!res.ok) throw new Error(await getErrorFromResponse(res));
-  return await res.json();
+  return await readJson(res, "run counts");
 }
 
 export async function fetchRun(trainingRunId, { signal } = {}) {
@@ -54,7 +71,7 @@ export async function fetchRun(trainingRunId, { signal } = {}) {
   if (!res.ok) {
     throw new Error(await getErrorFromResponse(res));
   }
-  return await res.json();
+  return await readJson(res, "run detail");
 }
 
 export async function fetchEvals({ signal } = {}) {
@@ -62,7 +79,7 @@ export async function fetchEvals({ signal } = {}) {
   if (!res.ok) {
     throw new Error(await getErrorFromResponse(res));
   }
-  const evals = await res.json();
+  const evals = await readJson(res, "evals");
   const seen = new Set();
   return evals.filter((e) => {
     if (seen.has(e.eval_id)) return false;

--- a/dashboards/frontend/src/lib/clock.js
+++ b/dashboards/frontend/src/lib/clock.js
@@ -1,0 +1,10 @@
+import { readable } from "svelte/store";
+
+// One ticking clock for every relative timestamp on the page. A per-instance
+// interval costs a timer and a re-render per rendered timestamp, and the run
+// list renders hundreds of them.
+export const nowMs = readable(Date.now(), (set) => {
+  if (typeof window === "undefined") return;
+  const id = window.setInterval(() => set(Date.now()), 5000);
+  return () => window.clearInterval(id);
+});

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -199,22 +199,6 @@
     collapsedGroupKeys = new Set();
   });
 
-  // A run row is ~50 DOM nodes, so a full history is seconds of layout on a
-  // phone and a re-render of every row on each refresh. The server hands out
-  // one page at a time and scrolling near the end asks for the next one.
-  let hiddenRunCount = $derived(
-    Math.max(matchingRunCount - filteredRuns.length, 0),
-  );
-
-  function growOnScroll(event) {
-    if (!hasMoreRuns) return;
-    const el = event.currentTarget;
-    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 600) {
-      onLoadMore();
-    }
-  }
-
-  let sentinel = $state(null);
   let list = $state(null);
 
   // A new query restarts paging at the first page. Staying scrolled to the
@@ -227,18 +211,21 @@
     for (const wrap of root.querySelectorAll(".table-wrap")) wrap.scrollTop = 0;
   });
 
-  $effect(() => {
-    const node = sentinel;
-    if (!node) return;
+  // A run row is ~50 DOM nodes, so a full history is seconds of layout on a
+  // phone and a re-render of every row on each refresh. The server hands out
+  // one page at a time, and reaching the end of a table asks for the next one.
+  // Rows scroll inside `.table-wrap`, so that's the root the sentinel is
+  // measured against rather than the viewport.
+  function pageOnReveal(node) {
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) onLoadMore();
       },
-      { rootMargin: "600px" },
+      { root: node.closest(".table-wrap"), rootMargin: "600px" },
     );
     observer.observe(node);
-    return () => observer.disconnect();
-  });
+    return { destroy: () => observer.disconnect() };
+  }
 </script>
 
 <section class="summary-sticky grid grid-cols-5 gap-[14px] p-[0_24px] mb-[24px] max-[900px]:grid-cols-2">
@@ -313,7 +300,6 @@
         <div
           class="table-wrap freeze-header"
           style={frozenOffset ? `--frozen-table-offset: ${frozenOffset};` : ""}
-          onscroll={growOnScroll}
         >
           <ResizableTable class="training-runs-table" {columns} stickyFirstColumn>
             <tbody>
@@ -466,6 +452,9 @@
               {/each}
             </tbody>
           </ResizableTable>
+          {#if hasMoreRuns}
+            <div class="table-page-sentinel" use:pageOnReveal></div>
+          {/if}
         </div>
       {/snippet}
 
@@ -493,11 +482,9 @@
         </div>
       {/if}
 
-      {#if hiddenRunCount > 0}
-        <div bind:this={sentinel} class="page-empty">
-          Showing {filteredRuns.length} of {matchingRunCount} runs
-        </div>
-      {/if}
+      <div class="page-empty">
+        Showing {filteredRuns.length} of {matchingRunCount} runs
+      </div>
     {/if}
   </div>
 </section>

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -218,7 +218,9 @@
   // signal that means "the reader reached the end of *this* scrollport": a
   // sentinel + IntersectionObserver either never re-fires once it is already
   // visible (a short group's table doesn't scroll at all) or pages the whole
-  // history unprompted, which is what this PR exists to stop.
+  // history unprompted, which is what this PR exists to stop. Grouped tables
+  // may not scroll at all, so the footer's button is what keeps every run
+  // reachable; scrolling is only the shortcut.
   function growOnScroll(event) {
     if (!hasMoreRuns) return;
     const el = event.currentTarget;
@@ -480,8 +482,13 @@
         </div>
       {/if}
 
-      <div class="page-empty">
-        Showing {filteredRuns.length} of {matchingRunCount} runs
+      <div class="page-empty flex flex-col items-center gap-[10px]">
+        <span>Showing {filteredRuns.length} of {matchingRunCount} runs</span>
+        {#if hasMoreRuns}
+          <button type="button" class="load-more-button" onclick={onLoadMore}>
+            Load more
+          </button>
+        {/if}
       </div>
     {/if}
   </div>

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -181,7 +181,7 @@
   }
 
   $effect(() => {
-    if (!loading && drawerRunId && drawerRunMissing) {
+    if (drawerRunId && drawerRunMissing) {
       onCloseDrawer();
     }
   });

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -9,6 +9,7 @@
   import RunSummary from "../components/RunSummary.svelte";
   import StatusPill from "../components/StatusPill.svelte";
   import TimeAgo from "../components/TimeAgo.svelte";
+  import { fetchRun } from "../lib/api.js";
   import { formatTagValue, getGroupTags } from "../lib/format.js";
   import { normalizeMetricLinks } from "../lib/metricLinks.js";
   import { toggleInSet } from "../lib/set.js";
@@ -57,9 +58,29 @@
   // full rollouts/logs detail lives on its own page. Clicking a run (or the
   // drawer's Expand button) navigates to that page; the page's Collapse button
   // brings the summary back as this drawer.
-  let selectedRun = $derived.by(
-    () => allRuns.find((run) => run.run_id === drawerRunId) || null,
-  );
+  // The list payload carries only the fields the table renders, so the drawer
+  // fetches the run's full record (config and all) when it opens.
+  let drawerDetail = $state(null);
+
+  $effect(() => {
+    const runId = drawerRunId;
+    drawerDetail = null;
+    if (!runId) return;
+    const controller = new AbortController();
+    fetchRun(runId, { signal: controller.signal })
+      .then((detail) => {
+        if (detail) drawerDetail = detail;
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  });
+
+  let selectedRun = $derived.by(() => {
+    const listRun = allRuns.find((run) => run.run_id === drawerRunId) || null;
+    if (!listRun) return null;
+    if (drawerDetail?.run_id !== drawerRunId) return listRun;
+    return { ...listRun, ...drawerDetail };
+  });
 
   const drawerWidth = "min(420px, calc(100vw - 24px))";
   const columns = [
@@ -171,6 +192,60 @@
     void groupBy;
     collapsedGroupKeys = new Set();
   });
+
+  // A run row is ~50 DOM nodes, so rendering every run costs seconds of layout
+  // on a phone and re-renders the whole table on each refresh. Rows come in as
+  // they are scrolled towards instead; filters still run over every run.
+  const renderChunk = 60;
+  let renderLimit = $state(renderChunk);
+
+  $effect(() => {
+    void search;
+    void activeRecipes;
+    void activeStatuses;
+    void activeGroups;
+    void groupBy;
+    renderLimit = renderChunk;
+  });
+
+  let visibleRuns = $derived(filteredRuns.slice(0, renderLimit));
+
+  let visibleGroups = $derived.by(() => {
+    let budget = renderLimit;
+    return runGroups.map((group) => {
+      if (collapsedGroupKeys.has(group.key)) return group;
+      const runs = group.runs.slice(0, Math.max(budget, 0));
+      budget -= runs.length;
+      return { ...group, runs };
+    });
+  });
+
+  let hiddenRunCount = $derived(Math.max(filteredRuns.length - renderLimit, 0));
+
+  function growOnScroll(event) {
+    if (hiddenRunCount <= 0) return;
+    const el = event.currentTarget;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 600) {
+      renderLimit += renderChunk;
+    }
+  }
+
+  let sentinel = $state(null);
+
+  $effect(() => {
+    const node = sentinel;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          renderLimit += renderChunk;
+        }
+      },
+      { rootMargin: "600px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  });
 </script>
 
 <section class="summary-sticky grid grid-cols-5 gap-[14px] p-[0_24px] mb-[24px] max-[900px]:grid-cols-2">
@@ -242,7 +317,11 @@
       <div class="page-empty">No runs match the current filters.</div>
     {:else}
       {#snippet runsTable(runs, frozenOffset)}
-        <div class="table-wrap freeze-header" style={frozenOffset ? `--frozen-table-offset: ${frozenOffset};` : ""}>
+        <div
+          class="table-wrap freeze-header"
+          style={frozenOffset ? `--frozen-table-offset: ${frozenOffset};` : ""}
+          onscroll={growOnScroll}
+        >
           <ResizableTable class="training-runs-table" {columns} stickyFirstColumn>
             <tbody>
               {#each runs as run, runIndex (`${run.run_id || "run"}-${run.created_at || 0}-${runIndex}`)}
@@ -398,10 +477,10 @@
       {/snippet}
 
       {#if groupBy === "none"}
-        {@render runsTable(filteredRuns)}
+        {@render runsTable(visibleRuns)}
       {:else}
         <div class="flex flex-col gap-[24px] p-0">
-          {#each runGroups as group (group.key)}
+          {#each visibleGroups as group (group.key)}
             <GroupSection
               title={group.key}
               subtitle={`${group.runs.length} run${group.runs.length === 1 ? "" : "s"}`}
@@ -418,6 +497,12 @@
               {@render runsTable(group.runs, "360px")}
             </GroupSection>
           {/each}
+        </div>
+      {/if}
+
+      {#if hiddenRunCount > 0}
+        <div bind:this={sentinel} class="page-empty">
+          Showing {renderLimit} of {filteredRuns.length} runs
         </div>
       {/if}
     {/if}

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -64,15 +64,21 @@
   // The list payload carries only the fields the table renders, so the drawer
   // fetches the run's full record (config and all) when it opens.
   let drawerDetail = $state(null);
+  // Set only when the server says the run is gone. The list holds one page, so
+  // a run being absent from it means nothing — the drawer renders from the
+  // detail fetch for runs deep-linked or scrolled past.
+  let drawerRunMissing = $state(false);
 
   $effect(() => {
     const runId = drawerRunId;
     drawerDetail = null;
+    drawerRunMissing = false;
     if (!runId) return;
     const controller = new AbortController();
     fetchRun(runId, { signal: controller.signal })
       .then((detail) => {
         if (detail) drawerDetail = detail;
+        else drawerRunMissing = true;
       })
       .catch(() => {});
     return () => controller.abort();
@@ -80,9 +86,10 @@
 
   let selectedRun = $derived.by(() => {
     const listRun = filteredRuns.find((run) => run.run_id === drawerRunId) || null;
-    if (!listRun) return null;
-    if (drawerDetail?.run_id !== drawerRunId) return listRun;
-    return { ...listRun, ...drawerDetail };
+    const detail = drawerDetail?.run_id === drawerRunId ? drawerDetail : null;
+    if (!listRun) return detail;
+    if (!detail) return listRun;
+    return { ...listRun, ...detail };
   });
 
   const drawerWidth = "min(420px, calc(100vw - 24px))";
@@ -174,11 +181,7 @@
   }
 
   $effect(() => {
-    if (
-      !loading &&
-      drawerRunId &&
-      !filteredRuns.some((run) => run.run_id === drawerRunId)
-    ) {
+    if (!loading && drawerRunId && drawerRunMissing) {
       onCloseDrawer();
     }
   });

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -213,18 +213,18 @@
 
   // A run row is ~50 DOM nodes, so a full history is seconds of layout on a
   // phone and a re-render of every row on each refresh. The server hands out
-  // one page at a time, and reaching the end of a table asks for the next one.
-  // Rows scroll inside `.table-wrap`, so that's the root the sentinel is
-  // measured against rather than the viewport.
-  function pageOnReveal(node) {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) onLoadMore();
-      },
-      { root: node.closest(".table-wrap"), rootMargin: "600px" },
-    );
-    observer.observe(node);
-    return { destroy: () => observer.disconnect() };
+  // one page at a time and scrolling a table near its end asks for the next
+  // one. Rows scroll inside `.table-wrap`, and a scroll event is the only
+  // signal that means "the reader reached the end of *this* scrollport": a
+  // sentinel + IntersectionObserver either never re-fires once it is already
+  // visible (a short group's table doesn't scroll at all) or pages the whole
+  // history unprompted, which is what this PR exists to stop.
+  function growOnScroll(event) {
+    if (!hasMoreRuns) return;
+    const el = event.currentTarget;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 600) {
+      onLoadMore();
+    }
   }
 </script>
 
@@ -300,6 +300,7 @@
         <div
           class="table-wrap freeze-header"
           style={frozenOffset ? `--frozen-table-offset: ${frozenOffset};` : ""}
+          onscroll={growOnScroll}
         >
           <ResizableTable class="training-runs-table" {columns} stickyFirstColumn>
             <tbody>
@@ -452,9 +453,6 @@
               {/each}
             </tbody>
           </ResizableTable>
-          {#if hasMoreRuns}
-            <div class="table-page-sentinel" use:pageOnReveal></div>
-          {/if}
         </div>
       {/snippet}
 

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -15,7 +15,10 @@
   import { toggleInSet } from "../lib/set.js";
 
   let {
-    allRuns,
+    totalRuns,
+    matchingRunCount,
+    hasMoreRuns,
+    onLoadMore = () => {},
     completedTotal,
     runningTotal,
     stoppedTotal,
@@ -76,7 +79,7 @@
   });
 
   let selectedRun = $derived.by(() => {
-    const listRun = allRuns.find((run) => run.run_id === drawerRunId) || null;
+    const listRun = filteredRuns.find((run) => run.run_id === drawerRunId) || null;
     if (!listRun) return null;
     if (drawerDetail?.run_id !== drawerRunId) return listRun;
     return { ...listRun, ...drawerDetail };
@@ -174,7 +177,7 @@
     if (
       !loading &&
       drawerRunId &&
-      !allRuns.some((run) => run.run_id === drawerRunId)
+      !filteredRuns.some((run) => run.run_id === drawerRunId)
     ) {
       onCloseDrawer();
     }
@@ -193,53 +196,40 @@
     collapsedGroupKeys = new Set();
   });
 
-  // A run row is ~50 DOM nodes, so rendering every run costs seconds of layout
-  // on a phone and re-renders the whole table on each refresh. Rows come in as
-  // they are scrolled towards instead; filters still run over every run.
-  const renderChunk = 60;
-  let renderLimit = $state(renderChunk);
-
-  $effect(() => {
-    void search;
-    void activeRecipes;
-    void activeStatuses;
-    void activeGroups;
-    void groupBy;
-    renderLimit = renderChunk;
-  });
-
-  let visibleRuns = $derived(filteredRuns.slice(0, renderLimit));
-
-  let visibleGroups = $derived.by(() => {
-    let budget = renderLimit;
-    return runGroups.map((group) => {
-      if (collapsedGroupKeys.has(group.key)) return group;
-      const runs = group.runs.slice(0, Math.max(budget, 0));
-      budget -= runs.length;
-      return { ...group, runs };
-    });
-  });
-
-  let hiddenRunCount = $derived(Math.max(filteredRuns.length - renderLimit, 0));
+  // A run row is ~50 DOM nodes, so a full history is seconds of layout on a
+  // phone and a re-render of every row on each refresh. The server hands out
+  // one page at a time and scrolling near the end asks for the next one.
+  let hiddenRunCount = $derived(
+    Math.max(matchingRunCount - filteredRuns.length, 0),
+  );
 
   function growOnScroll(event) {
-    if (hiddenRunCount <= 0) return;
+    if (!hasMoreRuns) return;
     const el = event.currentTarget;
     if (el.scrollTop + el.clientHeight >= el.scrollHeight - 600) {
-      renderLimit += renderChunk;
+      onLoadMore();
     }
   }
 
   let sentinel = $state(null);
+  let list = $state(null);
+
+  // A new query restarts paging at the first page. Staying scrolled to the
+  // bottom of the old, longer list would immediately ask for page after page
+  // again, so send the reader back to the top of the new results.
+  $effect(() => {
+    void search;
+    const root = list;
+    if (!root) return;
+    for (const wrap of root.querySelectorAll(".table-wrap")) wrap.scrollTop = 0;
+  });
 
   $effect(() => {
     const node = sentinel;
     if (!node) return;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          renderLimit += renderChunk;
-        }
+        if (entries.some((entry) => entry.isIntersecting)) onLoadMore();
       },
       { rootMargin: "600px" },
     );
@@ -251,7 +241,7 @@
 <section class="summary-sticky grid grid-cols-5 gap-[14px] p-[0_24px] mb-[24px] max-[900px]:grid-cols-2">
   <article class="summary-card">
     <span class="summary-label">Total runs</span>
-    <strong>{allRuns.length}</strong>
+    <strong>{totalRuns}</strong>
   </article>
   <article class="summary-card">
     <span class="summary-label">Completed runs</span>
@@ -300,7 +290,7 @@
     />
   </div>
 
-  <div class="p-0">
+  <div class="p-0" bind:this={list}>
     {#if loading}
       <div class="table-wrap freeze-header">
         <MinimalTableSkeleton
@@ -311,7 +301,7 @@
       </div>
     {:else if error}
       <div class="page-empty">Failed to load: {error}</div>
-    {:else if !allRuns.length}
+    {:else if !totalRuns}
       <div class="page-empty">No training runs found yet.</div>
     {:else if !filteredRuns.length}
       <div class="page-empty">No runs match the current filters.</div>
@@ -477,10 +467,10 @@
       {/snippet}
 
       {#if groupBy === "none"}
-        {@render runsTable(visibleRuns)}
+        {@render runsTable(filteredRuns)}
       {:else}
         <div class="flex flex-col gap-[24px] p-0">
-          {#each visibleGroups as group (group.key)}
+          {#each runGroups as group (group.key)}
             <GroupSection
               title={group.key}
               subtitle={`${group.runs.length} run${group.runs.length === 1 ? "" : "s"}`}
@@ -502,7 +492,7 @@
 
       {#if hiddenRunCount > 0}
         <div bind:this={sentinel} class="page-empty">
-          Showing {renderLimit} of {filteredRuns.length} runs
+          Showing {filteredRuns.length} of {matchingRunCount} runs
         </div>
       {/if}
     {/if}

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -85,6 +85,10 @@
   let run = $state(null);
   let runLoading = $state(false);
   let runError = $state("");
+  // A run id that isn't in the metadata volume won't appear later, so the
+  // 5s poll stops instead of refetching the same 404 for as long as the page
+  // stays open.
+  let runMissing = $state(false);
 
   async function loadRun(id, parentSignal) {
     if (parentSignal.aborted) return;
@@ -103,6 +107,7 @@
       if (parentSignal.aborted) return;
       if (nextRun === null) {
         run = null;
+        runMissing = true;
         runError = `Training run "${id}" was not found.`;
         return;
       }
@@ -153,6 +158,7 @@
     const id = runId;
     run = initialRun?.run_id === id ? initialRun : null;
     runError = "";
+    runMissing = false;
     if (!id) {
       runLoading = false;
       return;
@@ -161,7 +167,8 @@
     const controller = new AbortController();
     void loadRun(id, controller.signal);
     const interval = window.setInterval(() => {
-      if (runLoading || (runStatus && runStatus !== "running")) return;
+      if (runMissing || runLoading || (runStatus && runStatus !== "running"))
+        return;
       void loadRun(id, controller.signal);
     }, 5000);
 

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -643,7 +643,7 @@
   // steps stream in on a running run.
   $effect(() => {
     const id = runId;
-    if (!id || activeTab !== "summary") return;
+    if (!id || runMissing || activeTab !== "summary") return;
 
     const controller = new AbortController();
     void loadAdvantages(controller.signal);
@@ -664,7 +664,7 @@
   $effect(() => {
     const id = runId;
     const tab = activeTab;
-    if (!id || (tab !== "summary" && tab !== "rollouts")) return;
+    if (!id || runMissing || (tab !== "summary" && tab !== "rollouts")) return;
 
     const controller = new AbortController();
     rolloutsLoading = true;

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -429,6 +429,7 @@ def fastapi_app():
         Path as FastAPIPath,
     )  # Request imported at module scope
     from fastapi.concurrency import run_in_threadpool
+    from fastapi.middleware.gzip import GZipMiddleware
     from fastapi.responses import (
         FileResponse,
         JSONResponse,
@@ -447,6 +448,22 @@ def fastapi_app():
     )
 
     web = FastAPI()
+
+    class _GZipUnlessStreaming(GZipMiddleware):
+        """Compress responses, leaving server-sent-event streams untouched.
+
+        Buffering an SSE stream through gzip withholds each event until the
+        compressor flushes, which stalls the live log tail.
+        """
+
+        async def __call__(self, scope, receive, send):
+            path = scope.get("path", "") if scope["type"] == "http" else ""
+            if path.endswith("/logs/stream"):
+                await self.app(scope, receive, send)
+                return
+            await super().__call__(scope, receive, send)
+
+    web.add_middleware(_GZipUnlessStreaming, minimum_size=1024)
 
     # ── Optional password protection ──────────────────────────────────────
     # When DASHBOARD_PASSWORD is set we gate the whole app behind HTTP Basic
@@ -840,7 +857,16 @@ def fastapi_app():
 
     # ── Training runs ────────────────────────────────────────────────────
 
-    @web.get("/api/runs", response_model=list[RunSummary])
+    # The run list renders none of the full config or the per-step timing maps —
+    # the per-run detail endpoint serves those — yet they are most of the list
+    # payload (``config`` alone is ~60% of it), so the list drops them rather
+    # than shipping them on every poll. ``metadata`` stays: the list's group and
+    # tag columns fall back to it for runs that predate ``group_tags``.
+    run_list_excluded_fields = {"config", "step_times", "substep_times"}
+
+    # ``response_model`` is left off: FastAPI ignores ``response_model_exclude``
+    # for sequence response models, so the exclusion is applied here instead.
+    @web.get("/api/runs")
     async def runs(
         request: Request,
         since: int | None = None,
@@ -866,7 +892,12 @@ def fastapi_app():
             since=since,
             limit=limit,
         )
-        return filtered
+        return JSONResponse(
+            [
+                summary.model_dump(mode="json", exclude=run_list_excluded_fields)
+                for summary in filtered
+            ]
+        )
 
     @web.get("/api/runs/{training_run_id}", response_model=RunSummary)
     async def get_run(training_run_id: str):

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -13,7 +13,15 @@ import os
 import secrets as _secrets
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Awaitable, Callable, Iterable, TypedDict, cast
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Awaitable,
+    Callable,
+    Iterable,
+    TypedDict,
+    cast,
+)
 
 import modal
 from modal.exception import Error
@@ -23,13 +31,14 @@ if TYPE_CHECKING:
     from modal.client import _Client
     from modal_proto import api_pb2
 
-# Imported at module scope so FastAPI can resolve the ``request: Request``
-# annotation in stream_run_logs(). Under ``from __future__ import
+# Imported at module scope so FastAPI can resolve endpoint annotations such as
+# ``request: Request`` in stream_run_logs(). Under ``from __future__ import
 # annotations`` all type hints are strings, and FastAPI evaluates them
 # against the *defining function's* ``__globals__`` (i.e. this module).
 # Importing ``Request`` only inside ``fastapi_app()`` makes the name
 # invisible to FastAPI's introspection, which then mistakes the parameter
 # for a query string and 422s with ``{"loc": ["query", "request"]}``.
+from fastapi import Query
 from starlette.requests import Request
 
 # Used as endpoint parameter annotations, so — like ``Request`` above — these
@@ -81,6 +90,10 @@ from modal_training_gym.utils.metadata import (
 )
 
 SummaryLoader = Callable[[], Awaitable[list[JsonDict]]]
+
+# Repeated params (``?status=failed&status=stopped``) mirror the run list's
+# multi-select chips; an absent facet means "every bucket".
+FacetParam = Annotated[list[str] | None, Query()]
 
 
 # A single historical log line from ``AppFetchLogs``
@@ -429,7 +442,7 @@ def fastapi_app():
         Header,
         HTTPException,
         Path as FastAPIPath,
-    )  # Request imported at module scope
+    )  # Request and Query imported at module scope
     from fastapi.concurrency import run_in_threadpool
     from fastapi.responses import (
         FileResponse,
@@ -849,14 +862,13 @@ def fastapi_app():
     # tag columns fall back to it for runs that predate ``group_tags``.
     run_list_excluded_fields = {"config", "step_times", "substep_times"}
 
-    # Repeated params (``?status=failed&status=stopped``) mirror the run list's
-    # multi-select chips; an absent facet means "every bucket".
-    def _requested_facets(request: Request) -> dict[str, set[str]]:
-        return {
-            name: set(values)
-            for name in FACET_NAMES
-            if (values := request.query_params.getlist(name))
-        }
+    def _requested_facets(
+        status: list[str] | None,
+        recipe: list[str] | None,
+        group: list[str] | None,
+    ) -> dict[str, set[str]]:
+        selected = {"status": status, "recipe": recipe, "group": group}
+        return {name: set(values) for name, values in selected.items() if values}
 
     async def load_run_summaries() -> list[RunSummary]:
         try:
@@ -876,21 +888,24 @@ def fastapi_app():
         limit: int | None = None,
         offset: int = 0,
         q: str = "",
+        status: FacetParam = None,
+        recipe: FacetParam = None,
+        group: FacetParam = None,
     ):
         if limit is not None and limit < 1:
             raise HTTPException(status_code=400, detail="Limit must be positive")
         if offset < 0:
             raise HTTPException(status_code=400, detail="Offset must not be negative")
         summaries = await load_run_summaries()
-        # Facet params are multi-select unions, so they're read only by
-        # ``_requested_facets``: taking them here too would intersect the union
-        # with whichever repeated value ``get`` happens to return.
+        # Facet params are multi-select unions, declared above: taking them here
+        # too would intersect the union with whichever repeated value ``get``
+        # happens to return.
         filters = {
             name: request.query_params.get(name, "")
             for name, metadata in run_list_field_metadata().items()
             if metadata.get("filterable") and name not in FACET_NAMES
         }
-        facets = _requested_facets(request)
+        facets = _requested_facets(status, recipe, group)
         filtered = filter_run_summaries(
             summaries,
             filters=filters,
@@ -917,13 +932,18 @@ def fastapi_app():
     # every run (they're what the chips would select); ``matching`` counts the
     # current query, which is how many rows paging can still reach.
     @web.get("/api/runs/counts")
-    async def run_counts(request: Request, q: str = ""):
+    async def run_counts(
+        q: str = "",
+        status: FacetParam = None,
+        recipe: FacetParam = None,
+        group: FacetParam = None,
+    ):
         summaries = await load_run_summaries()
         counts = count_run_facets(summaries)
         counts["matching"] = len(
             filter_run_summaries(
                 summaries,
-                facets=_requested_facets(request),
+                facets=_requested_facets(status, recipe, group),
                 query=q,
             )
         )

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -1573,6 +1573,14 @@ def fastapi_app():
 
     # ── SPA fallback ─────────────────────────────────────────────────────
 
+    # Declared before the fallback so an unknown API path is a JSON 404 rather
+    # than the SPA's HTML served with a 200: a frontend newer than the deployed
+    # backend would otherwise parse index.html as JSON and report the parser's
+    # error ("The string did not match the expected pattern", on WebKit).
+    @web.get("/api/{full_path:path}", include_in_schema=False)
+    async def api_not_found(full_path: str):
+        raise HTTPException(status_code=404, detail=f"No such API path: {full_path}")
+
     @web.get("/{full_path:path}")
     async def serve_spa(full_path: str):
         return FileResponse(f"{STATIC_DIR}/index.html")

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -882,10 +882,13 @@ def fastapi_app():
         if offset < 0:
             raise HTTPException(status_code=400, detail="Offset must not be negative")
         summaries = await load_run_summaries()
+        # Facet params are multi-select unions, so they're read only by
+        # ``_requested_facets``: taking them here too would intersect the union
+        # with whichever repeated value ``get`` happens to return.
         filters = {
             name: request.query_params.get(name, "")
             for name, metadata in run_list_field_metadata().items()
-            if metadata.get("filterable")
+            if metadata.get("filterable") and name not in FACET_NAMES
         }
         facets = _requested_facets(request)
         filtered = filter_run_summaries(

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -50,6 +50,8 @@ from modal_training_gym.common.run import (
     TrainingRunStatus,
 )
 from modal_training_gym.common.run_list import (
+    FACET_NAMES,
+    count_run_facets,
     filter_run_summaries,
     run_list_field_metadata,
 )
@@ -429,7 +431,6 @@ def fastapi_app():
         Path as FastAPIPath,
     )  # Request imported at module scope
     from fastapi.concurrency import run_in_threadpool
-    from fastapi.middleware.gzip import GZipMiddleware
     from fastapi.responses import (
         FileResponse,
         JSONResponse,
@@ -448,22 +449,6 @@ def fastapi_app():
     )
 
     web = FastAPI()
-
-    class _GZipUnlessStreaming(GZipMiddleware):
-        """Compress responses, leaving server-sent-event streams untouched.
-
-        Buffering an SSE stream through gzip withholds each event until the
-        compressor flushes, which stalls the live log tail.
-        """
-
-        async def __call__(self, scope, receive, send):
-            path = scope.get("path", "") if scope["type"] == "http" else ""
-            if path.endswith("/logs/stream"):
-                await self.app(scope, receive, send)
-                return
-            await super().__call__(scope, receive, send)
-
-    web.add_middleware(_GZipUnlessStreaming, minimum_size=1024)
 
     # ── Optional password protection ──────────────────────────────────────
     # When DASHBOARD_PASSWORD is set we gate the whole app behind HTTP Basic
@@ -864,6 +849,24 @@ def fastapi_app():
     # tag columns fall back to it for runs that predate ``group_tags``.
     run_list_excluded_fields = {"config", "step_times", "substep_times"}
 
+    # Repeated params (``?status=failed&status=stopped``) mirror the run list's
+    # multi-select chips; an absent facet means "every bucket".
+    def _requested_facets(request: Request) -> dict[str, set[str]]:
+        return {
+            name: set(values)
+            for name in FACET_NAMES
+            if (values := request.query_params.getlist(name))
+        }
+
+    async def load_run_summaries() -> list[RunSummary]:
+        try:
+            data = await get_cached_list("runs", load_runs)
+        except Exception:
+            data = []
+        return [
+            RunSummary.model_validate(item) for item in data if isinstance(item, dict)
+        ]
+
     # ``response_model`` is left off: FastAPI ignores ``response_model_exclude``
     # for sequence response models, so the exclusion is applied here instead.
     @web.get("/api/runs")
@@ -871,26 +874,32 @@ def fastapi_app():
         request: Request,
         since: int | None = None,
         limit: int | None = None,
+        offset: int = 0,
+        q: str = "",
     ):
         if limit is not None and limit < 1:
             raise HTTPException(status_code=400, detail="Limit must be positive")
-        try:
-            data = await get_cached_list("runs", load_runs)
-        except Exception:
-            data = []
-        summaries = [
-            RunSummary.model_validate(item) for item in data if isinstance(item, dict)
-        ]
+        if offset < 0:
+            raise HTTPException(status_code=400, detail="Offset must not be negative")
+        summaries = await load_run_summaries()
         filters = {
             name: request.query_params.get(name, "")
             for name, metadata in run_list_field_metadata().items()
             if metadata.get("filterable")
         }
+        facets = _requested_facets(request)
         filtered = filter_run_summaries(
             summaries,
             filters=filters,
+            facets=facets,
+            query=q,
             since=since,
             limit=limit,
+            offset=offset,
+            # The list shows runs newest-first, and paging is only stable if the
+            # server orders by the same key: sorting by update time reshuffles
+            # the pages under the client whenever a run reports progress.
+            sort_by="created",
         )
         return JSONResponse(
             [
@@ -898,6 +907,24 @@ def fastapi_app():
                 for summary in filtered
             ]
         )
+
+    # Declared before ``/api/runs/{training_run_id}`` so "counts" isn't read as a
+    # run id. The page's totals and filter-chip counts come from here, since a
+    # paged list can't count runs the client hasn't loaded. Chip counts cover
+    # every run (they're what the chips would select); ``matching`` counts the
+    # current query, which is how many rows paging can still reach.
+    @web.get("/api/runs/counts")
+    async def run_counts(request: Request, q: str = ""):
+        summaries = await load_run_summaries()
+        counts = count_run_facets(summaries)
+        counts["matching"] = len(
+            filter_run_summaries(
+                summaries,
+                facets=_requested_facets(request),
+                query=q,
+            )
+        )
+        return counts
 
     @web.get("/api/runs/{training_run_id}", response_model=RunSummary)
     async def get_run(training_run_id: str):

--- a/modal_training_gym/common/run_list.py
+++ b/modal_training_gym/common/run_list.py
@@ -1,10 +1,17 @@
-"""List-field metadata and filtering for training-run summaries."""
+"""List-field metadata, facets, and filtering for training-run summaries."""
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
+from typing import Literal
 
 from modal_training_gym.common.run_summary import RunSummary
+
+UNTAGGED_RECIPE = "(untagged)"
+NO_GROUP = "(no group)"
+PENDING_STATUS = "pending"
+
+FACET_NAMES = ("status", "recipe", "group")
 
 
 def run_list_field_metadata() -> dict[str, dict[str, object]]:
@@ -24,20 +31,90 @@ def run_list_field_metadata() -> dict[str, dict[str, object]]:
     return metadata
 
 
+def run_facet_values(summary: RunSummary) -> dict[str, str]:
+    """Return the buckets the run list's filter chips group a run into."""
+    return {
+        "status": summary.display_status or PENDING_STATUS,
+        "recipe": summary.recipe or summary.framework or UNTAGGED_RECIPE,
+        "group": summary.group_id or NO_GROUP,
+    }
+
+
+def count_run_facets(summaries: Iterable[RunSummary]) -> dict[str, object]:
+    """Count runs per facet bucket and per status, over every known run.
+
+    The list endpoint serves one page at a time, so the chips and the totals on
+    the page can no longer be counted from the rows the client happens to hold.
+    """
+    facets: dict[str, dict[str, int]] = {name: {} for name in FACET_NAMES}
+    total = 0
+    for summary in summaries:
+        total += 1
+        for name, value in run_facet_values(summary).items():
+            facets[name][value] = facets[name].get(value, 0) + 1
+    return {"total": total, **facets}
+
+
+def _search_values(summary: RunSummary) -> Iterable[str]:
+    yield summary.run_id
+    yield summary.training_run_id
+    yield summary.modal_app_id
+    yield summary.model
+    yield summary.dataset
+    yield summary.recipe
+    yield summary.framework
+    yield summary.framework_status
+    yield summary.deployment_id
+    yield summary.group_id
+    if summary.group_tags is not None:
+        yield summary.group_tags.group_id
+        for tag in summary.group_tags.tags:
+            yield tag.key
+            yield str(tag.value)
+        for key, value in summary.group_tags.overrides.items():
+            yield key
+            yield str(value)
+    if summary.train_result is not None:
+        yield summary.train_result.training_run_id
+        yield summary.train_result.checkpoint_dir
+        yield summary.train_result.model_name
+        yield summary.train_result.model_path
+
+
+def _matches_query(summary: RunSummary, query: str) -> bool:
+    if not query:
+        return True
+    return any(query in value.casefold() for value in _search_values(summary) if value)
+
+
 def filter_run_summaries(
     summaries: Iterable[RunSummary],
     *,
-    filters: dict[str, str] | None = None,
+    filters: Mapping[str, str] | None = None,
+    facets: Mapping[str, set[str]] | None = None,
+    query: str = "",
     since: int | None = None,
     limit: int | None = None,
+    offset: int = 0,
+    sort_by: Literal["updated", "created"] = "updated",
 ) -> list[RunSummary]:
-    """Filter summaries by their configured list fields and update recency."""
+    """Filter summaries by their configured list fields and update recency.
+
+    ``facets`` keeps only runs whose bucket is in the given set (see
+    ``run_facet_values``); a facet without an entry is unfiltered. ``query`` is
+    matched case-insensitively against the run's identifiers, model, dataset and
+    group tags, and ``offset``/``limit`` page the sorted result.
+    """
     metadata = run_list_field_metadata()
     active_filters = {
         name: value.strip().casefold()
         for name, value in (filters or {}).items()
         if metadata.get(name, {}).get("filterable") and value.strip()
     }
+    active_facets = {
+        name: values for name, values in (facets or {}).items() if name in FACET_NAMES
+    }
+    normalized_query = query.strip().casefold()
 
     selected: list[RunSummary] = []
     for summary in summaries:
@@ -48,12 +125,26 @@ def filter_run_summaries(
             for name, expected in active_filters.items()
         ):
             continue
+        if active_facets:
+            values = run_facet_values(summary)
+            if any(
+                values[name] not in expected for name, expected in active_facets.items()
+            ):
+                continue
+        if not _matches_query(summary, normalized_query):
+            continue
         selected.append(summary)
 
-    selected.sort(
-        key=lambda summary: (summary.updated_at, summary.run_id),
-        reverse=True,
-    )
+    if sort_by == "created":
+        selected.sort(
+            key=lambda summary: (summary.created_at, summary.run_id), reverse=True
+        )
+    else:
+        selected.sort(
+            key=lambda summary: (summary.updated_at, summary.run_id), reverse=True
+        )
+    if offset:
+        selected = selected[offset:]
     if limit is not None:
         selected = selected[:limit]
     return selected

--- a/modal_training_gym/common/run_list.py
+++ b/modal_training_gym/common/run_list.py
@@ -68,8 +68,10 @@ def _search_values(summary: RunSummary) -> Iterable[str]:
     yield summary.group_id
     if summary.group_tags is not None:
         yield summary.group_tags.group_id
+        yield from summary.group_tags.axes
         for tag in summary.group_tags.tags:
             yield tag.key
+            yield tag.label
             yield str(tag.value)
         for key, value in summary.group_tags.overrides.items():
             yield key

--- a/tests/test_dashboard_runs_route.py
+++ b/tests/test_dashboard_runs_route.py
@@ -159,9 +159,7 @@ def test_runs_route_keeps_runs_when_train_result_store_fails(
     assert response.json()[0]["has_train_result"] is False
 
 
-def test_runs_route_filters_and_sorts_by_last_update(
-    fake_volume, monkeypatch, tmp_path
-):
+def test_runs_route_filters_and_sorts_by_creation(fake_volume, monkeypatch, tmp_path):
     _save_records()
     TrainingRun(
         training_run_id="run-route-2",
@@ -183,10 +181,86 @@ def test_runs_route_filters_and_sorts_by_last_update(
 
     assert filtered.status_code == 200
     assert [run["run_id"] for run in filtered.json()] == ["run-route-2"]
+    # ``since`` still selects on update time, but the list is ordered by
+    # creation: sorting by update time reshuffles the pages under a client that
+    # is paging through the list whenever a run reports progress.
     assert [run["run_id"] for run in all_runs.json()] == [
-        "run-route-2",
         "run-route-1",
+        "run-route-2",
     ]
+
+
+def test_runs_route_pages_and_omits_detail_only_fields(
+    fake_volume, monkeypatch, tmp_path
+):
+    _save_records()
+    TrainingRun(
+        training_run_id="run-route-2",
+        framework=Framework.MILES,
+        status="failed",
+        config={
+            "model": {"model_name": "other/model"},
+            "dataset": {"hf_repo": "other/data"},
+        },
+        created_at=50,
+        started_at=50,
+        updated_at=2_000_000_000,
+        metadata={"group_id": "other-group"},
+    ).save()
+
+    with _client(monkeypatch, tmp_path) as client:
+        first = client.get("/api/runs?limit=1")
+        second = client.get("/api/runs?limit=1&offset=1")
+        searched = client.get("/api/runs?q=OTHER/MODEL")
+        faceted = client.get("/api/runs?status=failed")
+        detail = client.get("/api/runs/run-route-1")
+
+    assert [run["run_id"] for run in first.json()] == ["run-route-1"]
+    assert [run["run_id"] for run in second.json()] == ["run-route-2"]
+    assert [run["run_id"] for run in searched.json()] == ["run-route-2"]
+    assert [run["run_id"] for run in faceted.json()] == ["run-route-2"]
+    # The table renders none of these, and they are most of the payload.
+    assert not {"config", "step_times", "substep_times"} & set(first.json()[0])
+    assert detail.json()["config"]
+
+
+def test_runs_counts_route_counts_every_run_and_the_current_query(
+    fake_volume, monkeypatch, tmp_path
+):
+    _save_records()
+    TrainingRun(
+        training_run_id="run-route-2",
+        framework=Framework.MILES,
+        status="failed",
+        config={"model": {"model_name": "other/model"}},
+        created_at=50,
+        started_at=50,
+        updated_at=2_000_000_000,
+    ).save()
+
+    with _client(monkeypatch, tmp_path) as client:
+        counts = client.get("/api/runs/counts").json()
+        failed = client.get("/api/runs/counts?status=failed").json()
+
+    assert counts["total"] == 2
+    assert counts["matching"] == 2
+    assert counts["status"]["failed"] == 1
+    assert counts["group"] == {"route-group": 1, "(no group)": 1}
+    # Bucket counts always describe every run — they are what the chips would
+    # select — while ``matching`` follows the current selection.
+    assert failed["status"] == counts["status"]
+    assert failed["matching"] == 1
+
+
+def test_unknown_api_path_is_a_json_404_not_the_spa(monkeypatch, tmp_path):
+    with _client(monkeypatch, tmp_path) as client:
+        missing = client.get("/api/nope")
+        spa = client.get("/nope")
+
+    assert missing.status_code == 404
+    assert missing.headers["content-type"].startswith("application/json")
+    assert spa.status_code == 200
+    assert spa.text == "ok"
 
 
 def test_apple_touch_icon_is_served_as_png(monkeypatch, tmp_path):

--- a/tests/test_dashboard_runs_route.py
+++ b/tests/test_dashboard_runs_route.py
@@ -224,6 +224,25 @@ def test_runs_route_pages_and_omits_detail_only_fields(
     assert detail.json()["config"]
 
 
+def test_runs_route_unions_repeated_facet_values(fake_volume, monkeypatch, tmp_path):
+    _save_records()
+    TrainingRun(
+        training_run_id="run-route-2",
+        framework=Framework.MILES,
+        config={"model": {"model_name": "other/model"}},
+        created_at=50,
+        started_at=50,
+        updated_at=200,
+    ).save()
+
+    with _client(monkeypatch, tmp_path) as client:
+        both = client.get("/api/runs?recipe=slime&recipe=miles")
+
+    # ``recipe`` is a filter-chip facet as well as a filterable column, so a
+    # multi-select must not narrow to whichever repeated value is read first.
+    assert [run["run_id"] for run in both.json()] == ["run-route-1", "run-route-2"]
+
+
 def test_runs_counts_route_counts_every_run_and_the_current_query(
     fake_volume, monkeypatch, tmp_path
 ):

--- a/tests/test_run_list.py
+++ b/tests/test_run_list.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from modal_training_gym.common.run_list import (
+    count_run_facets,
     filter_run_summaries,
     run_list_field_metadata,
 )
@@ -171,3 +172,63 @@ def test_since_uses_created_or_updated_time_inclusively_before_limiting():
         since=300,
         limit=1,
     ) == [recently_updated]
+
+
+def test_facets_select_buckets_and_default_to_every_bucket():
+    slime = _summary(run_id="slime", training_run_id="slime", recipe="slime")
+    miles = _summary(
+        run_id="miles",
+        training_run_id="miles",
+        recipe="miles",
+        display_status="failed",
+        group_id="",
+    )
+
+    assert filter_run_summaries([slime, miles], facets={"recipe": {"miles"}}) == [miles]
+    assert filter_run_summaries(
+        [slime, miles],
+        facets={"status": {"pending", "failed"}, "group": {"nightly", "(no group)"}},
+    ) == [slime, miles]
+    assert filter_run_summaries([slime, miles], facets={"group": {"(no group)"}}) == [
+        miles
+    ]
+
+
+def test_query_matches_identifiers_and_paging_slices_the_sorted_result():
+    first = _summary(run_id="first", training_run_id="first", created_at=300)
+    second = _summary(
+        run_id="second",
+        training_run_id="second",
+        model="org/other",
+        created_at=200,
+    )
+    third = _summary(run_id="third", training_run_id="third", created_at=100)
+
+    assert filter_run_summaries([first, second, third], query=" ORG/OTHER ") == [second]
+    assert filter_run_summaries(
+        [first, second, third],
+        sort_by="created",
+        offset=1,
+        limit=1,
+    ) == [second]
+
+
+def test_facet_counts_cover_every_run():
+    runs = [
+        _summary(run_id="a", training_run_id="a"),
+        _summary(run_id="b", training_run_id="b", display_status="failed"),
+        _summary(
+            run_id="c",
+            training_run_id="c",
+            recipe="",
+            framework="miles",
+            group_id="",
+        ),
+    ]
+
+    assert count_run_facets(runs) == {
+        "total": 3,
+        "status": {"pending": 2, "failed": 1},
+        "recipe": {"slime": 2, "miles": 1},
+        "group": {"nightly": 2, "(no group)": 1},
+    }

--- a/tests/test_run_list.py
+++ b/tests/test_run_list.py
@@ -194,6 +194,22 @@ def test_facets_select_buckets_and_default_to_every_bucket():
     ]
 
 
+def test_query_matches_the_group_metadata_the_tags_column_renders():
+    tagged = _summary(
+        run_id="tagged",
+        training_run_id="tagged",
+        group_tags={
+            "group_id": "sweep-1",
+            "axes": ["learning_rate"],
+            "tags": [{"key": "lr", "label": "Learning rate", "value": 3e-4}],
+        },
+    )
+    plain = _summary(run_id="plain", training_run_id="plain")
+
+    for query in ("learning_rate", "Learning rate", "0.0003", "sweep-1"):
+        assert filter_run_summaries([tagged, plain], query=query) == [tagged]
+
+
 def test_query_matches_identifiers_and_paging_slices_the_sorted_result():
     first = _summary(run_id="first", training_run_id="first", created_at=300)
     second = _summary(


### PR DESCRIPTION
The dashboard freezes/crashes mobile Safari because `/api/runs` returns the entire history as one array — 381 runs, 1.49 MB of JSON — every 5s (including while the tab is hidden), and the table mounts a row for each of them (~20k DOM nodes).

The list endpoint now filters, searches, sorts and pages server-side, and drops the fields the table never renders:

```python
# /api/runs?limit=100&offset=0&q=…&status=failed&recipe=slime
filtered = filter_run_summaries(summaries, facets=…, query=q, offset=offset, limit=limit, sort_by="created")
return JSONResponse([s.model_dump(mode="json", exclude={"config", "step_times", "substep_times"}) for s in filtered])
```

`config` alone was ~60% of the payload; the drawer/detail page fetches the full record from `/api/runs/{id}` on open, so nothing is lost. Sorting is by `created_at` rather than `updated_at` so pages don't reshuffle under the client when a run reports progress.

Paging breaks every total on the page (they were counted client-side from the full array), so `/api/runs/counts` returns just the numbers:

```json
{"total": 381, "matching": 94, "status": {"failed": 219, …}, "recipe": {"slime": 269, …}, "group": {…}}
```

Bucket counts cover every run (that's what the chips would select); `matching` is how many rows paging can still reach. The frontend keeps only the loaded window in `runs`, asks for the next 100 when you scroll near the end, and restarts at page one (scrolled back to the top) when the search or chips change.

Also in this branch, from the same investigation: a single shared clock for all `TimeAgo` components instead of one `setInterval` each, polling paused while `document.hidden`, and no overlapping refreshes (a slow response used to stack whole copies of the payload in memory).

Measured against real data (381 runs) in a 390×844 mobile viewport: first paint fetches 250 KB instead of 1.49 MB, 5.4k DOM nodes instead of 19.7k; the earlier heap/main-thread numbers on this branch were 56–84 MB → 24–31 MB and 7.0s → 1.3s of long tasks under 6× CPU throttling. That's desktop emulation — I haven't been able to reproduce on a real iPhone, so worth a check on your phone after it deploys.

## Checklist

Not an example; the example checklist doesn't apply.


Link to Devin session: https://modal.devinenterprise.com/sessions/95e5ad2ac22742e98d76804b1c04343b
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/95e5ad2ac22742e98d76804b1c04343b?variant=devin
Requested by: @joyliu-q