### PR TITLE
Count num_rollout from zero when continuing from a checkpoint

### DIFF
--- a/modal_training_gym/common/launcher_utils.py
+++ b/modal_training_gym/common/launcher_utils.py
@@ -469,6 +469,33 @@ def prepare_launch_config(
             object.__setattr__(cfg, field, path)
 
 
+def drop_materialized_config_key(cfg: Any, key: str) -> None:
+    """Remove ``key`` from the recipe's already-materialized escape-hatch YAML.
+
+    Runs after ``prepare_launch_config`` has replaced the escape-hatch dict
+    with a file path, so the YAML is rewritten and the recorded keys updated
+    so ``_emit_fields`` stops suppressing the same-named flag.
+    """
+    import yaml
+
+    escape_hatch = getattr(cfg, "_ESCAPE_HATCH_FIELD", None)
+    if not escape_hatch:
+        return
+    keys = tuple(getattr(cfg, "_materialized_config_keys", ()) or ())
+    if key not in keys:
+        return
+    path = getattr(cfg, escape_hatch, None)
+    if isinstance(path, str) and os.path.isfile(path):
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        data.pop(key, None)
+        with open(path, "w") as f:
+            yaml.dump(data, f)
+    object.__setattr__(
+        cfg, "_materialized_config_keys", tuple(k for k in keys if k != key)
+    )
+
+
 def build_train_cmd(
     cfg: Any,
     root: str,

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -351,6 +351,11 @@ class TrainConfig:
             recipe = _dc.replace(
                 self.recipe,
                 load=os.path.dirname(self.checkpoint.path.rstrip("/")),
+                start_rollout_id=(
+                    0
+                    if self.recipe.start_rollout_id is None
+                    else self.recipe.start_rollout_id
+                ),
             )
         _try_validate_model_parallelism(recipe, self.model)
         return recipe

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -26,6 +26,7 @@ from modal_training_gym.common.framework import (
     mount_tools_dir,
 )
 from modal_training_gym.common.launcher_utils import (
+    drop_materialized_config_key,
     serialize_recipe_params,
     timing_debug_env,
 )
@@ -1150,6 +1151,7 @@ def build_miles_app(
                 # Continue from the iteration stored in the run's own checkpoint,
                 # even for runs launched with an explicit start_rollout_id.
                 miles.start_rollout_id = None
+                drop_materialized_config_key(miles, "start_rollout_id")
             elif unresumable := _unresumable_save_dirs(save_root):
                 print(
                     f"WARNING: {save_root} holds saves that cannot be resumed "

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -1130,6 +1130,7 @@ def build_miles_app(
 
             original_save = miles.save
             original_load = miles.load
+            original_start_rollout_id = miles.start_rollout_id
             miles.save = save_root
             resume_checkpoint = torch_dist_resume_checkpoint(
                 save_root, is_complete=_is_resumable_checkpoint
@@ -1146,6 +1147,9 @@ def build_miles_app(
                     "resuming training from last saved iteration."
                 )
                 miles.load = save_root
+                # Continue from the iteration stored in the run's own checkpoint,
+                # even for runs launched with an explicit start_rollout_id.
+                miles.start_rollout_id = None
             elif unresumable := _unresumable_save_dirs(save_root):
                 print(
                     f"WARNING: {save_root} holds saves that cannot be resumed "
@@ -1160,6 +1164,7 @@ def build_miles_app(
             finally:
                 miles.save = original_save
                 miles.load = original_load
+                miles.start_rollout_id = original_start_rollout_id
 
             phase_report_url = (
                 os.environ.get("TRAINING_GYM_FRAMEWORK_STATUS_URL")

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -62,6 +62,7 @@ from modal_training_gym.common.launcher_helpers import (
     ship_callable,
 )
 from modal_training_gym.common.launcher_utils import (
+    drop_materialized_config_key,
     serialize_recipe_params,
     timing_debug_env,
 )
@@ -1103,6 +1104,7 @@ def build_slime_app(
                 # Continue from the iteration stored in the run's own checkpoint,
                 # even for runs launched with an explicit start_rollout_id.
                 object.__setattr__(slime, "start_rollout_id", None)
+                drop_materialized_config_key(slime, "start_rollout_id")
                 # Weights-only checkpoints (``no_save_optim``) have no Adam state;
                 # Megatron will KeyError on state_dict["optimizer"] unless we skip it.
                 if slime.no_save_optim and not slime.no_load_optim:

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -1069,6 +1069,7 @@ def build_slime_app(
 
             original_save = slime.save
             original_load = slime.load
+            original_start_rollout_id = slime.start_rollout_id
             original_ref_load = slime.ref_load
             original_no_load_optim = slime.no_load_optim
             object.__setattr__(slime, "save", save_root)
@@ -1099,6 +1100,9 @@ def build_slime_app(
                     "resuming training from last saved iteration."
                 )
                 object.__setattr__(slime, "load", save_root)
+                # Continue from the iteration stored in the run's own checkpoint,
+                # even for runs launched with an explicit start_rollout_id.
+                object.__setattr__(slime, "start_rollout_id", None)
                 # Weights-only checkpoints (``no_save_optim``) have no Adam state;
                 # Megatron will KeyError on state_dict["optimizer"] unless we skip it.
                 if slime.no_save_optim and not slime.no_load_optim:
@@ -1120,6 +1124,7 @@ def build_slime_app(
             finally:
                 object.__setattr__(slime, "save", original_save)
                 object.__setattr__(slime, "load", original_load)
+                object.__setattr__(slime, "start_rollout_id", original_start_rollout_id)
                 object.__setattr__(slime, "ref_load", original_ref_load)
                 object.__setattr__(slime, "no_load_optim", original_no_load_optim)
 

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -189,6 +189,10 @@ class MilesRecipe(BaseTrainRecipe):
 
         num_rollout:
             Training and rollout steps for the run.
+        start_rollout_id:
+            Rollout step to start counting from. ``None`` continues from the
+            iteration stored in ``load``; ``TrainConfig(checkpoint=...)`` sets
+            ``0`` so ``num_rollout`` counts the steps this run performs.
         rollout_batch_size:
             Prompts per rollout step, each expanded into a group of responses.
         rollout_max_response_len:
@@ -504,6 +508,7 @@ class MilesRecipe(BaseTrainRecipe):
 
     # ── Rollout and sampling ────────────────────────────────────────────────
     num_rollout: int = 1
+    start_rollout_id: int | None = None
     rollout_batch_size: int = 8
     n_samples_per_prompt: int = 2
     rollout_max_response_len: int = 4096

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -179,6 +179,10 @@ class SlimeRecipe(BaseTrainRecipe):
 
         num_rollout:
             Training and rollout steps for the run.
+        start_rollout_id:
+            Rollout step to start counting from. ``None`` continues from the
+            iteration stored in ``load``; ``TrainConfig(checkpoint=...)`` sets
+            ``0`` so ``num_rollout`` counts the steps this run performs.
         rollout_batch_size:
             Prompts sampled per rollout step; each prompt is expanded into a
             group of sampled responses.
@@ -387,6 +391,7 @@ class SlimeRecipe(BaseTrainRecipe):
     tensor_model_parallel_size: int = 1
     rollout_num_gpus_per_engine: int = 1
     num_rollout: int = 1
+    start_rollout_id: int | None = None
     rollout_batch_size: int = 8
 
     # ── App identity ─────────────────────────────────────────────────────────

--- a/tests/test_train_checkpoint.py
+++ b/tests/test_train_checkpoint.py
@@ -173,3 +173,31 @@ def test_miles_conversion_uses_wrapper_with_expected_environment() -> None:
         '            env["CONVERT_KEEP_PP1"] = "1"'
     ) in source
     assert 'if num_nodes > 1:\n            env["SKIP_RELEASE_RENAME"] = "1"' in source
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        pytest.param(SlimeRecipe(**_RECIPE_KW), id="slime"),
+        pytest.param(MilesRecipe(), id="miles"),
+    ],
+)
+def test_auto_resume_drops_extra_config_start_rollout_id(recipe, tmp_path) -> None:
+    import yaml
+
+    from modal_training_gym.common.launcher_utils import (
+        drop_materialized_config_key,
+        prepare_launch_config,
+    )
+
+    recipe.extra_config = {"start_rollout_id": 0, "qkv_format": "bshd"}
+    prepare_launch_config(
+        recipe, None, str(tmp_path), yaml_config_fields=("extra_config",)
+    )
+    assert "start_rollout_id" in recipe._escape_hatch_keys()
+
+    drop_materialized_config_key(recipe, "start_rollout_id")
+
+    assert recipe._escape_hatch_keys() == ("qkv_format",)
+    with open(recipe.extra_config) as f:
+        assert yaml.safe_load(f) == {"qkv_format": "bshd"}

--- a/tests/test_train_checkpoint.py
+++ b/tests/test_train_checkpoint.py
@@ -81,6 +81,32 @@ def test_checkpoint_wins_over_recipe_load() -> None:
     assert config._prepare_recipe().load == "/checkpoints/run"
 
 
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        pytest.param(SlimeRecipe(**_RECIPE_KW), id="slime"),
+        pytest.param(MilesRecipe(), id="miles"),
+    ],
+)
+def test_checkpoint_restarts_rollout_count_from_zero(recipe) -> None:
+    config = _config(recipe, CheckpointType.megatron)
+    prepared = config._prepare_recipe()
+    args = prepared.cli_args(model=config.model)
+
+    assert prepared.start_rollout_id == 0
+    assert args[args.index("--start-rollout-id") + 1] == "0"
+    assert recipe.start_rollout_id is None
+    assert "--start-rollout-id" not in recipe.cli_args(model=config.model)
+
+
+def test_explicit_start_rollout_id_wins_over_checkpoint_default() -> None:
+    config = _config(
+        SlimeRecipe(**_RECIPE_KW, start_rollout_id=5), CheckpointType.megatron
+    )
+
+    assert config._prepare_recipe().start_rollout_id == 5
+
+
 def test_config_summary_records_resume_without_mutating_recipe() -> None:
     config = _config(SlimeRecipe(**_RECIPE_KW), CheckpointType.megatron)
 


### PR DESCRIPTION
## Summary

`TrainConfig(checkpoint=...)` only set `recipe.load`, so slime/miles read the stored iteration `N` from the checkpoint and ran `range(N + 1, num_rollout)`. A continuation run with `num_rollout <= N + 1` therefore ran zero rollouts and reported itself as completed; users had to keep bumping `num_rollout` past the parent run's step count.

Both frameworks accept `--start-rollout-id`, which overrides the loaded iteration in that loop. This PR:

- adds a `start_rollout_id: int | None = None` field to `SlimeRecipe` and `MilesRecipe` (emitted as `--start-rollout-id`)
- `TrainConfig._prepare_recipe` sets `start_rollout_id=0` when a `checkpoint` is given (unless the recipe set it explicitly), so `num_rollout` is the number of steps *this* run performs and its checkpoints are numbered `iter_0000000...` under its own `save_root`
- the launchers' auto-resume branch (a retry finding a checkpoint in the run's own `save_root`) forces `start_rollout_id=None` for the built command, so crash-retries of a continuation run still pick up at the run's last saved iteration instead of restarting at 0

Behavior for plain crash-retries of a non-continuation run is unchanged (`_validate_resume_checkpoint` still guards the `num_rollout` target there).

Not tested on a live cluster; verified via `tests/test_train_checkpoint.py` (new cases) and inspection of slime's `train.py` / `placement_group.py` and miles' equivalents, which honor a user-set `args.start_rollout_id`.

## Checklist

- [x] N/A — SDK change, not an example


Link to Devin session: https://modal.devinenterprise.com/sessions/a83bfe400bc44aa0b1d8afc5528c56a9
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/a83bfe400bc44aa0b1d8afc5528c56a9?variant=devin
Requested by: @joyliu-q