### PR TITLE
patch failing ckpt saves

### DIFF
--- a/modal_training_gym/common/megatron_patches/patch_dist_ckpt_nofork.py
+++ b/modal_training_gym/common/megatron_patches/patch_dist_ckpt_nofork.py
@@ -1,0 +1,71 @@
+"""Stop Megatron's torch_dist writer from ``os.fork()``ing out of a Ray actor.
+
+Slime pins a pre-#3633 Megatron whose ``write_preloaded_data_multiproc``
+does ``mp.get_context("fork"); ctx.Process(...); p.start()``. From a
+multithreaded CUDA/Ray actor that ``os.fork()`` raises
+``BlockingIOError: [Errno 11] Resource temporarily unavailable`` (EAGAIN)
+on the final checkpoint save. ``--dist-ckpt-workers`` landed in the same
+PR that deleted this function, so the gym cannot pass the flag.
+
+Executed at image-build time via ``python3 <this file>``.
+"""
+
+import pathlib
+import re
+
+filesystem_async_py = pathlib.Path(
+    "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/filesystem_async.py"
+)
+
+if not filesystem_async_py.exists():
+    print(f"WARNING: {filesystem_async_py} not found — skipping dist-ckpt nofork patch")
+    raise SystemExit(0)
+
+src = filesystem_async_py.read_text()
+marker = "PATCHED_DIST_CKPT_NOFORK"
+
+if marker in src:
+    print("filesystem_async.py already patched to write torch_dist in-process")
+    raise SystemExit(0)
+
+if "write_preloaded_data_multiproc" not in src:
+    print(
+        "filesystem_async.py has no write_preloaded_data_multiproc — "
+        "skipping dist-ckpt nofork patch"
+    )
+    raise SystemExit(0)
+
+spawn = re.search(
+    r"^([ \t]+)p_list\.append\(\s*"
+    r"ctx\.Process\(\s*"
+    r"target=partial\(FileSystemWriterAsync\.write_preloaded_data,"
+    r"\s*transform_list\),\s*"
+    r"kwargs=kwargs,\s*"
+    r"\)\s*\)$",
+    src,
+    re.MULTILINE,
+)
+start = re.search(r"^([ \t]+)for p in p_list:\n\1    p\.start\(\)$", src, re.MULTILINE)
+join = re.search(r"^([ \t]+)p_list\[local_proc_idx\]\.join\(\)$", src, re.MULTILINE)
+
+if not (spawn and start and join):
+    print(
+        "WARNING: could not patch filesystem_async.py — "
+        "torch_dist Process spawn / p.start() / join() not found"
+    )
+    raise SystemExit(0)
+
+indent = spawn.group(1)
+src = src.replace(
+    spawn.group(0),
+    (
+        f"{indent}FileSystemWriterAsync.write_preloaded_data(\n"
+        f"{indent}    transform_list, **kwargs\n"
+        f"{indent})  # {marker}"
+    ),
+    1,
+)
+src = src.replace(start.group(0), f"{start.group(1)}pass  # {marker}", 1)
+src = src.replace(join.group(0), f"{join.group(1)}pass  # {marker}", 1)
+filesystem_async_py.write_text(src)
+print("Patched filesystem_async.py to write torch_dist in-process (no fork)")

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -131,6 +131,7 @@ _REPORTING_PATCH_COMMANDS = (
 _PATCH_DIST_CKPT_QUANTIZED_B64 = encode_patch(
     "patch_dist_ckpt_quantized", _MEGATRON_PATCHES
 )
+_PATCH_DIST_CKPT_NOFORK_B64 = encode_patch("patch_dist_ckpt_nofork", _MEGATRON_PATCHES)
 _PATCH_CHECKPOINT_SAVE_B64 = encode_patch("patch_checkpoint_save", _MEGATRON_PATCHES)
 _MEGATRON_TORCH_STRATEGY_PY = (
     "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/torch.py"
@@ -353,6 +354,7 @@ def _build_miles_base_image(miles: MilesRecipe) -> Image:
             f"rm -rf {HF_CACHE_PATH} 2>/dev/null || true",
             f"echo {_PATCH_SGLANG_ABORT_B64} | base64 -d | python3",
             f"echo {_PATCH_DIST_CKPT_QUANTIZED_B64} | base64 -d | python3",
+            f"echo {_PATCH_DIST_CKPT_NOFORK_B64} | base64 -d | python3",
             (
                 f"if test -f {_MEGATRON_TORCH_STRATEGY_PY}; then "
                 f"echo {_PATCH_CHECKPOINT_SAVE_B64} | base64 -d | python3; "

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -165,6 +165,7 @@ _PATCH_LOG_ELIDE_B64 = encode_patch("patch_log_elide", _SLIME_PATCHES)
 _PATCH_DIST_CKPT_QUANTIZED_B64 = encode_patch(
     "patch_dist_ckpt_quantized", _MEGATRON_PATCHES
 )
+_PATCH_DIST_CKPT_NOFORK_B64 = encode_patch("patch_dist_ckpt_nofork", _MEGATRON_PATCHES)
 # OPD / multi-turn: zero-std metrics must skip non-numeric rewards (dict/None).
 _PATCH_ZERO_STD_METRICS_B64 = encode_patch("patch_zero_std_metrics", _SLIME_PATCHES)
 _PATCH_SGLANG_PARALLEL_ALIASES_B64 = encode_patch(
@@ -193,6 +194,7 @@ _SLIME_EXTERNAL_PATCHES_B64 = (
     _PATCH_BRIDGE_NONE_TASK_B64,
     _PATCH_LOG_ELIDE_B64,
     _PATCH_DIST_CKPT_QUANTIZED_B64,
+    _PATCH_DIST_CKPT_NOFORK_B64,
 )
 
 

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -40,6 +40,7 @@ PKG_ROOT = REPO_ROOT / "modal_training_gym"
 REMOTE_ONLY = frozenset(
     {
         "modal_training_gym.common.megatron_patches.patch_checkpoint_save",
+        "modal_training_gym.common.megatron_patches.patch_dist_ckpt_nofork",
         "modal_training_gym.common.megatron_patches.patch_dist_ckpt_quantized",
         "modal_training_gym.common.megatron_patches.patch_gdn_packed_seq",
         "modal_training_gym.common.megatron_patches.patch_torch_load",


### PR DESCRIPTION
There have been instances where training runs fail (and occassionally recover) when saving checkpoints (see [this run](https://modal.com/apps/modal-labs/training-gym/ap-3HIzDULTD1rnmijoBIqYEd?activeTab=logs&start=1788478856&end=1788482503) as part of the weekly synmon). This is suspected to occur in roughly 1 in 10 runs.

After some searching, chat came across [this Megatron PR](https://github.com/NVIDIA/Megatron-LM/pull/3633), which our [pinned Slime version](https://github.com/modal-projects/training-gym/blob/main/modal_training_gym/frameworks/slime/launcher.py#L114-L115) doesn't include as it itself pins an older Megatron version ([last commit updating the Megatron version in Slime](https://github.com/THUDM/slime/commit/f3e7bd7f3091d3be05c20977eefb31a785d6221d)).

This PR patches Megatron accordingly.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->