### PR TITLE
small synmon fixes

### DIFF
--- a/synthetic_monitoring/model_validation.py
+++ b/synthetic_monitoring/model_validation.py
@@ -36,12 +36,14 @@ probe_image = (
     .uv_pip_install("slack-sdk==3.27.1", "matplotlib==3.10.1")
     .env({"MODAL_ENVIRONMENT": MODAL_ENV})
     .add_local_python_source("modal_training_gym", "synthetic_monitoring", "scripts")
+    .add_local_dir(
+        str(REPO_ROOT / "dashboards" / "frontend"),
+        remote_path="/root/dashboards/frontend",
+        ignore=["node_modules", "dist"],
+    )
 )
 
 slack_secret = modal.Secret.from_name("gym-bot-slack", environment_name=MODAL_ENV)
-modal_creds_secret = modal.Secret.from_name(
-    "_training-gym-modal-creds", environment_name=MODAL_ENV
-)
 
 app = modal.App("gym-synmon-launcher")
 
@@ -243,7 +245,6 @@ def _post_report(rows: list[dict]) -> None:
 @app.function(
     image=probe_image,
     timeout=PROBE_TIMEOUT_S + CLEANUP_GRACE_S,
-    secrets=[modal_creds_secret],
 )
 def monitor(model: str = "", num_steps: int = 1) -> dict:
     selected = _ValidationConfig.find(model).name
@@ -283,7 +284,7 @@ def monitor(model: str = "", num_steps: int = 1) -> dict:
     image=probe_image,
     timeout=LAUNCH_TIMEOUT_S,
     schedule=modal.Cron("17 0 * * 0"),
-    secrets=[slack_secret, modal_creds_secret],
+    secrets=[slack_secret],
 )
 def launch_weekly(model: str = "", num_steps: int = 1) -> list[dict]:
     names = (

--- a/synthetic_monitoring/model_validation.py
+++ b/synthetic_monitoring/model_validation.py
@@ -296,10 +296,10 @@ def launch_weekly(model: str = "", num_steps: int = 1) -> list[dict]:
         raise RuntimeError("no validatable models registered")
 
     rows: list[dict] = []
-    for name, payload in zip(
-        names,
-        monitor.map(names, kwargs={"num_steps": num_steps}, return_exceptions=True),
-    ):
+    payloads = list(
+        monitor.map(names, kwargs={"num_steps": num_steps}, return_exceptions=True)
+    )
+    for name, payload in zip(names, payloads):
         if isinstance(payload, Exception):
             tb = "".join(
                 traceback.format_exception(


### PR DESCRIPTION
In this [sample synmon training run](https://modal.com/apps/modal-labs/training-gym/deployed/gym-synmon-launcher?activeTab=functions&start=1788392908.106&end=1788479308.106&live=true&functionId=fu-kSuxGxFVLMv7iAaw172iNv&functionSection=calls&fcId=fc-01M1MQC6V6YYVVA90BFGEDEDGE&inputId=in-01M1MQC6VAYHAF5TW1Q50C1N9K), I saw in the logs:

```bash
WARNING: could not ensure the training-gym dashboard is deployed: local dir /root/modal_training_gym/_frontend does not exist. Continuing without dashboard status reporting; run `training-gym setup` to deploy it manually.
```

In the [launch container logs](https://modal.com/apps/modal-labs/training-gym/deployed/gym-synmon-launcher?activeTab=functions&start=1788392908.106&end=1788479308.106&live=true&functionId=fu-KwCvCLqfy87j0oP9B4gdT6&functionSection=containers&containerId=ta-01M1MQC3BQDY79171V9VEYFT2R), I saw:

```bash
UserWarning: Modal tokens provided by MODAL_TOKEN_ID and MODAL_TOKEN_SECRET (or through the config file) are ignored inside containers.
```

and [this](https://modal.com/apps/modal-labs/training-gym/deployed/gym-synmon-launcher?activeTab=logs&start=1788392908.106&end=1788479308.106&live=true&logId=ta-01M1MT9XG98PWFDQS619HS79ZR-1788482481482590437):

```bash
an error occurred during closing of asynchronous generator <async_generator object Synchronizer._run_generator_async at 0x2b17b9ed9480>
asyncgen: <async_generator object Synchronizer._run_generator_async at 0x2b17b9ed9480>
Traceback (most recent call last):
  File "/pkg/modal/_utils/async_utils.py", line 839, in __iter__
    yield from run_async_gen(runner, self._async_iterable)
GeneratorExit

During handling of the above exception, another exception occurred:

RuntimeError: aclose(): asynchronous generator is already running
```

All three are non-fatal issues, but are addressed nonetheless by 1) adding the dashboard frontend files to the container image, 2) removing the spurious modal creds secret (old artifact of the main modal examples synmon), and 3) moving the `.map()` call out of `zip()`.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->