### PR TITLE
Expose training-function max_retries on Slime/Miles recipes

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -921,7 +921,7 @@ def build_miles_app(
         volumes=all_volumes,
         secrets=train_secrets,
         timeout=24 * 60 * 60,
-        retries=Retries(max_retries=10, initial_delay=0.0),
+        retries=Retries(max_retries=miles.max_retries, initial_delay=0.0),
         single_use_containers=True,
         experimental_options=train_experimental_options,
         serialized=True,

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -919,8 +919,9 @@ def build_slime_app(
         # resumes from the last checkpoint. But a *deterministic* crash (esp.
         # before the first save_interval checkpoint) re-runs from scratch and
         # crashloops through every attempt — 10 wasted ~4h of a 40-GPU cluster on
-        # a step-1 crash. Cap low so a persistent failure surfaces fast.
-        retries=Retries(max_retries=3, initial_delay=0.0),
+        # a step-1 crash. The recipe default is low so a persistent failure
+        # surfaces fast.
+        retries=Retries(max_retries=slime.max_retries, initial_delay=0.0),
         single_use_containers=True,
         experimental_options=train_experimental_options or None,
         serialized=True,

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -57,6 +57,7 @@ _MILES_SKIP = {
     "custom_megatron_before_log_prob_hook",
     "custom_megatron_before_train_step_hook",
     "train_function_kwargs",
+    "max_retries",
     # Conversion-only parallelism and scratch: launcher-side, never forwarded to
     # the miles CLI.
     "conversion_tensor_model_parallel_size",
@@ -147,6 +148,11 @@ class MilesRecipe(BaseTrainRecipe):
             Extra env vars baked into the image.
         train_function_kwargs:
             Additional Modal Function keyword arguments for the training function.
+        max_retries:
+            Modal retries for the training function. Each retry resumes from
+            the last checkpoint, so keep it low while a workload is unvalidated
+            (a deterministic crash re-runs from scratch on every attempt) and
+            raise it once runs are stable and only die to preemption.
         capture_trace:
             Attach sampled per-request execution traces to recorded rollouts.
         trace_sample_limit:
@@ -641,6 +647,7 @@ class MilesRecipe(BaseTrainRecipe):
     # samples of each rollout. Off by default — traces inflate payloads, so
     # sampling keeps the added volume well under 1%. Not a miles CLI flag.
     train_function_kwargs: dict[str, Any] = field(default_factory=dict)
+    max_retries: int = 10
     capture_trace: bool = False
     trace_sample_limit: int = 16
 

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -66,6 +66,7 @@ _SLIME_SKIP = {
     "image_run_commands",
     "image_env",
     "train_function_kwargs",
+    "max_retries",
     "substep_timing",
     "conversion_pipeline_model_parallel_size",
     "conversion_tensor_model_parallel_size",
@@ -148,6 +149,11 @@ class SlimeRecipe(BaseTrainRecipe):
             Extra env vars baked into the image.
         train_function_kwargs:
             Additional Modal Function keyword arguments for the training function.
+        max_retries:
+            Modal retries for the training function. Each retry resumes from
+            the last checkpoint, so keep it low while a workload is unvalidated
+            (a deterministic crash re-runs from scratch on every attempt) and
+            raise it once runs are stable and only die to preemption.
         capture_trace:
             Attach sampled per-request execution traces to recorded rollouts.
         trace_sample_limit:
@@ -423,6 +429,7 @@ class SlimeRecipe(BaseTrainRecipe):
     image_run_commands: list[str] = field(default_factory=list)
     image_env: dict[str, str] = field(default_factory=dict)
     train_function_kwargs: dict[str, Any] = field(default_factory=dict)
+    max_retries: int = 3
 
     substep_timing: Literal["auto", "off"] = "auto"
 


### PR DESCRIPTION
Adds a `max_retries: int` recipe field so users can override the hardcoded `Retries(max_retries=...)` on the `train` Modal Function (from [this Slack thread](https://modal-com.slack.com/archives/C0B2K1D6Q4D/p1788466898332599)):

```python
Qwen3_8_27B_Recipe(max_retries=9, ...)
```

- `SlimeRecipe.max_retries` defaults to `3`, `MilesRecipe.max_retries` to `10` — the values the launchers previously hardcoded, so existing runs are unchanged.
- Added to each recipe's `_SKIP` set so it's a launcher setting, not a slime/miles CLI flag (verified `cli_args()` doesn't emit it).

## Checklist

N/A — library change, no new example.


Link to Devin session: https://modal.devinenterprise.com/sessions/ee86bde394d1451e9661f42a2c0ee763
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/ee86bde394d1451e9661f42a2c0ee763?variant=devin
Requested by: @omkaark
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->