### PR TITLE
Honor explicit single-rank checkpoint conversion overrides

### DIFF
--- a/modal_training_gym/common/launcher_utils.py
+++ b/modal_training_gym/common/launcher_utils.py
@@ -188,7 +188,8 @@ def get_checkpoint_conversion_policy(
     attribute is populated (the model script already sources them).
 
     TP/PP come from the ``conversion_*`` overrides when set, else from the training
-    layout. EP/ETP are emitted only when their ``conversion_*`` fields are set
+    layout. Explicit TP1/PP1 uses one rank instead of the automatic node-wide
+    conversion. EP/ETP are emitted only when their ``conversion_*`` fields are set
     explicitly, and the pipeline-split args are dropped at conversion PP1.
     """
     gpus_per_node = getattr(cfg, "actor_num_gpus_per_node", 8)
@@ -200,6 +201,12 @@ def get_checkpoint_conversion_policy(
     )
     pp = getattr(cfg, "conversion_pipeline_model_parallel_size", None) or getattr(
         cfg, "pipeline_model_parallel_size", 1
+    )
+    pins_layout = (
+        tp > 1
+        or pp > 1
+        or getattr(cfg, "conversion_tensor_model_parallel_size", None) is not None
+        or getattr(cfg, "conversion_pipeline_model_parallel_size", None) is not None
     )
     # Expert parallelism is opt-in: torch_dist reshards, so most models convert fine
     # at the implicit EP1. Models whose full expert set does not fit a rank at EP1
@@ -214,7 +221,7 @@ def get_checkpoint_conversion_policy(
             "Megatron otherwise defaults ETP to TP and the expert world size no "
             "longer matches tp*pp"
         )
-    if ep and etp and not (tp > 1 or pp > 1):
+    if ep and etp and not pins_layout:
         raise ValueError(
             "checkpoint conversion expert parallelism needs a pinned conversion "
             "layout: set conversion_tensor_model_parallel_size or "
@@ -225,7 +232,7 @@ def get_checkpoint_conversion_policy(
     if single_rank_mtp and tp == 1 and pp == 1 and getattr(cfg, "mtp_num_layers", 0):
         world_size = 1
     else:
-        world_size = tp * pp if (tp > 1 or pp > 1) else gpus_per_node
+        world_size = tp * pp if pins_layout else gpus_per_node
 
     if ep and etp and world_size % (etp * ep * pp) != 0:
         raise ValueError(
@@ -247,7 +254,6 @@ def get_checkpoint_conversion_policy(
             continue
 
         extra_args: list[str] = []
-        pins_layout = tp > 1 or pp > 1
         if pins_layout:
             extra_args += [
                 f"--tensor-model-parallel-size {tp}",
@@ -266,7 +272,9 @@ def get_checkpoint_conversion_policy(
             # dropping the split would then describe a layout nobody asked for.
             if pp == 1 and pins_layout and attr in _PIPELINE_SPLIT_ARGS:
                 continue
-            if x := getattr(cfg, attr, None):
+            # Zero is meaningful for MTP: it overrides model-script defaults
+            # during conversion just as the recipe does during training.
+            if (x := getattr(cfg, attr, None)) is not None:
                 extra_args.append(f"--{flag} {x}")
 
         emit_arch = bool(model and getattr(model, "architecture", None))

--- a/tests/test_checkpoint_conversion_policy.py
+++ b/tests/test_checkpoint_conversion_policy.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import pytest
+
+from modal_training_gym.common.launcher_utils import get_checkpoint_conversion_policy
+
+
+def test_implicit_single_rank_layout_keeps_automatic_conversion():
+    assert get_checkpoint_conversion_policy(SimpleNamespace())[:2] == (1, 8)
+
+
+@pytest.mark.parametrize("override", ["tensor", "pipeline"])
+def test_explicit_one_disables_automatic_conversion_parallelism(override):
+    cfg = SimpleNamespace(**{f"conversion_{override}_model_parallel_size": 1})
+    nodes, processes, args = get_checkpoint_conversion_policy(cfg)
+    assert (nodes, processes) == (1, 1)
+    assert args == [
+        "--tensor-model-parallel-size 1",
+        "--pipeline-model-parallel-size 1",
+    ]
+
+
+def test_explicit_tp1_pp1_overrides_sharded_training_and_drops_pipeline_split():
+    cfg = SimpleNamespace(
+        tensor_model_parallel_size=4,
+        pipeline_model_parallel_size=2,
+        conversion_tensor_model_parallel_size=1,
+        conversion_pipeline_model_parallel_size=1,
+        conversion_expert_model_parallel_size=1,
+        conversion_expert_tensor_parallel_size=1,
+        decoder_first_pipeline_num_layers=10,
+        mtp_num_layers=0,
+    )
+    nodes, processes, args = get_checkpoint_conversion_policy(cfg)
+    assert (nodes, processes) == (1, 1)
+    assert "--expert-model-parallel-size 1" in args
+    assert "--expert-tensor-parallel-size 1" in args
+    assert "--mtp-num-layers 0" in args
+    assert not any("pipeline-num-layers" in arg for arg in args)
+
+
+@pytest.mark.parametrize("mtp", [None, 0, 1])
+def test_mtp_none_is_omitted_but_zero_is_an_override(mtp):
+    args = get_checkpoint_conversion_policy(SimpleNamespace(mtp_num_layers=mtp))[2]
+    assert [arg for arg in args if arg.startswith("--mtp-num-layers")] == (
+        [] if mtp is None else [f"--mtp-num-layers {mtp}"]
+    )
+
+
+def test_expert_parallelism_must_fit_explicit_single_rank():
+    cfg = SimpleNamespace(
+        conversion_tensor_model_parallel_size=1,
+        conversion_expert_model_parallel_size=2,
+        conversion_expert_tensor_parallel_size=1,
+    )
+    with pytest.raises(ValueError, match="does not divide"):
+        get_checkpoint_conversion_policy(cfg)


### PR DESCRIPTION
An explicit conversion TP1/PP1 was treated like an unspecified layout, so the converter still used every GPU on the node. Preserve explicit overrides, including `mtp_num_layers=0`, while keeping automatic conversion for unspecified layouts.

Validation: 25 conversion/checkpoint tests pass, covering implicit layout, explicit TP1 or PP1, sharded training with single-rank conversion, zero MTP, and incompatible expert parallelism. Ruff and diff checks pass. A Qwen4B conversion ran successfully with one process on Modal.

The example-specific template checklist does not apply to this SDK fix.
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->