### PR TITLE
Support explicit no-save Miles runs

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -1118,6 +1118,7 @@ def build_miles_app(
         assert run_record is not None
 
         try:  # Wraps all post-setup work so any failure marks the run terminal.
+            extra_config = miles.extra_config or {}
             prepare_miles_config(miles, model, tempfile.mkdtemp())
 
             if wandb_key := os.environ.get("WANDB_API_KEY", ""):
@@ -1134,7 +1135,7 @@ def build_miles_app(
             original_save = miles.save
             original_load = miles.load
             original_start_rollout_id = miles.start_rollout_id
-            miles.save = save_root
+            miles.save = save_root if original_save else None
             resume_checkpoint = torch_dist_resume_checkpoint(
                 save_root, is_complete=_is_resumable_checkpoint
             )
@@ -1231,7 +1232,10 @@ def build_miles_app(
                 app_name=app_name,
                 framework=Framework.MILES,
                 training_run_id=training_run_id,
-                checkpoint_dir=save_root,
+                checkpoint_dir=extra_config.get(
+                    "save", save_root if original_save else ""
+                )
+                or "",
                 model=model,
                 checkpoints_volume_name=checkpoints_volume_name,
                 checkpoints_mount_path=checkpoints_mount_path,

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -221,8 +221,9 @@ class MilesRecipe(BaseTrainRecipe):
             Checkpoint trained from; normally set from the attached ``ModelConfig``.
         save:
             Checkpoint output directory on the mounted ``/checkpoints`` volume.
+            Set both ``save`` and ``save_interval`` to ``None`` to disable saving.
         save_interval:
-            Save a checkpoint every N rollout steps; ``None`` disables saving.
+            Save a checkpoint every N rollout steps; use ``None`` with ``save=None``.
         load:
             Directory to resume from; empty starts from the converted HF weights.
         no_save_optim:
@@ -476,7 +477,7 @@ class MilesRecipe(BaseTrainRecipe):
 
     # ── Checkpointing ───────────────────────────────────────────────────────
     hf_checkpoint: str = ""
-    save: str = str(CHECKPOINTS_PATH)
+    save: str | None = str(CHECKPOINTS_PATH)
     load: str = ""
     ref_load: str = ""
     megatron_to_hf_mode: str = "bridge"
@@ -793,10 +794,6 @@ class MilesRecipe(BaseTrainRecipe):
         if self.metrics is not None:
             fields.update(self._metrics_to_fields(self.metrics))
         out = self._emit_fields(fields)
-        # Megatron rejects --save without --save-interval, even when Miles
-        # disables all periodic/final saves with a None interval.
-        if self.save_interval is None:
-            out.pop("save", None)
         for src, dst in _HOOK_PATH_FLAGS.items():
             if src in _HOOK_WRAPPER_PATHS:
                 out[dst] = _HOOK_WRAPPER_PATHS[src]

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -222,7 +222,7 @@ class MilesRecipe(BaseTrainRecipe):
         save:
             Checkpoint output directory on the mounted ``/checkpoints`` volume.
         save_interval:
-            Save a checkpoint every N rollout steps.
+            Save a checkpoint every N rollout steps; ``None`` disables saving.
         load:
             Directory to resume from; empty starts from the converted HF weights.
         no_save_optim:
@@ -483,7 +483,7 @@ class MilesRecipe(BaseTrainRecipe):
     # Selects miles' megatron→HF weight mapping (e.g. "inkling"); when empty miles
     # infers it from the HF config's class name.
     model_name: str = ""
-    save_interval: int = 10
+    save_interval: int | None = 10
     no_save_optim: bool = False
 
     # ── Checkpoint conversion ───────────────────────────────────────────
@@ -793,6 +793,10 @@ class MilesRecipe(BaseTrainRecipe):
         if self.metrics is not None:
             fields.update(self._metrics_to_fields(self.metrics))
         out = self._emit_fields(fields)
+        # Megatron rejects --save without --save-interval, even when Miles
+        # disables all periodic/final saves with a None interval.
+        if self.save_interval is None:
+            out.pop("save", None)
         for src, dst in _HOOK_PATH_FLAGS.items():
             if src in _HOOK_WRAPPER_PATHS:
                 out[dst] = _HOOK_WRAPPER_PATHS[src]

--- a/tests/test_miles_checkpoint_saving.py
+++ b/tests/test_miles_checkpoint_saving.py
@@ -1,20 +1,58 @@
+import yaml
+import pytest
+
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common.models import ModelConfig
+from modal_training_gym.common.train_result import TrainResult
+from modal_training_gym.frameworks.miles.modal_helpers.utils import prepare_miles_config
 from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
 
 
-def test_disabled_saving_omits_launcher_supplied_save_path():
-    recipe = MilesRecipe(
-        save_interval=None, save="/checkpoints/run", ref_load="/checkpoints/initial"
-    )
+def test_explicitly_disabled_saving_omits_both_flags():
+    recipe = MilesRecipe(save_interval=None, save=None, ref_load="/checkpoints/initial")
     fields = recipe._fields()
-    assert "save" not in fields
+    assert fields["save"] is None
     assert fields.get("save_interval") is None
     assert "--save" not in recipe.cli_args()
     assert "--save-interval" not in recipe.cli_args()
     assert fields["ref_load"] == "/checkpoints/initial"
-    assert recipe.save == "/checkpoints/run"
+    assert recipe.save is None
 
 
 def test_enabled_saving_keeps_path_and_interval():
     fields = MilesRecipe(save_interval=10, save="/checkpoints/run")._fields()
     assert fields["save"] == "/checkpoints/run"
     assert fields["save_interval"] == 10
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_save_overrides_survive_yaml_materialization(tmp_path, enabled):
+    override = {
+        "save": "/checkpoints/override" if enabled else None,
+        "save_interval": 10 if enabled else None,
+    }
+    recipe = MilesRecipe(
+        save=None if enabled else "/checkpoints/original",
+        save_interval=None if enabled else 10,
+        extra_config=override,
+    )
+    for materialized in (False, True):
+        if materialized:
+            prepare_miles_config(recipe, None, str(tmp_path))
+            with open(recipe.extra_config) as f:
+                assert yaml.safe_load(f) == override
+        assert "--save" not in recipe.cli_args()
+        assert "--save-interval" not in recipe.cli_args()
+
+
+def test_result_without_checkpoint_keeps_original_model_source():
+    model = ModelConfig(model_name="org/model", model_path="/hf/model")
+    result = TrainResult(
+        app_name="test",
+        framework=Framework.MILES,
+        training_run_id="run",
+        checkpoint_dir="",
+        model_config=model,
+    )
+    assert result.checkpoints() == []
+    assert result.model.model_path == "/hf/model"

--- a/tests/test_miles_checkpoint_saving.py
+++ b/tests/test_miles_checkpoint_saving.py
@@ -1,0 +1,20 @@
+from modal_training_gym.train_recipes.miles_recipe import MilesRecipe
+
+
+def test_disabled_saving_omits_launcher_supplied_save_path():
+    recipe = MilesRecipe(
+        save_interval=None, save="/checkpoints/run", ref_load="/checkpoints/initial"
+    )
+    fields = recipe._fields()
+    assert "save" not in fields
+    assert fields.get("save_interval") is None
+    assert "--save" not in recipe.cli_args()
+    assert "--save-interval" not in recipe.cli_args()
+    assert fields["ref_load"] == "/checkpoints/initial"
+    assert recipe.save == "/checkpoints/run"
+
+
+def test_enabled_saving_keeps_path_and_interval():
+    fields = MilesRecipe(save_interval=10, save="/checkpoints/run")._fields()
+    assert fields["save"] == "/checkpoints/run"
+    assert fields["save_interval"] == 10


### PR DESCRIPTION
Miles and Megatron require both `save=None` and `save_interval=None` to disable checkpointing. Gym previously required a string save path and replaced it with a run directory before launching.

Allow both fields to be None and preserve an explicitly absent save destination. Use the existing CLI/YAML precedence rules directly; no save-path inference from the top-level interval. On completion, record an empty checkpoint_dir when saving is disabled, including through extra_config. TrainResult then retains its existing input-model fallback instead of pointing to an empty output directory; no trained checkpoint is available.

Validation: 26 focused checkpoint/hook tests pass, including explicit enable/disable flags, YAML overrides before and after materialization, and TrainResult's no-checkpoint behavior. Ruff passes. No recipes or run records included. This replaces the earlier interval-based shortcut in this PR.