### PR TITLE
Write torch_dist checkpoint shards from threads, and reject partial saves

### DIFF
--- a/modal_training_gym/common/megatron_patches/patch_ckpt_writer_threads.py
+++ b/modal_training_gym/common/megatron_patches/patch_ckpt_writer_threads.py
@@ -1,0 +1,181 @@
+"""Write torch_dist checkpoint shards from threads instead of forked processes.
+
+Megatron's ``FileSystemWriterAsync.write_preloaded_data_multiproc`` forks one
+worker process per write bucket, on every rank, at every save. Inside a Modal
+container that is already running Megatron ranks, SGLang engines, Ray, and
+rollout thread pools, that ``os.fork()`` can fail with
+``BlockingIOError: [Errno 11] Resource temporarily unavailable``, which kills
+the save and the run with it (seen on Qwen3.6-27B, 2026-09-04).
+
+Upstream Megatron replaced the forked workers with threads for exactly this
+reason (NVIDIA/Megatron-LM#3633, "Add single-process checkpoint save to avoid
+forked multiprocessing"). This patch back-ports that behavior to the pinned
+image: the method keeps its name and signature, so ``get_save_function_and_args``
+and the async caller are untouched, and the per-bucket worker
+``write_preloaded_data`` is unchanged -- it already talks to its queues through
+``put``/``get``/``task_done``, which ``queue.Queue`` provides just as
+``multiprocessing`` queues do.
+
+Executed at image-build time via ``python3 <this file> [path]``.
+"""
+
+import pathlib
+import re
+import sys
+
+DEFAULT_PATH = (
+    "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/filesystem_async.py"
+)
+MARKER = "write(sync,threads)"
+
+METHOD_PATTERN = re.compile(
+    r"^    @staticmethod\n"
+    r"(?:    @_disable_gc\(\)\n)?"
+    r"    def write_preloaded_data_multiproc\((?P<signature>.*?)\)(?P<returns> -> None)?:\n"
+    r".*?"
+    r"(?=^    @staticmethod\n)",
+    re.MULTILINE | re.DOTALL,
+)
+
+THREADED_METHOD = '''    @staticmethod
+    @_disable_gc()
+    def write_preloaded_data_multiproc({signature}) -> None:
+        """
+        Performs saving data to storage with multiple threads.
+
+        Patched by modal-training-gym: the upstream version forks one process per
+        write bucket, which fails with EAGAIN in process-heavy containers. Threads
+        preserve the parallel write and the queue protocol the worker expects.
+        """
+        logger = logging.getLogger(__name__)
+        w_start = time()
+        write_results_or_exc: Union[dict, Exception] = dict()
+        local_results_queue: queue.Queue = queue.Queue()
+        count_queue: queue.Queue = queue.Queue()
+        thread_list: List[threading.Thread] = []
+        for i, write_bucket in enumerate(write_buckets):
+            try:
+                count_queue.put(i)
+                kwargs = {{
+                    "local_proc_idx": i,
+                    "write_bucket": write_bucket,
+                    "results_queue": local_results_queue,
+                    "count_queue": count_queue,
+                    "use_fsync": True,
+                }}
+{msc_block}
+                thread_list.append(
+                    threading.Thread(
+                        target=partial({worker_target}),
+                        kwargs=kwargs,
+                        name=f"ckpt-writer-{{i}}",
+                    )
+                )
+            except Exception as e:
+                err_msg = f"An error is caught while a worker {{i}} is created, error: {{e}}"
+                logger.error(err_msg)
+                write_results_or_exc = RuntimeError(err_msg)
+
+        if not isinstance(write_results_or_exc, Exception):
+            for t in thread_list:
+                t.start()
+
+            logger.debug("FileSystemWriterAsync: collecting worker results...")
+
+            # Every worker takes its ticket back off ``count_queue`` and marks it
+            # done, so ``join`` returns once all buckets are written.
+            count_queue.join()
+            for _ in range(len(write_buckets)):
+                try:
+                    local_proc_idx, local_results_or_exc = local_results_queue.get_nowait()
+                except queue.Empty:
+                    write_results_or_exc = RuntimeError(
+                        "Unexpected empty `local_results_queue`"
+                        f" (expected {{len(write_buckets)}} items)"
+                    )
+                    break
+                if isinstance(local_results_or_exc, Exception):
+                    err_msg = (
+                        f"Local worker {{local_proc_idx}} encountered"
+                        f" an error: {{local_results_or_exc}}"
+                    )
+                    logger.error(err_msg)
+                    write_results_or_exc = local_results_or_exc
+                    break
+                assert isinstance(local_results_or_exc, list), type(local_results_or_exc)
+                write_results_or_exc[local_proc_idx] = local_results_or_exc
+            for t in thread_list:
+                t.join()
+
+            logger.debug("FileSystemWriterAsync: collected worker results successfully")
+
+        global_results_queue.put(write_results_or_exc)
+
+        w_end = time()
+        logger.debug(f"{{w_end}}, rank: {{rank}}, write(sync,threads): {{w_end - w_start}}")
+
+'''
+
+MSC_BLOCK = """
+                if use_msc:
+                    signature = inspect.signature(FileSystemWriterAsync.write_preloaded_data)
+                    if len(signature.parameters) > 6:
+                        kwargs["use_msc"] = use_msc
+"""
+
+
+def patch_source(src: str) -> str | None:
+    """Return the patched source, or ``None`` when there is nothing to do."""
+    if MARKER in src or "def write_preloaded_data_multithread" in src:
+        return None
+    match = METHOD_PATTERN.search(src)
+    if match is None:
+        raise SystemExit(
+            "patch_ckpt_writer_threads: write_preloaded_data_multiproc not found; "
+            "the Megatron checkpoint writer changed shape, refusing to guess"
+        )
+    signature = " ".join(match.group("signature").split()).rstrip(",").rstrip()
+    params = [p.split(":")[0].strip() for p in signature.split(",") if p.strip()]
+    for required in ("rank", "write_buckets", "global_results_queue"):
+        if required not in params:
+            raise SystemExit(
+                f"patch_ckpt_writer_threads: unexpected signature ({signature!r})"
+            )
+    worker = "FileSystemWriterAsync.write_preloaded_data"
+    worker_target = (
+        f"{worker}, transform_list" if "transform_list" in params else worker
+    )
+    method = THREADED_METHOD.format(
+        signature=signature,
+        msc_block=MSC_BLOCK.rstrip("\n") if "use_msc" in params else "",
+        worker_target=worker_target,
+    )
+    patched = src[: match.start()] + method + src[match.end() :]
+    if not re.search(r"^import threading$", patched, re.MULTILINE):
+        patched = re.sub(
+            r"^import queue$",
+            "import queue\nimport threading",
+            patched,
+            count=1,
+            flags=re.MULTILINE,
+        )
+    if not re.search(r"^import queue$", patched, re.MULTILINE):
+        raise SystemExit(
+            "patch_ckpt_writer_threads: expected `import queue` in filesystem_async.py"
+        )
+    compile(patched, "filesystem_async.py", "exec")
+    return patched
+
+
+def main(argv: list[str]) -> None:
+    path = pathlib.Path(argv[1] if len(argv) > 1 else DEFAULT_PATH)
+    patched = patch_source(path.read_text())
+    if patched is None:
+        print("filesystem_async.py already writes checkpoint shards from threads")
+        return
+    path.write_text(patched)
+    print("Patched filesystem_async.py to write checkpoint shards from threads")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -132,8 +132,14 @@ _PATCH_DIST_CKPT_QUANTIZED_B64 = encode_patch(
     "patch_dist_ckpt_quantized", _MEGATRON_PATCHES
 )
 _PATCH_CHECKPOINT_SAVE_B64 = encode_patch("patch_checkpoint_save", _MEGATRON_PATCHES)
+_PATCH_CKPT_WRITER_THREADS_B64 = encode_patch(
+    "patch_ckpt_writer_threads", _MEGATRON_PATCHES
+)
 _MEGATRON_TORCH_STRATEGY_PY = (
     "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/torch.py"
+)
+_MEGATRON_FILESYSTEM_ASYNC_PY = (
+    "/root/Megatron-LM/megatron/core/dist_checkpointing/strategies/filesystem_async.py"
 )
 
 
@@ -358,6 +364,12 @@ def _build_miles_base_image(miles: MilesRecipe) -> Image:
                 f"echo {_PATCH_CHECKPOINT_SAVE_B64} | base64 -d | python3; "
                 f"else echo 'WARNING: {_MEGATRON_TORCH_STRATEGY_PY} not found, "
                 "skipping checkpoint-save patch'; fi"
+            ),
+            (
+                f"if test -f {_MEGATRON_FILESYSTEM_ASYNC_PY}; then "
+                f"echo {_PATCH_CKPT_WRITER_THREADS_B64} | base64 -d | python3; "
+                f"else echo 'WARNING: {_MEGATRON_FILESYSTEM_ASYNC_PY} not found, "
+                "skipping checkpoint-writer patch'; fi"
             ),
             *_REPORTING_PATCH_COMMANDS,
             f"echo {_PATCH_SUBSTEP_TIMING_B64} | base64 -d | python3",

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -124,6 +124,9 @@ _PATCH_MEGATRON_BRIDGE_B64 = encode_patch("patch_megatron_bridge", _SLIME_PATCHE
 _PATCH_TORCH_LOAD_B64 = encode_patch("patch_torch_load", _MEGATRON_PATCHES)
 _PATCH_GLOBAL_PLAN_B64 = encode_patch("patch_global_plan", _SLIME_PATCHES)
 _PATCH_CHECKPOINT_SAVE_B64 = encode_patch("patch_checkpoint_save", _MEGATRON_PATCHES)
+_PATCH_CKPT_WRITER_THREADS_B64 = encode_patch(
+    "patch_ckpt_writer_threads", _MEGATRON_PATCHES
+)
 _PATCH_ADVANTAGES_B64 = encode_patch("patch_advantages", _SLIME_PATCHES)
 _PATCH_BRIDGE_NONE_TASK_B64 = encode_patch("patch_bridge_none_task", _SLIME_PATCHES)
 _PATCH_GDN_PACKED_SEQ_B64 = encode_patch("patch_gdn_packed_seq", _MEGATRON_PATCHES)
@@ -193,6 +196,7 @@ _SLIME_EXTERNAL_PATCHES_B64 = (
     _PATCH_BRIDGE_NONE_TASK_B64,
     _PATCH_LOG_ELIDE_B64,
     _PATCH_DIST_CKPT_QUANTIZED_B64,
+    _PATCH_CKPT_WRITER_THREADS_B64,
 )
 
 
@@ -291,11 +295,25 @@ def _response_parser_path(model: Any) -> str:
 
 
 def _is_complete_torch_dist_checkpoint(path: str) -> bool:
+    """Whether ``path`` holds a *finished* torch_dist checkpoint.
+
+    ``.metadata`` is written last, by ``save_state_dict_async_finalize``, so its
+    presence is what separates a completed save from a crashed one. A save that
+    died mid-write leaves ``common.pt`` and the ``.distcp`` shards behind, so
+    those alone cannot tell the two apart: without the ``.metadata`` check a
+    retry resumes from the partial ``iter_*`` directory (Megatron then silently
+    ignores it and restarts from ``ref_load``), and a crashed conversion is
+    reported as a cache hit.
+    """
     try:
         names = os.listdir(path)
     except OSError:
         return False
-    return "common.pt" in names and any(name.endswith(".distcp") for name in names)
+    return (
+        ".metadata" in names
+        and "common.pt" in names
+        and any(name.endswith(".distcp") for name in names)
+    )
 
 
 _PIPELINE_SPLIT_FLAGS = (

--- a/tests/test_patch_ckpt_writer_threads.py
+++ b/tests/test_patch_ckpt_writer_threads.py
@@ -1,0 +1,149 @@
+"""The Megatron checkpoint-writer patch: threads instead of forked processes."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import queue
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = ROOT / "modal_training_gym/common/megatron_patches/patch_ckpt_writer_threads.py"
+FIXTURE = ROOT / "tests/testdata/megatron/filesystem_async.py.input"
+
+
+def _load_patch_module():
+    spec = importlib.util.spec_from_file_location("patch_ckpt_writer_threads", PATCH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def patched_source() -> str:
+    patched = _load_patch_module().patch_source(FIXTURE.read_text())
+    assert patched is not None
+    return patched
+
+
+def test_patch_replaces_forked_workers_with_threads(patched_source: str) -> None:
+    ast.parse(patched_source)
+    assert 'mp.get_context("fork")' not in patched_source
+    assert "ctx.Process(" not in patched_source
+    assert "threading.Thread(" in patched_source
+    assert re.search(r"^import threading$", patched_source, re.MULTILINE)
+    # The caller in get_save_function_and_args is untouched, so the method must
+    # keep its name and full signature.
+    assert (
+        "def write_preloaded_data_multiproc(transform_list: List[_StorageWriterTransforms], "
+        "use_msc: bool, rank: int, write_buckets: List[WriteBucket], "
+        "global_results_queue: mp.Queue) -> None:"
+    ) in patched_source
+    assert (
+        "partial(self.write_preloaded_data_multiproc, transform_list, self.use_msc)"
+        in (patched_source)
+    )
+
+
+def test_patch_is_idempotent(patched_source: str) -> None:
+    assert _load_patch_module().patch_source(patched_source) is None
+
+
+def test_patch_is_a_no_op_once_upstream_uses_threads() -> None:
+    upstream = "import queue\n\n\nclass FileSystemWriterAsync:\n    def write_preloaded_data_multithread(self):\n        pass\n"
+    assert _load_patch_module().patch_source(upstream) is None
+
+
+def test_patch_refuses_an_unrecognized_writer() -> None:
+    with pytest.raises(SystemExit, match="not found"):
+        _load_patch_module().patch_source(
+            "import queue\n\nclass FileSystemWriterAsync:\n    pass\n"
+        )
+
+
+def _exec_writer_class(patched_source: str, namespace: dict) -> type:
+    """Run the patched method and the unchanged worker against stub dependencies."""
+    start = patched_source.index(
+        "    @staticmethod\n    @_disable_gc()\n    def write_preloaded_data_multiproc("
+    )
+    class_body = patched_source[start:]
+    source = "class FileSystemWriterAsync:\n" + class_body
+    exec(compile(source, "patched_filesystem_async", "exec"), namespace)
+    return namespace["FileSystemWriterAsync"]
+
+
+def _stub_namespace() -> dict:
+    import inspect
+    import logging
+    import threading
+    from functools import partial
+    from time import time
+    from typing import List, Union
+
+    def _disable_gc():
+        return lambda fn: fn
+
+    def _write_item(stream, data, write_item, storage_key):
+        stream.write(data)
+        return ("written", write_item, storage_key)
+
+    return {
+        "_disable_gc": _disable_gc,
+        "_write_item": _write_item,
+        "_process_memory": lambda: 0,
+        "inspect": inspect,
+        "logging": logging,
+        "threading": threading,
+        "partial": partial,
+        "time": time,
+        "List": List,
+        "Union": Union,
+        "queue": queue,
+        "os": os,
+    }
+
+
+def test_threaded_writer_honors_the_worker_queue_protocol(
+    patched_source: str, tmp_path: Path
+) -> None:
+    writer = _exec_writer_class(patched_source, _stub_namespace())
+    buckets = [
+        (
+            str(tmp_path / f"__0_{i}.distcp"),
+            f"key{i}",
+            ([(f"item{i}", f"payload{i}".encode())], []),
+        )
+        for i in range(3)
+    ]
+    results: queue.Queue = queue.Queue()
+
+    writer.write_preloaded_data_multiproc([], False, 0, buckets, results)
+
+    written = results.get_nowait()
+    assert isinstance(written, dict)
+    assert sorted(written) == [0, 1, 2]
+    for i in range(3):
+        assert written[i] == [("written", f"item{i}", f"key{i}")]
+        assert (tmp_path / f"__0_{i}.distcp").read_bytes() == f"payload{i}".encode()
+    assert results.empty()
+
+
+def test_threaded_writer_propagates_a_worker_failure(
+    patched_source: str, tmp_path: Path
+) -> None:
+    writer = _exec_writer_class(patched_source, _stub_namespace())
+    buckets = [
+        (str(tmp_path / "__0_0.distcp"), "ok", ([("item", b"x")], [])),
+        (str(tmp_path / "missing-dir" / "__0_1.distcp"), "bad", ([("item", b"y")], [])),
+    ]
+    results: queue.Queue = queue.Queue()
+
+    writer.write_preloaded_data_multiproc([], False, 0, buckets, results)
+
+    outcome = results.get_nowait()
+    assert isinstance(outcome, FileNotFoundError)

--- a/tests/test_slime_resume_completeness.py
+++ b/tests/test_slime_resume_completeness.py
@@ -1,0 +1,47 @@
+"""A torch_dist save that died mid-write must not be treated as resumable."""
+
+from pathlib import Path
+
+from modal_training_gym.common.run import torch_dist_resume_checkpoint
+from modal_training_gym.frameworks.slime.launcher import (
+    _is_complete_torch_dist_checkpoint,
+)
+
+
+def _write(directory: Path, *names: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (directory / name).write_bytes(b"")
+
+
+def test_finished_save_is_complete(tmp_path: Path) -> None:
+    _write(tmp_path, ".metadata", "metadata.json", "common.pt", "__0_0.distcp")
+    assert _is_complete_torch_dist_checkpoint(str(tmp_path))
+
+
+def test_save_that_died_before_metadata_is_incomplete(tmp_path: Path) -> None:
+    _write(tmp_path, "common.pt", "__0_0.distcp", "__1_0.distcp")
+    assert not _is_complete_torch_dist_checkpoint(str(tmp_path))
+
+
+def test_missing_directory_is_incomplete(tmp_path: Path) -> None:
+    assert not _is_complete_torch_dist_checkpoint(str(tmp_path / "absent"))
+
+
+def test_partial_iter_dir_is_not_offered_for_resume(tmp_path: Path) -> None:
+    _write(tmp_path / "iter_0000001", "common.pt", "__0_0.distcp")
+    assert (
+        torch_dist_resume_checkpoint(
+            str(tmp_path), is_complete=_is_complete_torch_dist_checkpoint
+        )
+        is None
+    )
+
+
+def test_finished_iter_dir_is_offered_for_resume(tmp_path: Path) -> None:
+    _write(tmp_path / "iter_0000001", ".metadata", "common.pt", "__0_0.distcp")
+    resume = torch_dist_resume_checkpoint(
+        str(tmp_path), is_complete=_is_complete_torch_dist_checkpoint
+    )
+    assert resume is not None
+    assert resume["resume_from_iteration"] == 1

--- a/tests/testdata/megatron/filesystem_async.py.input
+++ b/tests/testdata/megatron/filesystem_async.py.input
@@ -1,0 +1,275 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+
+"""Storage writer for PyT Distributed format allowing asynchronous save."""
+
+import dataclasses
+import inspect
+import logging
+import os
+import pickle
+import queue
+from functools import partial
+from heapq import heappop, heappush
+from itertools import chain
+from operator import itemgetter
+from pathlib import Path
+from time import time
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+from torch import multiprocessing as mp
+from torch.distributed.checkpoint import FileSystemWriter
+from torch.distributed.checkpoint.api import WRAPPED_EXCEPTION, _wrap_exception
+from torch.distributed.checkpoint.filesystem import DEFAULT_SUFFIX, _StoragePrefix, _write_item
+from torch.distributed.checkpoint.metadata import Metadata
+
+try:
+    from torch.distributed.checkpoint.filesystem import _StorageWriterTransforms
+except ImportError:
+    _StorageWriterTransforms = Any
+
+from torch.distributed.checkpoint.planner import SavePlan, SavePlanner, WriteItem, WriteItemType
+from torch.distributed.checkpoint.storage import WriteResult
+from torch.futures import Future
+
+from .async_utils import _disable_gc
+
+logger = logging.getLogger(__name__)
+
+WriteBucket = Tuple[Path, str, Tuple[list, list]]  # represents writes to a single file
+
+
+
+class FileSystemWriterAsync(FileSystemWriter):
+    """Excerpt of NVIDIA/Megatron-LM filesystem_async.py at a7c207f8 (pre-#3633)."""
+
+
+    def get_save_function_and_args(self) -> Tuple[Optional[Callable], Optional[Callable], List]:
+        """
+        Get function that saves the data to storage along with its arguments.
+        Allows the external caller to apply the save function synchronously or asynchronously.
+
+        Returns: None (if there is nothing to write on this rank) or a tuple of:
+            1) the function that saves the data.
+            2) the function that stages the GPU tensors to a destination for async checkpointing.
+               This function should be self-contained.
+            3) arguments to that function in 1).
+        """
+        if not self.write_buckets:
+            return None, None, []
+        transform_list = [self.transforms] if hasattr(self, "transforms") else []
+        return (
+            partial(self.write_preloaded_data_multiproc, transform_list, self.use_msc),
+            partial(self.preload_tensors, self.write_buckets, True),
+            [torch.distributed.get_rank(), self.write_buckets, self.results_queue],
+        )
+
+    @staticmethod
+    def preload_tensors(write_buckets: List[WriteBucket], non_blocking=True) -> List[WriteBucket]:
+        """
+        Preloads tensors in `state_dict` to host memory via CPU memory.
+
+        Args:
+            write_buckets (List): List of `WriteBucket` objects that define what to
+                save in a checkpoint.
+            non_blocking (bool, optional): knob to enable pinned D2H memcpy. Default is True.
+        """
+        result = []
+
+        for bucket in write_buckets:
+            file_name, storage_key, (bytes_data, tensor_data) = bucket
+            tensor_data = [
+                (item, tensor.to("cpu", non_blocking=non_blocking)) for item, tensor in tensor_data
+            ]
+            result.append((file_name, storage_key, (bytes_data, tensor_data)))
+        if non_blocking:
+            torch.cuda.synchronize()
+        return result
+
+    @staticmethod
+    @_disable_gc()
+    def write_preloaded_data_multiproc(
+        transform_list: List[_StorageWriterTransforms],
+        use_msc: bool,
+        rank: int,
+        write_buckets: List[WriteBucket],
+        global_results_queue: mp.Queue,
+    ) -> None:
+        """
+        Performs saving data to storage with multiple processes.
+
+        Starts predefined number of processes and uses 2 queues to make sure the results
+        are complete:
+        - local_results_queue - to send the actual results
+        - count_queue - small queue to mark worker as completed
+
+        Using just one queue disallowed proper exception handling.
+
+        This method is meant to be run in a forked subprocess.
+        Triggering GC during execution leads to CUDA errors
+        (cleaning up tensors owned by the parent process).
+        To prevent this, we disable the GC explicitly for this function with _disable_gc.
+
+        Args:
+            write_buckets (List[WriteBucket]): write plan
+            global_results_queue (mp.Queue): mp.Queue to collect Dict[List[WriteResults]]
+                (or an Exception) from parallel write processes to the main training process
+        Returns: None
+        """
+        logger = logging.getLogger(__name__)
+        w_start = time()
+        write_results_or_exc: Union[dict, Exception] = dict()
+        ctx = mp.get_context("fork")
+        local_results_queue = ctx.Queue()
+        count_queue = ctx.JoinableQueue()
+        p_list = []
+        for i, write_bucket in enumerate(write_buckets):
+            try:
+                count_queue.put(i)
+
+                kwargs = {
+                    "local_proc_idx": i,
+                    "write_bucket": write_bucket,
+                    "results_queue": local_results_queue,
+                    "count_queue": count_queue,
+                    "use_fsync": True,
+                }
+
+                if use_msc:
+                    import inspect
+
+                    # Remove the inspect after the test_async_save.py is fixed.
+                    signature = inspect.signature(FileSystemWriterAsync.write_preloaded_data)
+                    if len(signature.parameters) > 6:
+                        kwargs["use_msc"] = use_msc
+
+                p_list.append(
+                    ctx.Process(
+                        target=partial(FileSystemWriterAsync.write_preloaded_data, transform_list),
+                        kwargs=kwargs,
+                    )
+                )
+            except Exception as e:
+                err_msg = f"An error is caught while a proc {i} is created, error: {e}"
+                logger.error(err_msg)
+                write_results_or_exc = RuntimeError(err_msg)
+
+        if not isinstance(write_results_or_exc, Exception):
+            for p in p_list:
+                p.start()
+
+            logger.debug("FileSystemWriterAsync: collecting worker results...")
+
+            # To make sure all nodes are completed
+            count_queue.join()
+            # At this point, all workers completed, so the queue should have exactly
+            # `len(write_buckets)` items
+            for proc_idx in range(len(write_buckets)):
+                try:
+                    local_proc_idx, local_results_or_exc = local_results_queue.get()
+                except queue.Empty:
+                    write_results_or_exc = RuntimeError(
+                        "Unexpected empty `local_results_queue`"
+                        f" (got only {proc_idx}/{len(write_buckets)} items)"
+                    )
+                    break
+                else:
+                    if isinstance(local_results_or_exc, Exception):
+                        err_msg = (
+                            f"Local process {local_proc_idx} encountered"
+                            f" an error: {local_results_or_exc}"
+                        )
+                        logger.error(err_msg)
+                        write_results_or_exc = local_results_or_exc
+                        break
+                    assert isinstance(local_results_or_exc, list), type(local_results_or_exc)
+                    write_results_or_exc[local_proc_idx] = local_results_or_exc
+                    p_list[local_proc_idx].join()
+
+            logger.debug("FileSystemWriterAsync: collected worker results successfully")
+
+        global_results_queue.put(write_results_or_exc)
+
+        w_end = time()
+        logger.debug(f"{w_end}, rank: {rank}, write(sync,parallel): {w_end - w_start}")
+
+    @staticmethod
+    @_disable_gc()
+    def write_preloaded_data(
+        transform_list: List[_StorageWriterTransforms],
+        local_proc_idx: int,
+        write_bucket: WriteBucket,
+        results_queue: mp.SimpleQueue,
+        count_queue: mp.JoinableQueue,
+        use_fsync: bool,
+        **kwargs,
+    ) -> None:
+        """
+        Performs actual data saving to storage.
+
+        Args:
+            local_proc_idx (int): index of a local process that performs writing
+            write_bucket (WriteBucket): data to write to storage
+            results_queue (mp.Queue): queue to return the write results
+                to the proxy checkpoint process.
+            count_queue (mp.JoinableQueue): queue to marks worker task as completed
+            use_fsync (bool): if True, calls os.fsync at the end of saving
+
+        Returns: None, the write result are put into the `queue`
+        """
+        logger = logging.getLogger(__name__)
+        logger.debug(f"{local_proc_idx} started")
+        mem_before = _process_memory()
+        use_msc = kwargs.get("use_msc", False)
+
+        local_results = []
+        try:
+            file_name, storage_key, (bytes_data, tensor_data) = write_bucket
+            extra_kwargs = {}
+            if "serialization_format" in inspect.signature(_write_item).parameters:
+                from torch.distributed.checkpoint.filesystem import SerializationFormat
+
+                extra_kwargs["serialization_format"] = SerializationFormat.TORCH_SAVE
+            if use_msc:
+                import multistorageclient as msc
+
+                open_file = msc.open
+            else:
+                open_file = open
+            with open_file(file_name, "wb") as stream:
+                for write_item, data in bytes_data:
+                    local_results.append(
+                        _write_item(
+                            *transform_list, stream, data, write_item, storage_key, **extra_kwargs
+                        )
+                    )
+
+                for write_item, tensor in tensor_data:
+                    assert tensor.is_cpu
+                    local_results.append(
+                        _write_item(
+                            *transform_list, stream, tensor, write_item, storage_key, **extra_kwargs
+                        )
+                    )
+
+                if use_fsync:
+                    if use_msc:
+                        stream.fsync()
+                    else:
+                        os.fsync(stream.fileno())
+            local_output = (local_proc_idx, local_results)
+        except Exception as e:
+            logger.debug(f"{local_proc_idx} failed")
+            local_output = (local_proc_idx, e)  # type: ignore[assignment]
+
+        results_queue.put(local_output)
+        # Signal this process is done.
+        count_queue.get()
+        count_queue.task_done()
+
+        mem_after = _process_memory()
+        logger.debug(
+            f"{local_proc_idx} consumed: {mem_after - mem_before},"
+            f" before: {mem_before}, after: {mem_after}"
+        )
+


### PR DESCRIPTION
## Problem

Run `green-poodle-f5c489546992` (Qwen3.6-27B agentic smoke, one colocated 8×H200 node) trained both rollouts and then died at the final checkpoint save, twice in a row, with:

```
File ".../megatron/core/dist_checkpointing/strategies/filesystem_async.py", line 308, in write_preloaded_data_multiproc
File "/usr/lib/python3.12/multiprocessing/popen_fork.py", line 66, in _launch
    self.pid = os.fork()
BlockingIOError: [Errno 11] Resource temporarily unavailable
```

Megatron's `FileSystemWriterAsync.write_preloaded_data_multiproc` forks one worker process per write bucket, on every rank, at every save. In a container already running Megatron ranks, SGLang engines, Ray, and rollout thread pools, the fork can fail. The identical config saved fine the day before (`funny-interface-d2a700808798`), so this is environmental and intermittent, which is the worst kind. Upstream Megatron replaced the forked workers with threads for the same reason in NVIDIA/Megatron-LM#3633 (Feb 2026); the pinned image predates that.

The crashed save also exposed a second gap: `iter_0000001/` was left with `.distcp` shards and `common.pt` but no `.metadata`, and the slime launcher's `_is_complete_torch_dist_checkpoint` accepted it. The retry set `--load` to the partial directory, Megatron ignored it, and training silently restarted from `ref_load` at rollout 0.

## Changes

- **`common/megatron_patches/patch_ckpt_writer_threads.py`**: image-build patch that rewrites `write_preloaded_data_multiproc` to run the per-bucket workers in threads. Method name, signature, and the worker's queue protocol are unchanged, so `get_save_function_and_args` and the async caller are untouched. It is a no-op on a Megatron that already has upstream's threaded writer, idempotent, and refuses (fails the build) if the method has an unrecognized shape rather than guessing.
- Wired into the slime base image (Megatron-side patch list, survives the git overlay) and the miles image (guarded on the file existing, like the checkpoint-save patch).
- **Slime `_is_complete_torch_dist_checkpoint`** now requires `.metadata`, matching what the miles launcher already does.

## Verification

- Unit tests: the patch applied to an excerpt of pre-#3633 Megatron (`tests/testdata/megatron/filesystem_async.py.input`) removes the fork, keeps the signature, is idempotent, no-ops on the upstream threaded version, and refuses an unknown shape. The patched method is also executed against the unchanged worker with stub I/O: three buckets write and report through the queues, and a failing bucket propagates its exception. Completeness tests cover finished, partial, and missing directories plus the resume scan.
- The patch applies cleanly to the real pinned image at build time (`Patched filesystem_async.py to write checkpoint shards from threads`, right after the existing #3845 backport).
- Full suite: 929 passed, 1 skipped. ruff clean.
- End-to-end: a rerun of the same smoke with this fix is in progress; I'll post the outcome here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->