### PR TITLE
Support Miles controller/executor status and timing patches

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -470,6 +470,7 @@ def build_miles_app(
             " local_miles checkout; transient router failures during rollout"
             " cleanup may crash the run'",
             *_REPORTING_PATCH_COMMANDS,
+            f"echo {_PATCH_SUBSTEP_TIMING_B64} | base64 -d | python3",
         )
 
     if miles.image_run_commands:

--- a/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_rollout_status_reporting.py
+++ b/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_rollout_status_reporting.py
@@ -33,8 +33,10 @@ _LINE_INJECTIONS: list[tuple[str, str, str, re.Pattern[str]]] = [
         "initialize_rollouts",
         "None",
         re.compile(
-            r"^(?P<indent>[ \t]*)(?P<line>rollout_manager, num_rollout_per_epoch = "
-            r"create_rollout_manager\(args, pgs\[\"rollout\"\]\))[ \t]*$",
+            r"^(?P<indent>[ \t]*)(?P<line>(?:rollout_manager, num_rollout_per_epoch = "
+            r"create_rollout_manager\(args, pgs\[\"rollout\"\]\)|"
+            r"inference_controller, rollout_executor, num_rollout_per_epoch = "
+            r"await create_rollout_components\(args\)))[ \t]*$",
             re.M,
         ),
     ),
@@ -43,8 +45,9 @@ _LINE_INJECTIONS: list[tuple[str, str, str, re.Pattern[str]]] = [
         "generate_rollouts",
         "rollout_id",
         re.compile(
-            r"^(?P<indent>[ \t]*)(?P<line>rollout_data\w* = await "
-            r"rollout_manager\.generate\.remote\(rollout_id\))[ \t]*$",
+            r"^(?P<indent>[ \t]*)(?P<line>(?:rollout_data\w* = await "
+            r"rollout_manager\.generate\.remote\(rollout_id\)|"
+            r"await inference_controller\.prepare_rollout\(rollout_id\)))[ \t]*$",
             re.M,
         ),
     ),
@@ -65,7 +68,7 @@ _LINE_INJECTIONS: list[tuple[str, str, str, re.Pattern[str]]] = [
         "offload_rollout",
         "rollout_id",
         re.compile(
-            r"^(?P<indent>[ \t]*)(?P<line>await rollout_manager\.offload\.remote\("
+            r"^(?P<indent>[ \t]*)(?P<line>await (?:rollout_manager\.offload\.remote|inference_controller\.offload(?:_kv|_weights)?)\("
             r"[^\n]*\))[ \t]*$",
             re.M,
         ),
@@ -84,7 +87,7 @@ _LINE_INJECTIONS: list[tuple[str, str, str, re.Pattern[str]]] = [
         "weight_sync",
         "rollout_id",
         re.compile(
-            r"^(?P<indent>[ \t]*)(?P<line>await actor_model\.update_weights\("
+            r"^(?P<indent>[ \t]*)(?P<line>await (?:actor_model\.update_weights\(|update_weights\(actor_model, rollout_executor, )"
             r"rollout_id=rollout_id\))[ \t]*$",
             re.M,
         ),
@@ -116,6 +119,15 @@ def _patch_file(path: Path) -> None:
     for marker, phase, rollout_id_expr, pattern in _LINE_INJECTIONS:
         if marker in src:
             continue
+        if (
+            "create_rollout_components" in src
+            and phase == "offload_train"
+            and path.name == "train_async.py"
+        ):
+            pattern = re.compile(
+                r"^(?P<indent>[ \t]*)(?P<line>await (?:critic_model|actor_model)\.offload\(\))[ \t]*$",
+                re.M,
+            )
 
         def _replacement(match: re.Match[str]) -> str:
             indent = match.group("indent")
@@ -127,7 +139,9 @@ def _patch_file(path: Path) -> None:
             )
 
         src, count = pattern.subn(_replacement, src)
-        if count == 0:
+        if count == 0 and not (
+            path.name == "train_async.py" and phase == "offload_rollout"
+        ):
             failed.append(phase)
 
     if CHECKPOINT_SAVE_MARKER not in src:

--- a/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
+++ b/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
@@ -14,7 +14,7 @@ they open a lane at their entry point and the phases below use the module-level
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 PREAMBLE_MARKER = "PATCHED_TRAINING_GYM_TIMING_PREAMBLE"
@@ -525,6 +525,16 @@ def wrap_scope(src: str, scope: tuple[str, str, str], path: Path) -> str:
 
 
 def _patch_package_file(root: Path, target: PackageTarget) -> None:
+    # Miles split RolloutManager into a controller and executor in September 2026.
+    if (
+        target.path == "miles/ray/rollout/rollout_manager.py"
+        and not (root / target.path).exists()
+    ):
+        target = replace(
+            target,
+            path="miles/ray/rollout/rollout_executor.py",
+            scope=("    async def get(self, rollout_id):\n", *target.scope[1:]),
+        )
     path = root / target.path
     if not path.exists():
         raise RuntimeError(f"{path}: not found; {root.name} layout changed")
@@ -535,6 +545,19 @@ def _patch_package_file(root: Path, target: PackageTarget) -> None:
         return
 
     for phase, block in target.blocks:
+        if (
+            phase == "compute_log_probs"
+            and "                fp32_output=False,\n" in src
+        ):
+            block = block.replace(
+                "                store_prefix=store_prefix,\n",
+                "                store_prefix=store_prefix,\n                fp32_output=False,\n",
+            )
+        if phase == "train_step_finalize" and '        tag="train",\n' in src:
+            block = block.replace(
+                '        op="train_step",\n',
+                '        tag="train",\n        op="train_step",\n',
+            )
         src = replace_once(src, block, wrap_block(block, phase, "_tg_time_phase"), path)
     if target.scope is not None:
         src = wrap_scope(src, target.scope, path)  # last: it reindents the body
@@ -559,6 +582,113 @@ def patch_package_file(root: Path, target: PackageTarget) -> None:
         print(f"WARNING: {target.path} substep timing patch skipped: {exc}")
 
 
+def _patch_component_driver(src: str, path: Path) -> str:
+    """Instrument the controller/executor driver using complete await statements.
+
+    Matching calls, rather than their indentation, handles both memory-transfer
+    branches without changing the branch structure or ordering of those calls.
+    """
+    tree = ast.parse(src)
+    loops = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.For)
+        and isinstance(n.target, ast.Name)
+        and n.target.id == "rollout_id"
+    ]
+    if len(loops) != 1:
+        raise RuntimeError(f"{path}: expected one rollout loop, found {len(loops)}")
+    loop = loops[0]
+    train_line = min(
+        n.lineno
+        for n in ast.walk(loop)
+        if isinstance(n, ast.Call) and ast.unparse(n.func) == "actor_model.train"
+    )
+    phases = {
+        "inference_controller.prepare_rollout": "generate_rollouts",
+        "rollout_executor.get.remote": "generate_rollouts",
+        "inference_controller.prepare_eval": "evaluate_rollouts",
+        "rollout_executor.eval.remote": "evaluate_rollouts",
+        "eval_dispatcher.dispatch": "evaluate_rollouts",
+        "eval_dispatcher.drain": "evaluate_rollouts_end",
+        "inference_controller.offload": "offload_rollout",
+        "inference_controller.offload_kv": "offload_rollout",
+        "inference_controller.offload_weights": "offload_rollout",
+        "actor_model.onload": "offload_rollout",
+        "actor_model.train": "train_models",
+        "critic_model.train": "train_models",
+        "save": "checkpoint_save",
+        "save_training_model": "checkpoint_save",
+        "offload_train": "offload_train",
+        "actor_model.offload": "offload_train",
+        "critic_model.offload": "offload_train",
+        "actor_model.clear_memory": "offload_train",
+        "inference_controller.onload_weights": "weight_sync",
+        "inference_controller.onload_kv": "weight_sync",
+        "update_weights": "weight_sync",
+    }
+    lines = src.splitlines(keepends=True)
+    changes = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Expr, ast.Assign)):
+            continue
+        if isinstance(node.value, ast.Await):
+            value = node.value.value
+            call = (
+                ast.unparse(value.func)
+                if isinstance(value, ast.Call)
+                else ast.unparse(value)
+            )
+        elif (
+            isinstance(node, ast.Assign)
+            and ast.unparse(node.targets[0]) == "rollout_data_curr_ref"
+            and isinstance(node.value, ast.IfExp)
+            and isinstance(node.value.body, ast.Await)
+        ):
+            call = "wait_for_next_rollout"
+        else:
+            continue
+        inside = loop.lineno < node.lineno <= loop.end_lineno
+        phase = phases.get(call)
+        if call == "rollout_data_next_future" and inside:
+            phase = "wait_for_rollout"
+        if call == "wait_for_next_rollout" and inside:
+            phase = "wait_for_next_rollout"
+        if phase is None:
+            continue
+        if not inside:
+            if call == "update_weights":
+                phase = "initial_weight_sync"
+            elif call not in {"eval_dispatcher.dispatch", "eval_dispatcher.drain"}:
+                continue
+        if inside and phase == "evaluate_rollouts" and node.lineno > train_line:
+            phase = "evaluate_rollouts_end"
+        block = "".join(lines[node.lineno - 1 : node.end_lineno])
+        wrapped = wrap_block(block, phase)
+        if call == "eval_dispatcher.dispatch":
+            wrapped = wrapped.replace(
+                f"with _tg_rec.phase('{phase}'):",
+                f"with (_tg_rec.phase('{phase}') if not args.eval_uses_snapshots else _tg_nullcontext()):",
+            )
+        if not inside:
+            indent = block[: len(block) - len(block.lstrip(" "))]
+            wrapped = (
+                f"{indent}with _tg_role('driver', None) as _tg_rec:\n"
+                + indent_block(wrapped)
+                + "\n"
+            )
+        changes.append((node.lineno - 1, node.end_lineno, wrapped))
+    for start, end, wrapped in sorted(changes, reverse=True):
+        lines[start:end] = [wrapped]
+    src = _inject_preamble("".join(lines))
+    src = src.replace(
+        PREAMBLE,
+        "from contextlib import nullcontext as _tg_nullcontext\n" + PREAMBLE,
+        1,
+    )
+    return _wrap_driver_loop(src, path)
+
+
 def _patch_file(path: Path, wraps: list[tuple[str, str]]) -> None:
     if not path.exists():
         print(f"WARNING: {path} not found, skipping substep timing patch")
@@ -567,6 +697,28 @@ def _patch_file(path: Path, wraps: list[tuple[str, str]]) -> None:
     src = path.read_text()
     if PREAMBLE_MARKER in src:
         print(f"{path.name} already patched for substep timing")
+        return
+
+    if "create_rollout_components" in src:
+        src = _patch_component_driver(src, path)
+        required = {
+            "initial_weight_sync",
+            "weight_sync",
+            "train_models",
+            "evaluate_rollouts",
+            "evaluate_rollouts_end",
+        }
+        required |= (
+            {"wait_for_rollout", "wait_for_next_rollout"}
+            if path.name == "train_async.py"
+            else {"generate_rollouts"}
+        )
+        missing = sorted(phase for phase in required if phase_marker(phase) not in src)
+        if missing:
+            raise RuntimeError(f"{path}: phases not instrumented: {missing}")
+        compile(src, str(path), "exec")
+        path.write_text(src)
+        print(f"Patched {path.name} for controller/executor substep timing")
         return
 
     src = _inject_preamble(src)

--- a/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
+++ b/modal_training_gym/frameworks/miles/modal_helpers/patches/patch_substep_timing.py
@@ -659,7 +659,12 @@ def _patch_component_driver(src: str, path: Path) -> str:
         if not inside:
             if call == "update_weights":
                 phase = "initial_weight_sync"
-            elif call not in {"eval_dispatcher.dispatch", "eval_dispatcher.drain"}:
+            elif call not in {
+                "inference_controller.prepare_eval",
+                "rollout_executor.eval.remote",
+                "eval_dispatcher.dispatch",
+                "eval_dispatcher.drain",
+            }:
                 continue
         if inside and phase == "evaluate_rollouts" and node.lineno > train_line:
             phase = "evaluate_rollouts_end"

--- a/tests/test_miles_patches.py
+++ b/tests/test_miles_patches.py
@@ -16,6 +16,29 @@ TESTDATA = Path(__file__).parent / "testdata" / "miles"
 STATUS_PATCH_FILES = ("train.py", "train_async.py", "log_utils.py")
 
 
+def test_controller_executor_status_anchors(tmp_path, capsys):
+    path = tmp_path / "train.py"
+    path.write_text("""async def train(args):
+    inference_controller, rollout_executor, num_rollout_per_epoch = await create_rollout_components(args)
+    for rollout_id in range(args.num_rollout):
+        await inference_controller.prepare_rollout(rollout_id)
+        await inference_controller.offload(tags=offload_tags)
+        await actor_model.train(rollout_id, rollout_data_pack)
+        await offload_train()
+        await update_weights(actor_model, rollout_executor, rollout_id=rollout_id)
+        if should_run_periodic_action(rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout):
+            await save(rollout_id)
+""")
+    rollout_patcher._patch_file(path)
+    patched = path.read_text()
+    compile(patched, str(path), "exec")
+    assert "WARNING" not in capsys.readouterr().out
+    for _, phase, _, _ in rollout_patcher._LINE_INJECTIONS:
+        assert f"_tg_report('{phase}', args," in patched
+    rollout_patcher._patch_file(path)
+    assert path.read_text() == patched
+
+
 @pytest.fixture(scope="session")
 def miles_inputs() -> dict[str, str]:
     inputs = [TESTDATA / f"{name}.input" for name in STATUS_PATCH_FILES]

--- a/tests/test_substep_timing_patch.py
+++ b/tests/test_substep_timing_patch.py
@@ -26,6 +26,7 @@ def test_miles_component_async_waits_and_snapshot_eval(patchers, tmp_path):
 from miles.ray.placement_group import create_rollout_components
 async def train(args):
     await update_weights(actor_model, rollout_executor)
+    await inference_controller.prepare_eval()
     await eval_dispatcher.dispatch(0, hf_dir=args.hf_checkpoint)
     for rollout_id in range(args.start_rollout_id, args.num_rollout):
         if rollout_data_next_future is not None:
@@ -51,6 +52,8 @@ async def train(args):
     ):
         assert patcher.phase_marker(phase) in patched
     assert patched.count("if not args.eval_uses_snapshots else _tg_nullcontext()") == 2
+    before_loop = patched.split("for rollout_id in range")[0]
+    assert before_loop.count("with _tg_rec.phase('evaluate_rollouts'):") == 1
 
 
 def test_component_driver_does_not_write_partial_instrumentation(patchers, tmp_path):
@@ -72,6 +75,9 @@ def test_miles_controller_driver_preserves_calls_and_branches(patchers, tmp_path
 from miles.ray.placement_group import create_rollout_components
 async def train(args):
     await update_weights(actor_model, rollout_executor)
+    if args.num_rollout == 0 and args.eval_interval is not None:
+        await inference_controller.prepare_eval()
+        await rollout_executor.eval.remote(rollout_id=0)
     for rollout_id in range(args.start_rollout_id, args.num_rollout):
         await inference_controller.prepare_eval()
         await rollout_executor.eval.remote(rollout_id)
@@ -104,6 +110,9 @@ async def train(args):
         "evaluate_rollouts_end",
     ):
         assert patcher.phase_marker(phase) in patched
+
+    before_loop = patched.split("for rollout_id in range")[0]
+    assert before_loop.count("with _tg_rec.phase('evaluate_rollouts'):") == 2
 
     class StripTiming(ast.NodeTransformer):
         def visit_With(self, node):

--- a/tests/test_substep_timing_patch.py
+++ b/tests/test_substep_timing_patch.py
@@ -11,6 +11,7 @@ expected output with ``uv run pytest tests/test_substep_timing_patch.py
 from __future__ import annotations
 
 import importlib.util
+import ast
 import sys
 from pathlib import Path
 
@@ -18,6 +19,123 @@ import pytest
 
 TESTDATA = Path(__file__).parent / "testdata"
 FRAMEWORKS = Path(__file__).parents[1] / "modal_training_gym" / "frameworks"
+
+
+def test_miles_component_async_waits_and_snapshot_eval(patchers, tmp_path):
+    source = """from __future__ import annotations
+from miles.ray.placement_group import create_rollout_components
+async def train(args):
+    await update_weights(actor_model, rollout_executor)
+    await eval_dispatcher.dispatch(0, hf_dir=args.hf_checkpoint)
+    for rollout_id in range(args.start_rollout_id, args.num_rollout):
+        if rollout_data_next_future is not None:
+            rollout_data_curr_ref = await rollout_data_next_future
+        await actor_model.train(rollout_id, rollout_data_curr_ref)
+        rollout_data_curr_ref = (await x) if (x := rollout_data_next_future) is not None else None
+        rollout_data_next_future = None
+        await update_weights(actor_model, rollout_executor, rollout_id=rollout_id)
+        await eval_dispatcher.dispatch(rollout_id, force=rollout_id == args.num_rollout - 1)
+    await eval_dispatcher.drain()
+"""
+    patcher = patchers["miles"]
+    path = tmp_path / "train_async.py"
+    path.write_text(source)
+    patcher._patch_file(path, patcher.ENTRYPOINTS[path.name])
+    patched = path.read_text()
+    compile(patched, str(path), "exec")
+    for phase in (
+        "wait_for_rollout",
+        "wait_for_next_rollout",
+        "evaluate_rollouts",
+        "evaluate_rollouts_end",
+    ):
+        assert patcher.phase_marker(phase) in patched
+    assert patched.count("if not args.eval_uses_snapshots else _tg_nullcontext()") == 2
+
+
+def test_component_driver_does_not_write_partial_instrumentation(patchers, tmp_path):
+    source = """from miles.ray.placement_group import create_rollout_components
+async def train(args):
+    for rollout_id in range(args.start_rollout_id, args.num_rollout):
+        await actor_model.train(rollout_id, data)
+"""
+    path = tmp_path / "train.py"
+    path.write_text(source)
+    patcher = patchers["miles"]
+    with pytest.raises(RuntimeError, match="phases not instrumented"):
+        patcher._patch_file(path, patcher.ENTRYPOINTS[path.name])
+    assert path.read_text() == source
+
+
+def test_miles_controller_driver_preserves_calls_and_branches(patchers, tmp_path):
+    source = """import asyncio
+from miles.ray.placement_group import create_rollout_components
+async def train(args):
+    await update_weights(actor_model, rollout_executor)
+    for rollout_id in range(args.start_rollout_id, args.num_rollout):
+        await inference_controller.prepare_eval()
+        await rollout_executor.eval.remote(rollout_id)
+        await inference_controller.prepare_rollout(rollout_id)
+        rollout_data_pack = await rollout_executor.get.remote(rollout_id)
+        await actor_model.train(rollout_id, rollout_data_pack)
+        if args.colocate_memory_peak_device == "gpu":
+            await inference_controller.onload_weights()
+            await offload_train()
+        else:
+            await offload_train()
+            await inference_controller.onload_weights()
+        await update_weights(actor_model, rollout_executor, rollout_id=rollout_id)
+        await inference_controller.prepare_eval()
+        await rollout_executor.eval.remote(rollout_id)
+"""
+    path = tmp_path / "train.py"
+    path.write_text(source)
+    patcher = patchers["miles"]
+    patcher._patch_file(path, patcher.ENTRYPOINTS[path.name])
+    patched = path.read_text()
+    compile(patched, str(path), "exec")
+    for phase in (
+        "initial_weight_sync",
+        "evaluate_rollouts",
+        "generate_rollouts",
+        "train_models",
+        "offload_train",
+        "weight_sync",
+        "evaluate_rollouts_end",
+    ):
+        assert patcher.phase_marker(phase) in patched
+
+    class StripTiming(ast.NodeTransformer):
+        def visit_With(self, node):
+            node = self.generic_visit(node)
+            return (
+                node.body
+                if any("_tg_" in ast.unparse(i.context_expr) for i in node.items)
+                else node
+            )
+
+    before = ast.parse(source)
+    after = StripTiming().visit(ast.parse(patched))
+    after.body = after.body[-len(before.body) :]  # Remove injected bootstrap imports.
+    assert ast.dump(before) == ast.dump(after)
+    patcher._patch_file(path, patcher.ENTRYPOINTS[path.name])
+    assert path.read_text() == patched
+
+
+def test_miles_rollout_executor_layout(patchers, tmp_path):
+    patcher = patchers["miles"]
+    target = patcher.PACKAGE_TARGETS[0]
+    path = tmp_path / "miles/ray/rollout/rollout_executor.py"
+    path.parent.mkdir(parents=True)
+    source = (TESTDATA / "miles/rollout_manager.py.input").read_text()
+    path.write_text(
+        source.replace(
+            "async def generate(self, rollout_id):", "async def get(self, rollout_id):"
+        )
+    )
+    patcher._patch_package_file(tmp_path, target)
+    assert "with _tg_role('rollout', rollout_id):" in path.read_text()
+    compile(path.read_text(), str(path), "exec")
 
 
 def patcher_path(framework: str) -> Path:


### PR DESCRIPTION
Draft for the newer Miles/Docker migration; hold until that migration is ready.

Miles splits rollout management between an inference controller and RolloutExecutor, so the previous status/timing anchors skip initialization, generation, weight updates, and worker timing. Adapt the existing timing recorders and status hooks to this layout and the changed Megatron call signatures. Reapply timing after a local Miles source overlay.

The new driver matching wraps complete await statements while preserving branch order. It currently retains the older layout for the repository's existing image. When that image is retired, the legacy path can be removed. Initial evaluation preparation and synchronous evaluation-only calls are included; snapshot dispatch keeps its existing timing treatment.

Validation: 35 existing/extended patch tests pass. Both actual drivers in Miles commit `78747f69123da316af95e581c78114b26282bb8f` compile, remain idempotent, and have identical training ASTs after removing timing wrappers. The earlier seven-target check also passed. Marker checks detect missing core phases; they do not prove coverage of arbitrary future Miles changes. Ruff passes. Training-step validation is ongoing. No recipes or run records included.