### PR TITLE
Render flattened multi-turn transcripts on the dashboard instead of a blank response

### DIFF
--- a/modal_training_gym/common/dashboard.py
+++ b/modal_training_gym/common/dashboard.py
@@ -17,7 +17,7 @@ DASHBOARD_PREVIEW_ENV_KEY = "TRAINING_GYM_DASHBOARD_PREVIEW"
 DASHBOARD_VERSION_ENV_KEY = "DASHBOARD_VERSION"
 
 # Bump when the deployed dashboard frontend or backend changes.
-DASHBOARD_VERSION = 1
+DASHBOARD_VERSION = 2
 
 
 def current_dashboard_version() -> str:

--- a/modal_training_gym/common/sample_extraction.py
+++ b/modal_training_gym/common/sample_extraction.py
@@ -667,6 +667,17 @@ def _sample_to_dict(
                 continue
             if _is_small_json_value(value):
                 metadata[key] = value
+            elif isinstance(value, dict):
+                # One oversized entry (an agent loop stashing its full prompt
+                # next to its turn counts and timings) should not erase the
+                # whole tag; keep the sub-entries that fit on their own.
+                compact = {
+                    sub_key: sub_value
+                    for sub_key, sub_value in value.items()
+                    if sub_value is not None and _is_small_json_value(sub_value)
+                }
+                if compact and _is_small_json_value(compact):
+                    metadata[key] = compact
         # Multi-turn trajectory (capped to the first N samples): lets the
         # dashboard's ConversationView render the full agent conversation.
         # Without it, multi-turn rollouts collapse to a single flat block.

--- a/modal_training_gym/common/training_rollout.py
+++ b/modal_training_gym/common/training_rollout.py
@@ -102,19 +102,66 @@ def _clean_prompt(text: str) -> str:
     return re.sub(r"\n{3,}", "\n\n", cleaned).strip()
 
 
+# A multi-turn agent loop that appends later turns to the response verbatim
+# (chat-template tokens included) yields one flat string per episode:
+#   {assistant}<|im_end|>\n<|im_start|>user\n<tool_response>...</tool_response><|im_end|>\n
+#   <|im_start|>assistant\n<think>...</think>...<tool_call>...</tool_call><|im_end|>...
+_CHAT_TURN_RE = re.compile(r"<\|im_start\|>(\w+)\n")
+_TOOL_RESPONSE_RE = re.compile(
+    r"^\s*<tool_response>\s*(.*?)\s*</tool_response>\s*$", re.DOTALL
+)
+
+
+def _transcript_messages(text: str) -> list[dict[str, str]] | None:
+    """Split a flattened multi-turn chat transcript into role-tagged messages.
+
+    Returns ``None`` for a plain single-turn response. A ``user`` turn that is
+    nothing but a ``<tool_response>`` block is the environment answering a tool
+    call, so it is tagged ``tool`` and unwrapped for display.
+    """
+    if "<|im_start|>" not in text:
+        return None
+    pieces = _CHAT_TURN_RE.split(text)
+    turns = [("assistant", pieces[0]), *zip(pieces[1::2], pieces[2::2])]
+    messages: list[dict[str, str]] = []
+    for role, body in turns:
+        body = body.replace("<|im_end|>", "").replace("<|endoftext|>", "").strip()
+        if not body:
+            continue
+        if role == "user" and (match := _TOOL_RESPONSE_RE.match(body)):
+            role, body = "tool", match.group(1)
+        messages.append({"role": role, "content": body})
+    return messages if len(messages) > 1 else None
+
+
 def _apply_parsed(rows: object) -> None:
     if not isinstance(rows, list):
         return
     for row in rows:
         if not isinstance(row, dict):
             continue
+        raw = row.get("response")
+        transcript = _transcript_messages(raw) if isinstance(raw, str) else None
+        if transcript:
+            metadata = row.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+                row["metadata"] = metadata
+            # The dashboard renders trajectory_messages turn by turn (roles,
+            # per-turn thinking, tool calls); a rollout hook that already
+            # recorded its own structured trajectory wins.
+            metadata.setdefault("trajectory_messages", transcript)
         parsed = row.get("parsed_response")
         if isinstance(parsed, dict) and isinstance(parsed.get("content"), str):
-            raw = row.get("response")
             if isinstance(raw, str):
                 row["raw_response"] = raw
-            row["response"] = parsed.get("content") or ""
-            if parsed.get("thinking"):
+            # The parser sees a single turn, so for a transcript its content is
+            # the last turn's text, which is empty when that turn is a tool
+            # call. Never replace a real response with nothing.
+            row["response"] = parsed.get("content") or (
+                raw if isinstance(raw, str) else ""
+            )
+            if parsed.get("thinking") and not transcript:
                 row["thinking"] = parsed["thinking"]
             if parsed.get("tool_calls"):
                 row["tool_calls"] = parsed["tool_calls"]

--- a/tests/test_multiturn_transcript_display.py
+++ b/tests/test_multiturn_transcript_display.py
@@ -1,0 +1,121 @@
+"""Flattened multi-turn agent transcripts render turn by turn on the dashboard."""
+
+from __future__ import annotations
+
+from modal_training_gym.common.sample_extraction import _sample_to_dict
+from modal_training_gym.common.training_rollout import (
+    _apply_parsed,
+    _transcript_messages,
+)
+
+# The shape the agentic Slime fork writes: the first assistant turn opens the
+# string, later turns are appended verbatim with chat-template tokens.
+TRANSCRIPT = (
+    "<think>\nExplore first.\n</think>\n\nI'll look around.\n\n"
+    "<tool_call>\n<function=bash>\n<parameter=command>\nls /app\n</parameter>\n"
+    "</function>\n</tool_call><|im_end|>\n"
+    "<|im_start|>user\n<tool_response>\n<returncode>0</returncode>\n<output>\ncel\nREADME.md\n"
+    "</output>\n</tool_response><|im_end|>\n"
+    "<|im_start|>assistant\n<think>\nNow read the README.\n</think>\n\n"
+    "<tool_call>\n<function=bash>\n<parameter=command>\ncat /app/README.md\n</parameter>\n"
+    "</function>\n</tool_call><|im_end|>"
+)
+
+
+def test_transcript_splits_into_role_tagged_turns() -> None:
+    messages = _transcript_messages(TRANSCRIPT)
+
+    assert messages is not None
+    assert [m["role"] for m in messages] == ["assistant", "tool", "assistant"]
+    assert messages[0]["content"].startswith("<think>\nExplore first.")
+    assert "<|im_end|>" not in messages[0]["content"]
+    # The environment's reply is unwrapped from its <tool_response> envelope.
+    assert (
+        messages[1]["content"]
+        == "<returncode>0</returncode>\n<output>\ncel\nREADME.md\n</output>"
+    )
+    assert messages[2]["content"].startswith("<think>\nNow read the README.")
+
+
+def test_single_turn_response_is_not_a_transcript() -> None:
+    assert _transcript_messages("<think>hmm</think>The answer is 4.") is None
+    assert _transcript_messages("") is None
+
+
+def test_display_never_blanks_a_transcript_whose_last_turn_is_a_tool_call() -> None:
+    # What the recorder stores: the model parser saw only the final turn, whose
+    # text is empty once its tool call is stripped.
+    row = {
+        "response": TRANSCRIPT,
+        "parsed_response": {
+            "content": "",
+            "thinking": "Now read the README.",
+            "tool_calls": [
+                {"name": "bash", "arguments": {"command": "cat /app/README.md"}}
+            ],
+        },
+        "metadata": {"instance_id": "task-1"},
+    }
+
+    _apply_parsed([row])
+
+    assert row["response"] == TRANSCRIPT
+    assert row["raw_response"] == TRANSCRIPT
+    assert [m["role"] for m in row["metadata"]["trajectory_messages"]] == [
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    # Per-turn thinking lives in the trajectory; no stray top-level block.
+    assert "thinking" not in row
+    assert row["tool_calls"][0]["name"] == "bash"
+    assert row["metadata"]["instance_id"] == "task-1"
+
+
+def test_display_keeps_a_hook_supplied_trajectory() -> None:
+    supplied = [{"role": "assistant", "content": "structured"}]
+    row = {"response": TRANSCRIPT, "metadata": {"trajectory_messages": supplied}}
+
+    _apply_parsed([row])
+
+    assert row["metadata"]["trajectory_messages"] is supplied
+
+
+def test_single_turn_display_is_unchanged() -> None:
+    row = {
+        "response": "<think>secret</think>raw answer",
+        "parsed_response": {"content": "raw answer", "thinking": "secret"},
+    }
+
+    _apply_parsed([row])
+
+    assert row["response"] == "raw answer"
+    assert row["raw_response"] == "<think>secret</think>raw answer"
+    assert row["thinking"] == "secret"
+    assert "trajectory_messages" not in row.get("metadata", {})
+
+
+def test_oversized_metadata_tag_keeps_its_small_entries() -> None:
+    sample = {
+        "prompt": "p",
+        "response": "r",
+        "reward": 0.0,
+        "metadata": {
+            "agentic": {
+                "turns": 2,
+                "is_solved": False,
+                "timing": {"boot": 9.2, "verifier": 8.2},
+                "full_prompt": "x" * 5000,
+            },
+            "note": "y" * 5000,
+        },
+    }
+
+    out = _sample_to_dict(sample)
+
+    assert out["metadata"]["agentic"] == {
+        "turns": 2,
+        "is_solved": False,
+        "timing": {"boot": 9.2, "verifier": 8.2},
+    }
+    assert "note" not in out["metadata"]


### PR DESCRIPTION
## Problem

Opening a rollout of an agentic run (`dynamic-raid-941a9eaf1379`, the Qwen3.6-27B Harbor smoke) on the dashboard shows the prompt but no response. The data is recorded: every sample on the metadata volume has a 900 to 3000 character response. It is the display path that blanks it.

The agentic Slime fork appends later turns to `sample.response` verbatim, chat-template tokens included:

```
{assistant}<|im_end|>
<|im_start|>user
<tool_response>...</tool_response><|im_end|>
<|im_start|>assistant
<think>...</think>
<tool_call>...</tool_call><|im_end|>
```

At record time `parsed_response` is computed with the model's parser, which is single-turn: it keeps only the text after the last `<|im_start|>assistant`, and once the tool call is stripped that is `""`. At serve time `_apply_parsed` does `row["response"] = parsed["content"] or ""`, so the API returns an empty response, and `ConversationView` (no `trajectory_messages`, empty `response`) renders nothing. Same for every earlier run of this recipe and for `multiturn_slime`, whose dashboard changes were Trackio links only.

## Changes

- `training_rollout._transcript_messages` splits a flattened transcript into role-tagged messages; a `user` turn that is only a `<tool_response>` block becomes `tool` and is unwrapped. `_apply_parsed` stores them as `metadata.trajectory_messages` (a hook-supplied trajectory wins), never replaces a real response with empty parsed content, and skips the top-level `thinking` for transcripts since each turn carries its own. The frontend already renders `trajectory_messages` turn by turn with per-turn thinking toggles and tool calls, so no frontend change.
- `sample_extraction._sample_to_dict`: an oversized metadata tag that is a dict keeps its small entries instead of vanishing. The fork's `agentic` tag (turns, timings, `is_solved`, outcome) was being dropped because it also carries the episode's full prompt.
- `DASHBOARD_VERSION` 1 to 2 so `ensure_dashboard_deployed()` redeploys.

## Verification

- Applied `_apply_parsed` to the actual recorded rollout of `dynamic-raid-941a9eaf1379`: both samples split into `assistant` / `tool` / `assistant` turns with the tool output unwrapped, response kept, no stray top-level thinking.
- New tests cover the transcript split, the blank-response regression, a hook-supplied trajectory taking precedence, the unchanged single-turn path, and the metadata compaction. Existing route and CLI display tests pass unchanged.
- Full suite: 923 passed, 1 skipped. ruff clean.

Fixes the display for already recorded runs once the dashboard is redeployed (`training-gym setup`, or automatically on the next launch from a checkout with this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->