### PR TITLE
Allow Miles runs to reuse a shared project volume

### DIFF
--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -131,13 +131,14 @@ def resolve_checkpoint_volumes(
     *,
     volume_prefix: str,
     default_mount_path: str,
+    default_volume_name: str | None = None,
 ) -> tuple[str, str, "Volume"]:
     """Resolve the checkpoints volume name / mount path / Volume, honoring an
     optional ``CheckpointConfig`` override."""
     checkpoints_volume_name = (
         checkpoint.checkpoints_volume_name
         if checkpoint is not None and checkpoint.checkpoints_volume_name
-        else f"{volume_prefix}-checkpoints"
+        else default_volume_name or f"{volume_prefix}-checkpoints"
     )
     checkpoints_mount_path = (
         checkpoint.checkpoints_mount_path.rstrip("/") or "/"

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -17,6 +17,7 @@ import secrets as _secrets
 import tempfile
 import textwrap
 import time
+from pathlib import Path
 from typing import Any, Callable
 
 import cloudpickle
@@ -221,7 +222,10 @@ def run_prepare_dataset(
     and validating the prepared prompt/eval paths."""
     data_volume.reload()
     prompt_data, eval_paths = resolve_data_paths(dataset)
-    if clear_data_dir and dataset.always_prepare and os.path.exists(prompt_data):
+    if dataset.always_prepare and not clear_data_dir:
+        for path in (prompt_data, *(eval_paths or {}).values()):
+            Path(path).unlink(missing_ok=True)
+    elif dataset.always_prepare and os.path.exists(prompt_data):
         import shutil
 
         data_dir = os.path.dirname(prompt_data)

--- a/modal_training_gym/common/launcher_helpers.py
+++ b/modal_training_gym/common/launcher_helpers.py
@@ -214,12 +214,14 @@ def run_prepare_dataset(
     dataset: Any,
     data_volume: "Volume",
     resolve_data_paths: Callable[[Any], tuple[str, Any]],
+    *,
+    clear_data_dir: bool = True,
 ) -> None:
     """Materialize the dataset onto the data volume, honoring ``always_prepare``
     and validating the prepared prompt/eval paths."""
     data_volume.reload()
     prompt_data, eval_paths = resolve_data_paths(dataset)
-    if dataset.always_prepare and os.path.exists(prompt_data):
+    if clear_data_dir and dataset.always_prepare and os.path.exists(prompt_data):
         import shutil
 
         data_dir = os.path.dirname(prompt_data)

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -670,7 +670,12 @@ def build_miles_app(
         name="prepare_dataset",
     )
     def prepare_dataset():
-        run_prepare_dataset(dataset, data_volume, miles._resolve_data_paths)
+        run_prepare_dataset(
+            dataset,
+            data_volume,
+            miles._resolve_data_paths,
+            clear_data_dir=not bool(miles.project_volume_name),
+        )
 
     convert_nnodes = get_checkpoint_conversion_policy(miles, model=model)[0]
     convert_multi_node = convert_nnodes > 1
@@ -1071,9 +1076,11 @@ def build_miles_app(
             prompt_data, eval_paths = miles._resolve_data_paths(dataset)
             needs_prepare = not os.path.exists(prompt_data)
             if dataset.always_prepare and os.path.exists(prompt_data):
-                data_dir = os.path.dirname(prompt_data)
-                print(f"always_prepare=True - removing {data_dir}")
-                shutil.rmtree(data_dir, ignore_errors=True)
+                # Shared storage does not grant ownership of the data file's parent.
+                if not miles.project_volume_name:
+                    data_dir = os.path.dirname(prompt_data)
+                    print(f"always_prepare=True - removing {data_dir}")
+                    shutil.rmtree(data_dir, ignore_errors=True)
                 needs_prepare = True
             if needs_prepare:
                 print(f"Preparing dataset ({prompt_data})...")

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -585,19 +585,38 @@ def build_miles_app(
         setattr(miles, attr, None)
 
     hf_cache_volume = Volume.from_name("huggingface-cache", create_if_missing=True)
-    data_volume = Volume.from_name(f"{volume_prefix}-data", create_if_missing=True)
     checkpoints_volume_name, checkpoints_mount_path, checkpoints_volume = (
         resolve_checkpoint_volumes(
             checkpoint,
             volume_prefix=volume_prefix,
             default_mount_path=str(CHECKPOINTS_PATH),
+            default_volume_name=miles.project_volume_name,
         )
     )
+    if miles.project_volume_name:
+        if checkpoints_volume_name != miles.project_volume_name:
+            raise ValueError(
+                "The resume checkpoint must use the configured project volume."
+            )
+        data_mount_path = checkpoints_mount_path
+        data_volume = checkpoints_volume
+        prompt_data, eval_paths = miles._resolve_data_paths(dataset)
+        for path in (prompt_data, *(eval_paths or {}).values()):
+            if os.path.commonpath([os.path.normpath(path), data_mount_path]) != data_mount_path:
+                raise ValueError(
+                    f"With project_volume_name, dataset paths must be below "
+                    f"{data_mount_path}: {path}"
+                )
+    else:
+        data_mount_path = str(DATA_PATH)
+        data_volume = Volume.from_name(f"{volume_prefix}-data", create_if_missing=True)
     all_volumes: dict[str | PurePosixPath, Any] = {
         str(HF_CACHE_PATH): hf_cache_volume,
-        str(DATA_PATH): data_volume,
+        data_mount_path: data_volume,
         checkpoints_mount_path: checkpoints_volume,
     }
+    # A project volume has one mount and must not be reloaded concurrently twice.
+    input_volumes = tuple(all_volumes.values())
 
     tags = build_app_tags(
         framework="miles",
@@ -641,14 +660,14 @@ def build_miles_app(
 
     @app.function(
         image=image,
-        volumes={str(DATA_PATH): data_volume},
+        volumes={str(HF_CACHE_PATH): hf_cache_volume, data_mount_path: data_volume},
         timeout=4 * 60 * 60,
         secrets=hf_secrets(),
         serialized=True,
         name="prepare_dataset",
     )
     def prepare_dataset():
-        run_prepare_dataset(dataset, data_volume, MilesRecipe._resolve_data_paths)
+        run_prepare_dataset(dataset, data_volume, miles._resolve_data_paths)
 
     convert_nnodes = get_checkpoint_conversion_policy(miles, model=model)[0]
     convert_multi_node = convert_nnodes > 1
@@ -943,11 +962,7 @@ def build_miles_app(
         if framework_status_token:
             os.environ["TRAINING_GYM_FRAMEWORK_STATUS_TOKEN"] = framework_status_token
 
-        await asyncio.gather(
-            hf_cache_volume.reload.aio(),
-            data_volume.reload.aio(),
-            checkpoints_volume.reload.aio(),
-        )
+        await asyncio.gather(*(volume.reload.aio() for volume in input_volumes))
 
         cluster = ModalRayCluster()
         cluster.discover_cluster(miles.total_nodes)
@@ -1050,7 +1065,7 @@ def build_miles_app(
             await checkpoints_volume.commit.aio()
 
             await _set_framework_status(MilesStatus.PREPARE_DATASET)
-            prompt_data, eval_paths = MilesRecipe._resolve_data_paths(dataset)
+            prompt_data, eval_paths = miles._resolve_data_paths(dataset)
             needs_prepare = not os.path.exists(prompt_data)
             if dataset.always_prepare and os.path.exists(prompt_data):
                 data_dir = os.path.dirname(prompt_data)
@@ -1096,11 +1111,7 @@ def build_miles_app(
         else:
             deadline = time.time() + 4 * 60 * 60
             while True:
-                await asyncio.gather(
-                    hf_cache_volume.reload.aio(),
-                    data_volume.reload.aio(),
-                    checkpoints_volume.reload.aio(),
-                )
+                await asyncio.gather(*(volume.reload.aio() for volume in input_volumes))
                 if os.path.exists(prep_marker):
                     break
                 if os.path.exists(prep_error):

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -602,7 +602,10 @@ def build_miles_app(
         data_volume = checkpoints_volume
         prompt_data, eval_paths = miles._resolve_data_paths(dataset)
         for path in (prompt_data, *(eval_paths or {}).values()):
-            if os.path.commonpath([os.path.normpath(path), data_mount_path]) != data_mount_path:
+            if (
+                os.path.commonpath([os.path.normpath(path), data_mount_path])
+                != data_mount_path
+            ):
                 raise ValueError(
                     f"With project_volume_name, dataset paths must be below "
                     f"{data_mount_path}: {path}"

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -1075,12 +1075,15 @@ def build_miles_app(
             await _set_framework_status(MilesStatus.PREPARE_DATASET)
             prompt_data, eval_paths = miles._resolve_data_paths(dataset)
             needs_prepare = not os.path.exists(prompt_data)
-            if dataset.always_prepare and os.path.exists(prompt_data):
+            if dataset.always_prepare and miles.project_volume_name:
                 # Shared storage does not grant ownership of the data file's parent.
-                if not miles.project_volume_name:
-                    data_dir = os.path.dirname(prompt_data)
-                    print(f"always_prepare=True - removing {data_dir}")
-                    shutil.rmtree(data_dir, ignore_errors=True)
+                for path in (prompt_data, *(eval_paths or {}).values()):
+                    Path(path).unlink(missing_ok=True)
+                needs_prepare = True
+            elif dataset.always_prepare and os.path.exists(prompt_data):
+                data_dir = os.path.dirname(prompt_data)
+                print(f"always_prepare=True - removing {data_dir}")
+                shutil.rmtree(data_dir, ignore_errors=True)
                 needs_prepare = True
             if needs_prepare:
                 print(f"Preparing dataset ({prompt_data})...")

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -37,6 +37,7 @@ _MILES_SKIP = {
     "cloud",
     "region",
     "name",
+    "project_volume_name",
     "app_tags",
     "image_overlay",
     "image_run_commands",
@@ -107,6 +108,9 @@ class MilesRecipe(BaseTrainRecipe):
             Internal discriminator fixed to Miles.
         name:
             Modal app title. The launcher derives it from the class when empty.
+        project_volume_name:
+            Optional shared volume for data and checkpoints, mounted once at
+            ``/checkpoints``. The recipe's dataset paths must use this mount.
         app_tags:
             Extra tags merged into the Modal app metadata for the dashboard.
 
@@ -443,6 +447,7 @@ class MilesRecipe(BaseTrainRecipe):
     cloud: str | None = None
     region: str | None = None
     name: str = ""
+    project_volume_name: str | None = None
     app_tags: dict = field(default_factory=dict)
     image_overlay: Callable[[modal.Image], modal.Image] | None = None
     image_run_commands: list[str] = field(default_factory=list)

--- a/tests/test_miles_project_volume.py
+++ b/tests/test_miles_project_volume.py
@@ -60,17 +60,30 @@ def test_default_recipe_keeps_separate_data_and_checkpoint_mounts(build_app):
 def test_forced_preparation_preserves_other_files_in_shared_directory(tmp_path):
     prompt = tmp_path / "train.jsonl"
     prompt.write_text("old data")
+    eval_path = tmp_path / "eval.jsonl"
+    eval_path.write_text("old eval")
     checkpoint = tmp_path / "model" / "release" / "__0_0.distcp"
     checkpoint.parent.mkdir(parents=True)
     checkpoint.write_text("weights")
     dataset = Mock(always_prepare=True)
-    dataset.prepare.side_effect = lambda path, evals: prompt.write_text("new data")
+
+    def prepare(path, evals):
+        assert not prompt.exists()
+        assert not eval_path.exists()
+        prompt.write_text("new data")
+        eval_path.write_text("new eval")
+
+    dataset.prepare.side_effect = prepare
 
     run_prepare_dataset(
-        dataset, Mock(), lambda _: (str(prompt), {}), clear_data_dir=False
+        dataset,
+        Mock(),
+        lambda _: (str(prompt), {"eval": str(eval_path)}),
+        clear_data_dir=False,
     )
 
     assert prompt.read_text() == "new data"
+    assert eval_path.read_text() == "new eval"
     assert checkpoint.read_text() == "weights"
 
 

--- a/tests/test_miles_project_volume.py
+++ b/tests/test_miles_project_volume.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from modal_training_gym.common.dataset import HuggingFaceDataset
+from modal_training_gym.common.launcher_helpers import run_prepare_dataset
 from modal_training_gym.common.models import Qwen3_5_4B
 from modal_training_gym.frameworks.miles import launcher
 from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
@@ -44,6 +45,7 @@ def test_project_volume_is_mounted_once_for_training_and_preparation(
     monkeypatch.setattr(launcher, "run_prepare_dataset", prepare_data)
     prepare.get_raw_f()()
     assert prepare_data.call_args.args[2] is ProjectRecipe._resolve_data_paths
+    assert prepare_data.call_args.kwargs == {"clear_data_dir": False}
 
 
 def test_default_recipe_keeps_separate_data_and_checkpoint_mounts(build_app):
@@ -53,6 +55,23 @@ def test_default_recipe_keeps_separate_data_and_checkpoint_mounts(build_app):
         "/data",
         "/checkpoints",
     }
+
+
+def test_forced_preparation_preserves_other_files_in_shared_directory(tmp_path):
+    prompt = tmp_path / "train.jsonl"
+    prompt.write_text("old data")
+    checkpoint = tmp_path / "model" / "release" / "__0_0.distcp"
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.write_text("weights")
+    dataset = Mock(always_prepare=True)
+    dataset.prepare.side_effect = lambda path, evals: prompt.write_text("new data")
+
+    run_prepare_dataset(
+        dataset, Mock(), lambda _: (str(prompt), {}), clear_data_dir=False
+    )
+
+    assert prompt.read_text() == "new data"
+    assert checkpoint.read_text() == "weights"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_miles_project_volume.py
+++ b/tests/test_miles_project_volume.py
@@ -1,0 +1,66 @@
+from unittest.mock import Mock
+
+import pytest
+
+from modal_training_gym.common.dataset import HuggingFaceDataset
+from modal_training_gym.common.models import Qwen3_5_4B
+from modal_training_gym.frameworks.miles import launcher
+from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+
+
+class ProjectRecipe(MilesRecipe):
+    @staticmethod
+    def _resolve_data_paths(dataset):
+        return "/checkpoints/data/train.jsonl", {"eval": "/checkpoints/data/eval.jsonl"}
+
+
+@pytest.fixture
+def build_app(monkeypatch):
+    for name in ("hf_secrets", "proxy_auth_secrets", "metric_secrets"):
+        monkeypatch.setattr(launcher, name, lambda *a, **kw: [])
+    monkeypatch.setattr(launcher, "resolve_caller_context", lambda: (None, None))
+    dataset = HuggingFaceDataset(
+        hf_repo="org/data", input_column="prompt", output_column="answer"
+    )
+
+    def build(recipe):
+        return launcher.build_miles_app(
+            training_run_id="test", miles=recipe, model=Qwen3_5_4B(), dataset=dataset
+        )
+
+    return build
+
+
+def test_project_volume_is_mounted_once_for_training_and_preparation(
+    build_app, monkeypatch
+):
+    app = build_app(ProjectRecipe(project_volume_name="shared-project"))
+    train = app.registered_functions["train"]
+    prepare = app.registered_functions["prepare_dataset"]
+    assert set(train.spec.volumes) == {"/root/.cache/huggingface", "/checkpoints"}
+    assert set(prepare.spec.volumes) == {"/root/.cache/huggingface", "/checkpoints"}
+    assert prepare.spec.volumes["/checkpoints"] is train.spec.volumes["/checkpoints"]
+    prepare_data = Mock()
+    monkeypatch.setattr(launcher, "run_prepare_dataset", prepare_data)
+    prepare.get_raw_f()()
+    assert prepare_data.call_args.args[2] is ProjectRecipe._resolve_data_paths
+
+
+def test_default_recipe_keeps_separate_data_and_checkpoint_mounts(build_app):
+    app = build_app(MilesRecipe())
+    assert set(app.registered_functions["train"].spec.volumes) == {
+        "/root/.cache/huggingface",
+        "/data",
+        "/checkpoints",
+    }
+
+
+@pytest.mark.parametrize(
+    "path", ["/data/train.jsonl", "/checkpoints/../outside/train.jsonl"]
+)
+def test_project_data_must_be_inside_its_mount(build_app, monkeypatch, path):
+    monkeypatch.setattr(
+        ProjectRecipe, "_resolve_data_paths", staticmethod(lambda ds: (path, {}))
+    )
+    with pytest.raises(ValueError, match="dataset paths must be below"):
+        build_app(ProjectRecipe(project_volume_name="shared-project"))


### PR DESCRIPTION
Miles currently puts prepared data and converted starting weights in recipe-specific volumes. Add optional `project_volume_name` so related recipes can reuse those inputs in one mounted project volume, with a separate Hugging Face cache. Honor recipe data paths during preparation/training and reload each mounted volume once.

Dataset paths must remain inside the shared mount. For `always_prepare=True`, remove only the declared prompt/eval output files before invoking `prepare()`. This preserves neighboring checkpoints and ensures stale outputs cannot pass validation. Both standalone preparation and in-training preparation use this behavior. Dedicated data volumes retain their existing directory cleanup.

Validation: 26 focused storage/checkpoint/hook tests pass. The shared-storage regression checks that old train/eval outputs are absent before preparation and neighboring model weights survive. Ruff passes. No recipes or run records included.