### PR TITLE
Accept Miles checkpoints with embedded common state

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -332,18 +332,14 @@ def _is_complete_torch_dist_checkpoint(path: str) -> bool:
     (its default ``is_complete`` is ``os.path.isdir``), so a conversion that died
     mid-write is reported as a cache hit and silently skips re-conversion — which
     then feeds partial weights to training. A crashed conversion does leave
-    ``common.pt`` and the ``.distcp`` shards behind, so those alone are not enough
-    to tell the two apart.
+    data shards behind, so those alone are not enough to tell the two apart.
+    Newer Megatron stores common state inside torch_dist rather than common.pt.
     """
     try:
         names = os.listdir(path)
     except OSError:
         return False
-    return (
-        ".metadata" in names
-        and "common.pt" in names
-        and any(name.endswith(".distcp") for name in names)
-    )
+    return ".metadata" in names and any(name.endswith(".distcp") for name in names)
 
 
 def _build_miles_base_image(miles: MilesRecipe) -> Image:

--- a/tests/test_miles_checkpoint_completeness.py
+++ b/tests/test_miles_checkpoint_completeness.py
@@ -1,0 +1,33 @@
+import pytest
+
+from modal_training_gym.frameworks.miles.launcher import (
+    _is_complete_torch_dist_checkpoint,
+)
+from modal_training_gym.common.run import has_torch_dist_checkpoint
+
+
+@pytest.mark.parametrize("legacy_common", [False, True])
+def test_completed_conversion_with_legacy_or_embedded_common_state(
+    tmp_path, legacy_common
+):
+    release = tmp_path / "release"
+    release.mkdir()
+    for name in [
+        ".metadata",
+        "__0_0.distcp",
+        *(["common.pt"] if legacy_common else []),
+    ]:
+        (release / name).touch()
+    (tmp_path / "latest_checkpointed_iteration.txt").write_text("release")
+    assert has_torch_dist_checkpoint(
+        str(tmp_path), is_complete=_is_complete_torch_dist_checkpoint
+    )
+
+
+@pytest.mark.parametrize(
+    "names", [[], ["__0_0.distcp"], ["__0_0.distcp", "common.pt"], [".metadata"]]
+)
+def test_incomplete_conversion_is_not_a_cache_hit(tmp_path, names):
+    for name in names:
+        (tmp_path / name).touch()
+    assert not _is_complete_torch_dist_checkpoint(str(tmp_path))


### PR DESCRIPTION
The current Miles image writes Megatron common state as a `common_state` ShardedObject inside torch_dist. A successful conversion therefore has `.metadata` and `.distcp` shards without a separate `common.pt`. Gym incorrectly rejects it as incomplete and never starts training.

Remove the legacy-file requirement while retaining the metadata completion marker and data-shard check. Older checkpoints that contain common.pt still pass. This is a cache-completion check, not a full checkpoint integrity validator.

Validation: 19 focused checkpoint tests pass. Inspected `load_common_state_dict()` and the save path in the actual `radixark/miles:dev-202609071227` image: they explicitly support legacy common.pt and current embedded common_state. The live Qwen3.5-4B retry then successfully loaded the converted checkpoint without common.pt through Megatron. No recipes or run records included.