### PR TITLE
dashboard text cleanup

### DIFF
--- a/dashboards/frontend/src/components/RunTimeline.svelte
+++ b/dashboards/frontend/src/components/RunTimeline.svelte
@@ -6,7 +6,6 @@
     APPROXIMATE_LANE_NOTE,
     breakLabelLayout,
     colorFor,
-    descriptionFor,
     fmtSecs,
     groupTooltipChildren,
     labelFor,
@@ -256,13 +255,10 @@
   }
 
   const roleDescriptions = {
-    driver:
-      "driver — orchestrates the training loop; sequences generation, weight sync and checkpointing (not a GPU worker)",
-    rollout:
-      "rollout — inference engines generating samples from the current policy",
-    actor: "actor — the policy model being trained",
-    critic:
-      "critic — value model scoring states; PPO-style runs only (use_critic=true)",
+    driver: "Runs the training loop.",
+    rollout: "Inference engines sampling from the current policy.",
+    actor: "Policy being trained.",
+    critic: "Value model.",
   };
 
   function nestedChild(bar, name) {
@@ -493,7 +489,7 @@
                 class="step"
                 style:left={`${pct(step.renderOffset ?? step.offset)}%`}
                 style:width={`${Math.max(pct(step.renderDuration ?? step.duration), 0.05)}%`}
-                title={`Step ${step.number}: ${fmtSecs(step.duration)} wall clock — ${fmtSecs(step.work)} work, ${fmtSecs(step.idle)} measured idle`}
+                title={`Step ${step.number}: ${fmtSecs(step.duration)} wall clock, ${fmtSecs(step.work)} work, ${fmtSecs(step.idle)} measured idle`}
               >
                 <span class="step-text"
                   >Step {step.number} · {fmtSecs(step.duration)}</span
@@ -636,8 +632,8 @@
               class="timeline-break"
               style:left={`${pct(gap.offset)}%`}
               style:width={`${Math.max(pct(gap.duration), 0.4)}%`}
-              title={`${fmtSecs(gap.hidden)} not instrumented — compressed to keep measured phases readable`}
-              aria-label={`${fmtSecs(gap.hidden)} of unmeasured time, compressed`}
+              title={`${fmtSecs(gap.hidden)} not instrumented, drawn compressed`}
+              aria-label={`${fmtSecs(gap.hidden)} not instrumented, drawn compressed`}
             >
               <span
                 class="timeline-break-label"
@@ -686,9 +682,6 @@
     </span>
     {#if clockSpan(tip.bar)}
       <span class="tg-tip-when">{clockSpan(tip.bar)}</span>
-    {/if}
-    {#if descriptionFor(tip.bar.name)}
-      <span class="tg-tip-desc">{descriptionFor(tip.bar.name)}</span>
     {/if}
     {#if concurrencyStat(tip.bar)}
       <span class="tg-tip-stat">{concurrencyStat(tip.bar)}</span>
@@ -1203,16 +1196,6 @@
   .tg-tip-name {
     color: var(--color-c-gray-100);
     font-weight: 600;
-  }
-
-  .tg-tip-desc {
-    display: block;
-    max-width: 34ch;
-    white-space: normal;
-    margin-top: 2px;
-    color: var(--color-c-gray-70, #8a8a8a);
-    font-size: 10px;
-    line-height: 13px;
   }
 
   .tg-tip-stat {

--- a/dashboards/frontend/src/lib/timing.js
+++ b/dashboards/frontend/src/lib/timing.js
@@ -1,7 +1,6 @@
 export {
   CATEGORIES,
   colorFor,
-  descriptionFor,
   fmtSecs,
   HIDDEN_PHASES,
   isLegacyTiming,

--- a/dashboards/frontend/src/lib/timing_spans.js
+++ b/dashboards/frontend/src/lib/timing_spans.js
@@ -214,9 +214,7 @@ export function isAsyncSpans(spans) {
 }
 
 export const APPROXIMATE_LANE_NOTE =
-  "Recorded on another node, so bars are shifted to fit the driver's timeline — " +
-  "positions are approximate; the start and end times in each tooltip are that " +
-  "node's own clock.";
+  "Recorded on another node, so bar positions are approximate."
 
 export function isApproximateSpan(span) {
   return Boolean(span?.unaligned || span?.clockShifted);

--- a/dashboards/frontend/src/lib/timing_vocabulary.js
+++ b/dashboards/frontend/src/lib/timing_vocabulary.js
@@ -74,7 +74,7 @@ export const TIMING_LABELS = {
   evaluate_rollouts: "Eval (before training)",
   evaluate_rollouts_end: "Eval (after training)",
   generate_rollouts: "Rollout generation",
-  offload_rollout: "Offload generation engines",
+  offload_rollout: "Offload rollout engines",
   compute_log_probs: "Calculate log probs",
   train_models: "Train",
   checkpoint_save: "Save checkpoint",
@@ -92,52 +92,9 @@ export const TIMING_LABELS = {
   optimizer_step: "Optimizer step",
   // Labels stay role-neutral: the tooltip prefixes the role that recorded the
   // phase, and the actor and the critic record the same phase names.
-  trainer_finalize: "Cleanup & offload",
+  trainer_finalize: "Trainer cleanup",
   train_step_finalize: "Train-step cleanup & metrics",
 };
-
-// What each phase actually wraps, described from the recording role's point of
-// view; kept in step with the patch sites in
-// modal_training_gym/frameworks/*/modal_helpers/patches/patch_substep_timing.py.
-export const PHASE_DESCRIPTIONS = {
-  evaluate_rollouts: "Evaluation pass before the first training step.",
-  evaluate_rollouts_end: "Evaluation pass after this step's training.",
-  generate_rollouts:
-    "The driver's call for this step's samples, start to finish — the engines' own generation is the nested bar.",
-  generate_samples: "Generating and scoring this step's batch on the engines.",
-  sample_generation:
-    "Generating one sample; summed over samples that ran at the same time.",
-  reward: "Scoring one sample's reward.",
-  reward_batch: "Scoring a whole batch of rewards in one call.",
-  reward_post_process: "Turning raw reward scores into training rewards.",
-  offload_rollout: "Freeing the engines' GPU memory before training starts.",
-  compute_log_probs:
-    "A forward-only log-prob pass; runs once per model that needs one (reference, old policy, teacher, actor).",
-  train_models:
-    "The driver's training call for this step, blocking until every worker returns.",
-  forward_backward: "Forward and backward pass over the microbatches.",
-  optimizer_step:
-    "Parameter update and LR-scheduler step; skipped steps record nothing.",
-  train_step_finalize:
-    "After each training step: releasing gradients, reducing the loss and logging.",
-  trainer_finalize:
-    "After the step's training: debug dump, replay clear, CPU weight backup, optional reference update, and the GPU offload.",
-  checkpoint_save: "Writing this step's checkpoint.",
-  offload_train:
-    "Freeing the trainer's GPU memory before the engines take new weights.",
-  weight_sync:
-    "Loading the updated weights into the generation engines, including bringing them back onto the GPU.",
-  initial_weight_sync:
-    "The first weight load into the engines, before the training loop starts.",
-  wait_for_rollout:
-    "Async driver idle: this step's samples were prefetched during the previous step and aren't ready yet.",
-  wait_for_next_rollout:
-    "Async driver idle: generation of the next step's samples has to finish before weights can change.",
-};
-
-export function descriptionFor(name) {
-  return PHASE_DESCRIPTIONS[name] || null;
-}
 
 export const IDLE_PHASES = new Set([
   "wait_for_rollout",

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -1729,9 +1729,9 @@
                 <td class="text-(--text-bright)">
                   {formatMean(r.mean)}
                   {#if r.error_summary?.verdict === "all_infra_failure"}
-                    <span class="inline-block text-[10px] font-medium p-[1px_6px] rounded-[3px] ml-[6px] align-middle bg-[rgba(239,68,68,0.15)] text-[#ef4444] [border:1px_solid_rgba(239,68,68,0.25)]" title="All samples failed due to infrastructure error">infra failure</span>
+                    <span class="inline-block text-[10px] font-medium p-[1px_6px] rounded-[3px] ml-[6px] align-middle bg-[rgba(239,68,68,0.15)] text-[#ef4444] [border:1px_solid_rgba(239,68,68,0.25)]" title="All samples hit infrastructure errors">infra failure</span>
                   {:else if r.error_summary?.verdict === "partial_infra_failure"}
-                    <span class="inline-block text-[10px] font-medium p-[1px_6px] rounded-[3px] ml-[6px] align-middle bg-[rgba(251,191,36,0.15)] text-[#fbbf24] [border:1px_solid_rgba(251,191,36,0.25)]" title="Some samples failed due to infrastructure error">partial failure</span>
+                    <span class="inline-block text-[10px] font-medium p-[1px_6px] rounded-[3px] ml-[6px] align-middle bg-[rgba(251,191,36,0.15)] text-[#fbbf24] [border:1px_solid_rgba(251,191,36,0.25)]" title="Some samples hit infrastructure errors">partial failure</span>
                   {/if}
                 </td>
                 <td>{r.episode_count ?? "—"}</td>
@@ -1777,7 +1777,7 @@
                           <div class="rollout-diagnostics" class:diag-critical={remoteErr >= totalSamples}>
                             <div class="diag-title">
                               {#if remoteErr >= totalSamples}
-                                All {totalSamples} samples failed — infrastructure error
+                                All {totalSamples} samples hit infrastructure errors
                               {:else}
                                 {remoteErr + infraInvalid} / {totalSamples} samples hit infrastructure errors
                               {/if}
@@ -1798,7 +1798,7 @@
                             </div>
                             {#if remoteErr >= totalSamples}
                               <div class="text-[11px] text-(--muted,#a3a3a3) mt-[6px]">
-                                Check the Modal app logs for sandbox/image build errors. Common cause: the environment image failed to build.
+                                Check the Modal app logs for sandbox or image build errors.
                               </div>
                             {/if}
                           </div>


### PR DESCRIPTION
The description line restated the label for most phases and made claims about framework internals that had drifted (LR scheduler step, GPU offload, step numbering). This removes phase descriptions from timeline tooltip and cleans up hover prose.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->