### PR TITLE
Deploy the PR's own dashboard backend for dashboard previews

### DIFF
--- a/.github/workflows/dashboard-preview.yml
+++ b/.github/workflows/dashboard-preview.yml
@@ -2,9 +2,11 @@ name: Dashboard preview
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - ".github/workflows/dashboard-preview.yml"
       - "dashboards/**"
+      - "modal_training_gym/_dashboard.py"
       - "scripts/previews/**"
 
 permissions:
@@ -16,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +51,9 @@ jobs:
           path: dashboard.tar.gz
 
   preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     needs:
       - build
     runs-on: ubuntu-latest
@@ -72,8 +77,17 @@ jobs:
         with:
           name: dashboard-dist
 
+      # The preview's frontend is static nginx, so its /api has to be proxied
+      # somewhere. Give the PR its own backend: the deployed one doesn't have
+      # the PR's API changes.
+      - name: Deploy dashboard API preview
+        id: api
+        run: |
+          uv run python scripts/previews/dashboard_api.py deploy ${{ github.event.pull_request.number }} | tee api.log
+          echo "url=$(tail -n 1 api.log)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy dashboard preview
-        run: uv run --no-project --with modal python scripts/previews/deploy.py ${{ github.event.pull_request.number }} dashboard dashboard.tar.gz
+        run: uv run --no-project --with modal python scripts/previews/deploy.py ${{ github.event.pull_request.number }} dashboard dashboard.tar.gz --api-url '${{ steps.api.outputs.url }}'
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
@@ -101,3 +115,24 @@ jobs:
               issue_number: prNumber,
               body: `${marker}\nDashboard preview: ${baseUrl}/${prNumber}/dashboard`,
             });
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    env:
+      MODAL_TOKEN_ID: ${{ secrets.PREVIEW_MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.PREVIEW_MODAL_TOKEN_SECRET }}
+      MODAL_ENVIRONMENT: training-gym
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - uses: astral-sh/setup-uv@v5
+
+      # The nginx sandbox is reaped by the previews app's hourly refresh; the
+      # PR's own dashboard app is ours to stop.
+      - name: Stop dashboard API preview
+        run: uv run python scripts/previews/dashboard_api.py stop ${{ github.event.pull_request.number }}

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -40,7 +40,10 @@ from modal_training_gym.common.config import (
     DASHBOARD_PROXY_AUTH_PATH,
     dashboard_requires_proxy_auth,
 )
-from modal_training_gym.common.dashboard import DASHBOARD_APP_NAME
+from modal_training_gym.common.dashboard import (
+    DASHBOARD_APP_NAME,
+    DASHBOARD_PREVIEW_ENV_KEY,
+)
 from modal_training_gym.common.run import (
     FrameworkStatusUpdate,
     TrainingRun,
@@ -100,6 +103,21 @@ REPO_BRANCH = "main"
 DASHBOARD_REQUIRES_PROXY_AUTH_ENV_KEY = "DASHBOARD_REQUIRES_PROXY_AUTH"
 TIMING_DEBUG_ENV = "TRAINING_GYM_TIMING_DEBUG"
 
+
+def _is_preview() -> bool:
+    return os.environ.get(DASHBOARD_PREVIEW_ENV_KEY, "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+# A preview deploy is one dashboard per open PR (see scripts/previews) reading
+# the same metadata volume as the real one, so it serves the API and nothing
+# else: the scheduled jobs rewrite that shared metadata, and a warm container
+# per open PR is a standing bill for a review aid.
+IS_PREVIEW = _is_preview()
+
 _repo_frontend = Path(__file__).resolve().parents[1] / "dashboards" / "frontend"
 _has_local_frontend = _repo_frontend.is_dir()
 
@@ -138,6 +156,7 @@ def _build_image() -> modal.Image:
                 if dashboard_requires_proxy_auth()
                 else "false",
                 TIMING_DEBUG_ENV: os.environ.get(TIMING_DEBUG_ENV, ""),
+                DASHBOARD_PREVIEW_ENV_KEY: "true" if IS_PREVIEW else "",
             }
         )
     )
@@ -363,7 +382,11 @@ def _run_compact_sync() -> None:
         compact_summary_store(summary_store)
 
 
-@app.function(schedule=modal.Cron("*/30 * * * *"), retries=3, timeout=1800)
+@app.function(
+    schedule=None if IS_PREVIEW else modal.Cron("*/30 * * * *"),
+    retries=3,
+    timeout=1800,
+)
 def compact_summaries() -> None:
     """Scheduled compaction of summary stores (every 30 min)."""
     _run_compact_sync()
@@ -371,7 +394,7 @@ def compact_summaries() -> None:
 
 
 @app.function(
-    schedule=modal.Cron("*/30 * * * *"),
+    schedule=None if IS_PREVIEW else modal.Cron("*/30 * * * *"),
     secrets=_function_secrets(),
     retries=3,
     timeout=1800,
@@ -390,7 +413,7 @@ def reconcile() -> None:
 
 
 @app.function(
-    min_containers=1,
+    min_containers=0 if IS_PREVIEW else 1,
     secrets=_function_secrets(),
 )
 @modal.concurrent(max_inputs=50, target_inputs=20)

--- a/modal_training_gym/common/dashboard.py
+++ b/modal_training_gym/common/dashboard.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 DASHBOARD_APP_NAME = "training-gym-dashboard"
 DASHBOARD_WEB_FUNCTION = "fastapi_app"
 
+# Set on a per-PR dashboard deploy (scripts/previews/dashboard_api.py) so it
+# serves the API without the scheduled jobs that rewrite shared metadata.
+DASHBOARD_PREVIEW_ENV_KEY = "TRAINING_GYM_DASHBOARD_PREVIEW"
+
 
 def deployed_dashboard_url() -> str | None:
     """Return the live dashboard web URL if its app is deployed, else ``None``.

--- a/scripts/previews/dashboard_api.py
+++ b/scripts/previews/dashboard_api.py
@@ -65,7 +65,12 @@ def is_already_gone(output: str, name: str) -> bool:
         return False
     return any(
         phrase in lowered
-        for phrase in ("app not found", "no such app", "lookup failed for app")
+        for phrase in (
+            "app not found",
+            "no app with name",
+            "no such app",
+            "lookup failed for app",
+        )
     )
 
 

--- a/scripts/previews/dashboard_api.py
+++ b/scripts/previews/dashboard_api.py
@@ -1,0 +1,88 @@
+"""Deploy (or stop) a PR's dashboard backend as its own Modal app.
+
+The frontend preview is static nginx, so before this its ``/api`` had to be
+proxied at the deployed dashboard — a PR that changes both halves of the
+dashboard then previewed its new frontend against the old API. Each PR now gets
+its own copy of the backend, deployed in preview mode (no scheduled jobs, no
+warm container) from the PR's checkout.
+
+Run with plain ``python``, not ``modal run``:
+
+    python scripts/previews/dashboard_api.py deploy 489
+    python scripts/previews/dashboard_api.py stop 489
+
+``deploy`` prints the app's web URL as its last line.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import modal
+
+from modal_training_gym.common.dashboard import DASHBOARD_PREVIEW_ENV_KEY
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_APP_PATH = REPO_ROOT / "dashboards" / "app.py"
+WEB_FUNCTION = "fastapi_app"
+
+
+def app_name(pr_number: int) -> str:
+    return f"training-gym-dashboard-pr-{pr_number}"
+
+
+def deploy(pr_number: int) -> str:
+    """Deploy the PR's dashboard app and return its web URL."""
+    name = app_name(pr_number)
+    print(f"Deploying dashboard API preview for #{pr_number} as {name}")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "modal",
+            "deploy",
+            str(DASHBOARD_APP_PATH),
+            "--name",
+            name,
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, DASHBOARD_PREVIEW_ENV_KEY: "1"},
+    )
+    return modal.Function.from_name(name, WEB_FUNCTION).get_web_url()
+
+
+def stop(pr_number: int) -> None:
+    """Stop the PR's dashboard app, tolerating one that's already gone."""
+    name = app_name(pr_number)
+    print(f"Stopping dashboard API preview {name}")
+    result = subprocess.run(
+        [sys.executable, "-m", "modal", "app", "stop", name],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return
+    print(result.stdout, end="")
+    print(result.stderr, end="", file=sys.stderr)
+    print(f"Warning: could not stop {name}; it may already be stopped.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["deploy", "stop"])
+    parser.add_argument("pr_number", type=int, help="PR number to act on")
+    args = parser.parse_args()
+
+    if args.command == "stop":
+        stop(args.pr_number)
+        return
+
+    print(deploy(args.pr_number))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/previews/dashboard_api.py
+++ b/scripts/previews/dashboard_api.py
@@ -54,6 +54,12 @@ def deploy(pr_number: int) -> str:
     return modal.Function.from_name(name, WEB_FUNCTION).get_web_url()
 
 
+def is_already_gone(output: str) -> bool:
+    """Whether ``modal app stop`` failed because there's nothing left to stop."""
+    lowered = output.lower()
+    return "not found" in lowered or "no such app" in lowered
+
+
 def stop(pr_number: int) -> None:
     """Stop the PR's dashboard app, tolerating one that's already gone."""
     name = app_name(pr_number)
@@ -68,7 +74,12 @@ def stop(pr_number: int) -> None:
         return
     print(result.stdout, end="")
     print(result.stderr, end="", file=sys.stderr)
-    print(f"Warning: could not stop {name}; it may already be stopped.")
+    if is_already_gone(result.stdout + result.stderr):
+        print(f"{name} is already stopped.")
+        return
+    # Anything else leaves a backend running against real metadata, so the
+    # cleanup job should go red and be retried.
+    raise SystemExit(result.returncode)
 
 
 def main() -> None:

--- a/scripts/previews/dashboard_api.py
+++ b/scripts/previews/dashboard_api.py
@@ -54,10 +54,19 @@ def deploy(pr_number: int) -> str:
     return modal.Function.from_name(name, WEB_FUNCTION).get_web_url()
 
 
-def is_already_gone(output: str) -> bool:
-    """Whether ``modal app stop`` failed because there's nothing left to stop."""
+def is_already_gone(output: str, name: str) -> bool:
+    """Whether ``modal app stop`` failed because there's nothing left to stop.
+
+    The app has to be the missing thing: a failure about some other absent
+    resource leaves the backend running.
+    """
     lowered = output.lower()
-    return "not found" in lowered or "no such app" in lowered
+    if name.lower() not in lowered:
+        return False
+    return any(
+        phrase in lowered
+        for phrase in ("app not found", "no such app", "lookup failed for app")
+    )
 
 
 def stop(pr_number: int) -> None:
@@ -74,7 +83,7 @@ def stop(pr_number: int) -> None:
         return
     print(result.stdout, end="")
     print(result.stderr, end="", file=sys.stderr)
-    if is_already_gone(result.stdout + result.stderr):
+    if is_already_gone(result.stdout + result.stderr, name):
         print(f"{name} is already stopped.")
         return
     # Anything else leaves a backend running against real metadata, so the

--- a/scripts/previews/deploy.py
+++ b/scripts/previews/deploy.py
@@ -45,9 +45,19 @@ async def main():
         batch.put_file(str(args.artifact), f"/{artifact_name}")
 
     print(f"Deploying {args.type} preview for #{args.pr_number}")
-    await deploy_preview.remote.aio(
-        args.pr_number, args.type, artifact_name, api_url=args.api_url
-    )
+    # The deployed previews app is main's code (see previews-app.yml), so on a
+    # branch that introduces `api_url` it doesn't take one yet: fall back to a
+    # preview proxied at the deployed dashboard rather than failing the job.
+    kwargs = {"api_url": args.api_url} if args.api_url else {}
+    try:
+        await deploy_preview.remote.aio(
+            args.pr_number, args.type, artifact_name, **kwargs
+        )
+    except TypeError as exc:
+        if not kwargs or "api_url" not in str(exc):
+            raise
+        print(f"Previews app does not accept api_url yet ({exc}); deploying without it")
+        await deploy_preview.remote.aio(args.pr_number, args.type, artifact_name)
 
 
 if __name__ == "__main__":

--- a/scripts/previews/deploy.py
+++ b/scripts/previews/deploy.py
@@ -24,6 +24,12 @@ async def main():
         "type", choices=["dashboard", "docs"], help="which frontend to deploy"
     )
     parser.add_argument("artifact", type=Path, help="path to the artifact .tar.gz")
+    parser.add_argument(
+        "--api-url",
+        default=None,
+        help="dashboard backend this preview's /api should proxy to; "
+        "defaults to the deployed dashboard",
+    )
     args = parser.parse_args()
 
     if not args.artifact.is_file():
@@ -39,7 +45,9 @@ async def main():
         batch.put_file(str(args.artifact), f"/{artifact_name}")
 
     print(f"Deploying {args.type} preview for #{args.pr_number}")
-    await deploy_preview.remote.aio(args.pr_number, args.type, artifact_name)
+    await deploy_preview.remote.aio(
+        args.pr_number, args.type, artifact_name, api_url=args.api_url
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -1,6 +1,7 @@
 import sys
 import tempfile
 import traceback
+from urllib.parse import urlparse
 from collections import defaultdict
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta
@@ -52,6 +53,12 @@ def get_mounted_artifact_path(name):
 
 PreviewType: TypeAlias = Literal["dashboard", "docs"]
 
+# Where a dashboard preview sends `/api` when the PR didn't bring its own
+# backend (see scripts/previews/dashboard_api.py).
+DEPLOYED_DASHBOARD_HOST = (
+    "modal-labs-training-gym--training-gym-dashboard-fastapi-app.modal.run"
+)
+
 
 def _docs_nginx_refresh_inc(redirects: dict[str, str]) -> str:
     blocks: list[str] = []
@@ -65,6 +72,21 @@ def _docs_nginx_refresh_inc(redirects: dict[str, str]) -> str:
     return "\n".join(blocks) + ("\n" if blocks else "")
 
 
+def render_dashboard_conf(template: str, api_url: Optional[str]) -> str:
+    """Point the dashboard conf's ``/api`` proxy at the API this preview uses."""
+    host = urlparse(api_url).netloc if api_url else DEPLOYED_DASHBOARD_HOST
+    if not host:
+        raise ValueError(f"no host in api_url={api_url!r}")
+    return template.replace("__API_HOST__", host)
+
+
+def _dashboard_nginx_conf(api_url: Optional[str]) -> Path:
+    template = (NGINX_CONF_DIR / "dashboard.conf").read_text()
+    conf = Path(tempfile.mkdtemp()) / "dashboard.conf"
+    conf.write_text(render_dashboard_conf(template, api_url))
+    return conf
+
+
 @dataclass
 class PreviewDeployment:
     type: PreviewType
@@ -72,6 +94,9 @@ class PreviewDeployment:
     sandbox_id: Optional[str] = None
     url: Optional[str] = None
     expiration: datetime | None = None
+    # Set when the PR deployed its own dashboard backend; `None` keeps the
+    # preview reading the deployed dashboard, as every preview used to.
+    api_url: Optional[str] = None
 
     def deploy(self):
         print(f"Deploying {self.type} preview from {self.artifact}")
@@ -90,7 +115,11 @@ class PreviewDeployment:
         remote_conf = "/etc/nginx/conf.d/preview.conf"
 
         if self.type == "dashboard":
-            image = image.add_local_file(NGINX_CONF_DIR / "dashboard.conf", remote_conf)
+            conf = _dashboard_nginx_conf(self.api_url)
+            image = image.add_local_file(conf, remote_conf)
+            print(
+                f"Dashboard preview proxies /api to {self.api_url or 'the deployed dashboard'}"
+            )
 
         if self.type == "docs":
             image = image.add_local_file(NGINX_CONF_DIR / "docs.conf", remote_conf)
@@ -141,7 +170,12 @@ class PreviewDeployment:
 
 
 @app.function(volumes={MOUNT_POINT: vol})
-def deploy_preview(pr_number: int, type: PreviewType, artifact: str):
+def deploy_preview(
+    pr_number: int,
+    type: PreviewType,
+    artifact: str,
+    api_url: Optional[str] = None,
+):
     print(f"Deploying {type} preview for #{pr_number}")
     key = (pr_number, type)
 
@@ -154,7 +188,7 @@ def deploy_preview(pr_number: int, type: PreviewType, artifact: str):
             deployment.terminate()
             deployment.cleanup_artifact()
 
-        deployment = PreviewDeployment(type=type, artifact=artifact)
+        deployment = PreviewDeployment(type=type, artifact=artifact, api_url=api_url)
         deployment.deploy()
     finally:
         deployments[key] = asdict(deployment)

--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import tempfile
 import traceback
@@ -72,11 +73,18 @@ def _docs_nginx_refresh_inc(redirects: dict[str, str]) -> str:
     return "\n".join(blocks) + ("\n" if blocks else "")
 
 
+MODAL_HOST_RE = re.compile(r"[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.modal\.run")
+
+
 def render_dashboard_conf(template: str, api_url: Optional[str]) -> str:
     """Point the dashboard conf's ``/api`` proxy at the API this preview uses."""
     host = urlparse(api_url).netloc if api_url else DEPLOYED_DASHBOARD_HOST
     if not host:
         raise ValueError(f"no host in api_url={api_url!r}")
+    # The host is substituted straight into nginx directives, and the preview
+    # only ever proxies at a Modal web endpoint.
+    if not MODAL_HOST_RE.fullmatch(host):
+        raise ValueError(f"not a modal.run host: {host!r}")
     return template.replace("__API_HOST__", host)
 
 

--- a/scripts/previews/nginx/dashboard.conf
+++ b/scripts/previews/nginx/dashboard.conf
@@ -7,9 +7,9 @@ server {
     index index.html;
 
     location /api {
-        proxy_pass https://modal-labs-training-gym--training-gym-dashboard-fastapi-app.modal.run;
+        proxy_pass https://__API_HOST__;
         proxy_ssl_server_name on;
-        proxy_set_header Host modal-labs-training-gym--training-gym-dashboard-fastapi-app.modal.run;
+        proxy_set_header Host __API_HOST__;
     }
 
     location / {

--- a/tests/test_dashboard_previews.py
+++ b/tests/test_dashboard_previews.py
@@ -57,6 +57,10 @@ def test_conf_only_proxies_at_modal_hosts(api_url):
 def test_cleanup_tolerates_a_missing_app_but_not_a_failing_one():
     name = app_name(489)
 
+    # modal 1.5.2's wording, from modal/cli/app.py.
+    assert is_already_gone(
+        f"No App with name '{name}' found in the 'main' environment.", name
+    )
     assert is_already_gone(f"Error: App not found: {name}", name)
     assert is_already_gone(f"Error: Lookup failed for App '{name}'", name)
     assert not is_already_gone("Error: connection to Modal failed", name)

--- a/tests/test_dashboard_previews.py
+++ b/tests/test_dashboard_previews.py
@@ -1,0 +1,45 @@
+"""The dashboard preview's `/api` proxy target and per-PR backend naming."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "previews"))
+
+from dashboard_api import app_name  # noqa: E402
+from frontend_previews import (  # noqa: E402
+    DEPLOYED_DASHBOARD_HOST,
+    render_dashboard_conf,
+)
+
+TEMPLATE = (REPO_ROOT / "scripts/previews/nginx/dashboard.conf").read_text()
+
+
+def test_conf_proxies_api_to_the_prs_own_backend():
+    conf = render_dashboard_conf(
+        TEMPLATE, "https://ws--training-gym-dashboard-pr-489-fastapi-app.modal.run"
+    )
+
+    host = "ws--training-gym-dashboard-pr-489-fastapi-app.modal.run"
+    assert f"proxy_pass https://{host};" in conf
+    assert f"proxy_set_header Host {host};" in conf
+    assert "__API_HOST__" not in conf
+
+
+def test_conf_without_a_pr_backend_keeps_using_the_deployed_dashboard():
+    conf = render_dashboard_conf(TEMPLATE, None)
+
+    assert f"proxy_pass https://{DEPLOYED_DASHBOARD_HOST};" in conf
+    assert "__API_HOST__" not in conf
+
+
+def test_conf_rejects_an_api_url_it_cannot_read_a_host_from():
+    with pytest.raises(ValueError):
+        render_dashboard_conf(TEMPLATE, "not-a-url")
+
+
+def test_backend_app_name_is_per_pr():
+    assert app_name(489) == "training-gym-dashboard-pr-489"
+    assert app_name(489) != app_name(490)

--- a/tests/test_dashboard_previews.py
+++ b/tests/test_dashboard_previews.py
@@ -8,7 +8,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "previews"))
 
-from dashboard_api import app_name  # noqa: E402
+from dashboard_api import app_name, is_already_gone  # noqa: E402
 from frontend_previews import (  # noqa: E402
     DEPLOYED_DASHBOARD_HOST,
     render_dashboard_conf,
@@ -38,6 +38,25 @@ def test_conf_without_a_pr_backend_keeps_using_the_deployed_dashboard():
 def test_conf_rejects_an_api_url_it_cannot_read_a_host_from():
     with pytest.raises(ValueError):
         render_dashboard_conf(TEMPLATE, "not-a-url")
+
+
+@pytest.mark.parametrize(
+    "api_url",
+    [
+        "https://evil.example.com",
+        "https://ok.modal.run;return 200 'x'",
+        "https://ok.modal.run.evil.example.com",
+    ],
+)
+def test_conf_only_proxies_at_modal_hosts(api_url):
+    # The host lands inside nginx directives verbatim.
+    with pytest.raises(ValueError):
+        render_dashboard_conf(TEMPLATE, api_url)
+
+
+def test_cleanup_tolerates_a_missing_app_but_not_a_failing_one():
+    assert is_already_gone("Error: App training-gym-dashboard-pr-489 not found")
+    assert not is_already_gone("Error: connection to Modal failed")
 
 
 def test_backend_app_name_is_per_pr():

--- a/tests/test_dashboard_previews.py
+++ b/tests/test_dashboard_previews.py
@@ -55,8 +55,12 @@ def test_conf_only_proxies_at_modal_hosts(api_url):
 
 
 def test_cleanup_tolerates_a_missing_app_but_not_a_failing_one():
-    assert is_already_gone("Error: App training-gym-dashboard-pr-489 not found")
-    assert not is_already_gone("Error: connection to Modal failed")
+    name = app_name(489)
+
+    assert is_already_gone(f"Error: App not found: {name}", name)
+    assert is_already_gone(f"Error: Lookup failed for App '{name}'", name)
+    assert not is_already_gone("Error: connection to Modal failed", name)
+    assert not is_already_gone("Error: Secret 'wandb' not found", name)
 
 
 def test_backend_app_name_is_per_pr():


### PR DESCRIPTION
A dashboard preview is a static nginx sandbox, so its `/api` had to be proxied at the *deployed* dashboard. A PR that touches both halves of the dashboard therefore previewed its new frontend against `main`'s API — and when the frontend called a route that didn't exist there yet, the backend's SPA fallback answered `index.html` with a 200, which Safari surfaced as `Failed to load: The string did not match the expected pattern` (seen on #489's preview of `/api/runs/counts`).

Each PR now gets its own copy of the backend, deployed from the PR's checkout:

```
preview job:  dashboard_api.py deploy 489   →  training-gym-dashboard-pr-489
              deploy.py 489 dashboard … --api-url <that app's web url>
              →  nginx conf rendered with proxy_pass <that app>   (was: hardcoded prod host)
cleanup job (PR closed):  dashboard_api.py stop 489
```

`--api-url` is optional and `PreviewDeployment.api_url` defaults to `None`, which renders the old prod host — so docs previews and any deployment already in the `training-gym-deployments` Dict keep working unchanged.

### Preview deploys are API-only

`TRAINING_GYM_DASHBOARD_PREVIEW=1` (set by `dashboard_api.py`, never by `training-gym setup` or a manual `modal deploy`) makes `_dashboard.py` drop `schedule=` from `compact_summaries`/`reconcile` and set `min_containers=0`. Without that, every open PR would run a second copy of the jobs that rewrite the shared `training-gym-metadata` volume — `reconcile` marks runs orphaned, `compact_summaries` rebuilds the summary stores — and hold a warm container each.

Preview backends read (and, over the ingestion routes, can write) the same real metadata as the deployed dashboard, and like `modal deploy` they don't get proxy auth, so a preview URL is an unauthenticated view of run metadata. Same exposure as the preview frontends today, but worth a look before merge — an alternative is a per-PR metadata volume, at the cost of previews showing no runs.

### This PR can't preview itself

`deploy_preview` runs in the deployed `training-gym-previews` app, which is `main`'s code (`previews-app.yml` deploys on push to main), so on this branch it doesn't take an `api_url` yet. `deploy.py` catches that and deploys the preview without one rather than failing the job:

```
Deploy dashboard API preview:  training-gym-dashboard-pr-491 → https://…dashboard-pr-491-f-c74690.modal.run
Deploy dashboard preview:      Previews app does not accept api_url yet (…); deploying without it
```

So #491's own preview still proxies at the deployed dashboard; PRs opened after this merges get their own backend. Same fallback keeps the branch's docs preview working.

Workflow trigger also now covers `modal_training_gym/_dashboard.py`, since the API half of a dashboard change lives there, and the job filters skip `build`/`preview` on the `closed` event that drives cleanup.

## Checklist

Not an example PR — the example checklist below doesn't apply.

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies


Link to Devin session: https://modal.devinenterprise.com/sessions/95e5ad2ac22742e98d76804b1c04343b
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/95e5ad2ac22742e98d76804b1c04343b?variant=devin
Requested by: @joyliu-q