### PR TITLE
Pin ASR recipe image deps (librosa/jiwer/soundfile, numpy<2)

### DIFF
--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
@@ -37,9 +37,13 @@ _ASR_PATCHES = (
 
 def _asr_image_run_commands() -> list[str]:
     # soundfile/librosa decode audio (transcription rollout); jiwer powers the −WER
-    # reward. librosa>=1.0 requires numpy 2.x, which Megatron rejects, so pin both.
-    # Then apply the upstream-gap shims at image build.
-    cmds = ['pip install --no-cache-dir jiwer "librosa<1.0" soundfile "numpy<2"']
+    # reward. Pinned: librosa>=1.0 requires numpy 2.x, which Megatron rejects; the
+    # numpy<2 constraint keeps pip from upgrading the base image's numpy. Then apply
+    # the upstream-gap shims at image build.
+    cmds = [
+        "pip install --no-cache-dir jiwer==4.0.0 librosa==0.11.0 soundfile==0.14.0 "
+        '"numpy<2"'
+    ]
     cmds += [
         f"echo {encode_patch(name, _ASR_PATCH_DIR)} | base64 -d | python3"
         for name in _ASR_PATCHES

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
@@ -37,8 +37,9 @@ _ASR_PATCHES = (
 
 def _asr_image_run_commands() -> list[str]:
     # soundfile/librosa decode audio (transcription rollout); jiwer powers the −WER
-    # reward. Then apply the upstream-gap shims at image build.
-    cmds = ["pip install --no-cache-dir jiwer librosa soundfile"]
+    # reward. librosa>=1.0 requires numpy 2.x, which Megatron rejects, so pin both.
+    # Then apply the upstream-gap shims at image build.
+    cmds = ['pip install --no-cache-dir jiwer "librosa<1.0" soundfile "numpy<2"']
     cmds += [
         f"echo {encode_patch(name, _ASR_PATCH_DIR)} | base64 -d | python3"
         for name in _ASR_PATCHES


### PR DESCRIPTION
Fixes the Qwen3-ASR-1.7B validation failure in https://github.com/modal-projects/training-gym/actions/runs/33672565105/job/100389574859 (`AssertionError: Megatron does not support numpy 2.x` from `slime/backends/megatron_utils/initialize.py`).

Root cause: `Qwen3_ASR_1_7B_Recipe.image_run_commands` ran an unpinned `pip install jiwer librosa soundfile`. librosa 1.0.0 (PyPI, 2026-08-11) declares `numpy>=2.1.0`, so any fresh build of the ASR image layer upgrades numpy to 2.x on top of the slime base image, and Megatron's init assertion trips at actor startup.

Fix: `pip install jiwer==4.0.0 librosa==0.11.0 soundfile==0.14.0 "numpy<2"` — exact pins for the three extras (librosa 0.11 is numpy 1.x-compatible), plus an explicit `numpy<2` constraint so pip can't upgrade the base image's numpy via any transitive dep.

## Checklist

- [x] Example pins its dependencies


Link to Devin session: https://modal.devinenterprise.com/sessions/e12e955aba2441d299d7ea498a1d447c
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/e12e955aba2441d299d7ea498a1d447c?variant=devin
Requested by: @anli5005
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->