### PR TITLE
Fix the previews app image build so it deploys again

### DIFF
--- a/scripts/previews/frontend_previews.py
+++ b/scripts/previews/frontend_previews.py
@@ -21,8 +21,8 @@ from astro_redirects import redirect_status, refresh_map_from_tarball  # noqa: E
 image = (
     modal.Image.debian_slim()
     .pip_install("PyGithub~=2.6.1")
-    .add_local_dir(Path(__file__).resolve().parent / "nginx", NGINX_CONF_DIR)
     .add_local_file(_ASTRO_REDIRECTS, "/root/astro_redirects.py", copy=True)
+    .add_local_dir(Path(__file__).resolve().parent / "nginx", NGINX_CONF_DIR)
 )
 
 with image.imports():
@@ -130,10 +130,11 @@ class PreviewDeployment:
             )
 
         if self.type == "docs":
-            image = image.add_local_file(NGINX_CONF_DIR / "docs.conf", remote_conf)
             inc = Path(tempfile.mkdtemp()) / "astro-refresh.inc"
             inc.write_text(_docs_nginx_refresh_inc(refresh_map_from_tarball(path)))
-            image = image.add_local_file(inc, "/etc/nginx/astro-refresh.inc", copy=True)
+            image = image.add_local_file(
+                inc, "/etc/nginx/astro-refresh.inc", copy=True
+            ).add_local_file(NGINX_CONF_DIR / "docs.conf", remote_conf)
 
         sb_app = modal.App.lookup(SANDBOX_APP_NAME, create_if_missing=True)
         self.expiration = datetime.now() + SANDBOX_TIMEOUT


### PR DESCRIPTION
Deploys of `training-gym-previews` have been failing since the nginx conf dir moved into the image, so the *deployed* `deploy_preview()` predates #491 and dashboard previews still proxy `/api` at the deployed dashboard instead of the PR's own backend (visible on #489's preview job: `Previews app does not accept api_url yet ...; deploying without it`).

Modal rejects a build step that runs after a non-`copy` `add_local_*`:

```
An image tried to run a build step after using `image.add_local_*` to include local files.
```

Two chains did that; both now add the mounted (non-`copy`) file last:

- module image: `add_local_dir(nginx)` → `add_local_file(astro_redirects, copy=True)` becomes `add_local_file(..., copy=True)` → `add_local_dir(nginx)`
- docs sandbox image: `add_local_file(docs.conf)` → `add_local_file(astro-refresh.inc, copy=True)` becomes the `copy=True` `.inc` first, then `docs.conf`

No behavioral change — same files land at the same paths. Not verifiable locally (hydrating an image needs Modal credentials this box doesn't have); the `Previews App` deploy on merge is the check.

## Checklist

- [ ] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.
- [ ] Example does _not_ require third-party dependencies to be installed locally
- [ ] Example pins its dependencies
  - [ ] Example pins container images to a stable tag, not a dynamic tag like `latest`
  - [ ] Example specifies a `python_version` for the base image, if it is used
  - [ ] Example pins all dependencies to at least minor version, `~=x.y.z` or `==x.y`
  - [ ] Example dependencies with `version < 1` are pinned to patch version, `==0.y.z`


Link to Devin session: https://modal.devinenterprise.com/sessions/95e5ad2ac22742e98d76804b1c04343b
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/95e5ad2ac22742e98d76804b1c04343b?variant=devin
Requested by: @joyliu-q