### PR TITLE
Avoid duplicate W&B tags in training apps

### DIFF
--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -169,10 +169,8 @@ def build_app_tags(
         tags["_modal_metric_project"] = modal_tag_value(metrics.project)
         if metrics.group:
             tags["_modal_metric_group"] = modal_tag_value(metrics.group)
-        if metrics.provider == "wandb":
-            tags["_modal_wandb_project"] = modal_tag_value(metrics.project)
-            if metrics.group:
-                tags["_modal_wandb_group"] = modal_tag_value(metrics.group)
+        # Provider-neutral tags already identify W&B. Duplicating the project
+        # and group as legacy W&B tags exceeds Modal's eight-tag limit.
     return tags
 
 

--- a/tests/test_wandb_preflight.py
+++ b/tests/test_wandb_preflight.py
@@ -107,7 +107,7 @@ def test_wandb_config_uses_the_provider_neutral_recipe_field():
     with pytest.raises(TypeError, match="abstract"):
         MetricConfig()
 
-    metric = WandbConfig(project="training")
+    metric = WandbConfig(project="training", group="experiment")
     recipe = Qwen3_4B_Recipe(metrics=metric)
 
     assert isinstance(metric, MetricConfig)
@@ -121,4 +121,6 @@ def test_wandb_config_uses_the_provider_neutral_recipe_field():
         metrics=metric,
     )
     assert tags["_modal_metric_project"] == "training"
-    assert tags["_modal_wandb_project"] == "training"
+    assert tags["_modal_metric_group"] == "experiment"
+    assert "_modal_wandb_project" not in tags
+    assert len(tags) <= 8


### PR DESCRIPTION
Training apps with a W&B project and group can exceed Modal’s eight-tag limit before any worker starts. Remove the duplicate legacy W&B tags; the existing provider, project, and group tags retain the same metadata.

Validation: 5 W&B/preflight tests pass, including a grouped run within the tag limit; Ruff and diff checks pass. The corrected launcher also passed app creation on Modal.

The example-specific template checklist does not apply to this SDK fix.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->