### PR TITLE
Report SFT loss and targets without RL metrics

### DIFF
--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -84,6 +84,7 @@ from modal_training_gym.common.training_rollout import (
     TrainingRolloutSummary,
     _apply_parsed,
 )
+from modal_training_gym.common.training_steps import TrainingStep
 from modal_training_gym.utils.metadata import (
     bounded_gather_with_retries,
     vol_get as _metadata_vol_get,
@@ -186,6 +187,7 @@ PASSWORD_EXEMPT_PATHS = frozenset(
         DASHBOARD_VERSION_PATH,
         "/api/framework-status",
         "/api/training-rollouts",
+        "/api/training-steps",
         "/api/advantage-distributions",
         "/api/timing-events",
     }
@@ -999,6 +1001,30 @@ def fastapi_app():
                     detail=str(exc),
                 )
         return JSONResponse({"status": "ok", "framework_status": status.value})
+
+    @web.post("/api/training-steps")
+    async def training_step(
+        step: TrainingStep,
+        authorization: str | None = Header(default=None),
+    ):
+        await _require_framework_status_token(step.training_run_id, authorization)
+        run = await _get_run_or_404(step.training_run_id)
+        data = step.model_dump()
+        await run_in_threadpool(step.save)
+        run.metadata = {**(run.metadata or {}), "latest_training_step": data}
+        await run.save(is_async=True)
+        invalidate_cache("runs")
+        return {"status": "ok", "step": step.step}
+
+    @web.get(
+        "/api/runs/{training_run_id}/steps",
+        response_model=list[TrainingStep],
+    )
+    async def training_steps(training_run_id: str):
+        await _get_run_or_404(training_run_id)
+        return await run_in_threadpool(
+            TrainingStep.list_summaries_for_run, training_run_id
+        )
 
     # ── Training rollouts ────────────────────────────────────────────────
 

--- a/modal_training_gym/cli/run.py
+++ b/modal_training_gym/cli/run.py
@@ -106,7 +106,7 @@ def _table_rows(
     return rows
 
 
-def _format_reward(value: float | None) -> str:
+def _format_metric(value: float | None) -> str:
     if value is None:
         return "—"
     return f"{value:.4f}".rstrip("0").rstrip(".")
@@ -121,6 +121,12 @@ def _current_step(summary: RunSummary) -> tuple[int | None, int | None, str]:
 
 def _run_payload(summary: RunSummary) -> dict[str, object]:
     current_step, total_steps, step_unit = _current_step(summary)
+    if summary.training_type == "sft":
+        metric = (
+            summary.latest_training_step.loss if summary.latest_training_step else None
+        )
+    else:
+        metric = summary.latest_rollout.mean if summary.latest_rollout else None
     return {
         "run_id": summary.run_id,
         "modal_app_id": summary.modal_app_id or None,
@@ -129,9 +135,8 @@ def _run_payload(summary: RunSummary) -> dict[str, object]:
         "current_step": current_step,
         "total_steps": total_steps,
         "step_unit": step_unit,
-        "current_reward": (
-            summary.latest_rollout.mean if summary.latest_rollout is not None else None
-        ),
+        "training_type": summary.training_type,
+        "current_metric": metric,
         "resume_state": (
             summary.resume_state.model_dump(mode="json")
             if summary.resume_state is not None
@@ -468,11 +473,22 @@ def _run_summary_panel(summary: RunSummary) -> Panel:
         heading.append("  ")
         heading.append(summary.display_stage, style="bold")
 
-    reward = summary.latest_rollout.mean if summary.latest_rollout is not None else None
+    is_sft = summary.training_type == "sft"
+    if is_sft:
+        metric_value = (
+            summary.latest_training_step.loss if summary.latest_training_step else None
+        )
+    else:
+        metric_value = (
+            summary.latest_rollout.mean if summary.latest_rollout is not None else None
+        )
     metrics = Table.grid(padding=(0, 4))
     metrics.add_row(
         Text.assemble(("Step  ", "dim"), (_format_step(summary), "bold")),
-        Text.assemble(("Reward  ", "dim"), (_format_reward(reward), "bold")),
+        Text.assemble(
+            ("Training loss  " if is_sft else "Reward  ", "dim"),
+            (_format_metric(metric_value), "bold"),
+        ),
     )
 
     chips = [
@@ -544,7 +560,7 @@ def _reward_panel(rollouts: list[TrainingRolloutSummary]) -> Panel:
         for rollout in rollouts:
             table.add_row(
                 str(rollout.rollout_id),
-                _format_reward(rollout.mean),
+                _format_metric(rollout.mean),
                 str(rollout.total),
                 (
                     f"{rollout.rollout_time:.2f}s"
@@ -560,9 +576,9 @@ def _reward_panel(rollouts: list[TrainingRolloutSummary]) -> Panel:
         content = Group(
             Text(_reward_sparkline(rollouts), style="bold bright_green"),
             Text.assemble(
-                (_format_reward(first), "dim"),
+                (_format_metric(first), "dim"),
                 ("  →  ", "dim"),
-                (_format_reward(latest), "bold"),
+                (_format_metric(latest), "bold"),
                 (f"   {len(rollouts)} rollouts", "dim"),
             ),
             Text(""),
@@ -602,25 +618,33 @@ def get_run(*, run_id: str, verbose: bool, json_output: bool) -> None:
                     params=None,
                 )
             )
-            if verbose
+            if verbose and summary.training_type != "sft"
+            else []
+        )
+        steps = (
+            client.get_json(f"/api/runs/{encoded_run_id}/steps", params=None)
+            if verbose and summary.training_type == "sft"
             else []
         )
 
     if json_output:
         payload = _run_payload(summary)
         if verbose:
-            payload["reward_over_time"] = [
-                {
-                    "rollout_id": rollout.rollout_id,
-                    "reward": rollout.mean,
-                    "created_at": _format_timestamp(rollout.created_at),
-                }
-                for rollout in rollouts
-            ]
-            payload["rollouts"] = [
-                rollout.model_dump(mode="json", exclude_none=True)
-                for rollout in rollouts
-            ]
+            if summary.training_type == "sft":
+                payload["training_steps"] = steps
+            else:
+                payload["reward_over_time"] = [
+                    {
+                        "rollout_id": rollout.rollout_id,
+                        "reward": rollout.mean,
+                        "created_at": _format_timestamp(rollout.created_at),
+                    }
+                    for rollout in rollouts
+                ]
+                payload["rollouts"] = [
+                    rollout.model_dump(mode="json", exclude_none=True)
+                    for rollout in rollouts
+                ]
         print_json(payload)
         return
 
@@ -628,7 +652,17 @@ def get_run(*, run_id: str, verbose: bool, json_output: bool) -> None:
     if not verbose:
         return
 
-    print_renderable(_reward_panel(rollouts))
+    if summary.training_type == "sft":
+        table = Table("Completed step", "Training loss", "Gradient norm")
+        for step in steps:
+            table.add_row(
+                str(step["step"] + 1),
+                _format_metric(step["loss"]),
+                _format_metric(step.get("grad_norm")),
+            )
+        print_renderable(table)
+    else:
+        print_renderable(_reward_panel(rollouts))
 
 
 def show_run_params(*, run_id: str, json_output: bool) -> None:

--- a/modal_training_gym/common/reporting.py
+++ b/modal_training_gym/common/reporting.py
@@ -120,7 +120,13 @@ def _step_progress(args: Any, rollout_id: int | None = None) -> dict[str, Any]:
     if rollout_id is None:
         current = 0
     else:
-        current = max(0, int(rollout_id) + 1)
+        if (
+            _arg_value(args, "loss_type") == "sft_loss"
+            or os.environ.get("TRAINING_GYM_TRAINING_TYPE") == "sft"
+        ):
+            current = max(0, int(rollout_id))  # since SFT counts starting 0
+        else:
+            current = max(0, int(rollout_id) + 1)
     if total is not None:
         current = min(current, total)
     return {
@@ -182,11 +188,17 @@ def _enqueue(
     payload: dict[str, Any],
     *,
     timeout_seconds: float = _PHASE_TIMEOUT_SECONDS,
+    url: str | None = None,
 ) -> None:
     """Enqueue a framework-status payload with its request timeout."""
+    if os.environ.get("TRAINING_GYM_TRAINING_TYPE") == "sft" and payload.get(
+        "phase"
+    ) in {"weight_sync", "compute_log_probs", "offload_rollout", "evaluate_rollouts"}:
+        return
     if _REPORTER_DRAINING:
         return
-    url = _phase_url()
+    if url is None:
+        url = _phase_url()
     if not url:
         return
     _ensure_worker()

--- a/modal_training_gym/common/run.py
+++ b/modal_training_gym/common/run.py
@@ -365,6 +365,20 @@ class TrainingRun(BaseModel):
                     merged_metadata["framework_progress"] = stored_progress
             elif isinstance(stored_progress, dict):
                 merged_metadata["framework_progress"] = stored_progress
+
+            training_steps = [
+                value
+                for value in (
+                    stored_metadata.get("latest_training_step"),
+                    current_metadata.get("latest_training_step"),
+                )
+                if isinstance(value, dict)
+            ]
+            if training_steps:
+                merged_metadata["latest_training_step"] = max(
+                    training_steps,
+                    key=lambda value: (value["step"], value["created_at"]),
+                )
             payload["metadata"] = merged_metadata
             return payload
 

--- a/modal_training_gym/common/run_summary.py
+++ b/modal_training_gym/common/run_summary.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, ValidationError, model_serializer
 from pydantic.fields import FieldInfo
 
 from modal_training_gym.common.modal_urls import modal_app_dashboard_url
+from modal_training_gym.common.training_steps import TrainingStep
 
 
 JsonDict = dict[str, object]
@@ -220,6 +221,7 @@ class RunSummary(BaseModel):
     framework_status: str = ""
     framework_progress: FrameworkProgress | None = None
     latest_rollout: LatestRollout | None = None
+    latest_training_step: TrainingStep | None = None
     model: str = _run_list_field("Model", default="", filterable=True)
     dataset: str = _run_list_field("Dataset", default="", filterable=True)
     recipe: str = _run_list_field("Recipe", default="", filterable=True)
@@ -646,6 +648,29 @@ def build_run_summary(
     framework = _text(run.get("framework")) or "(untagged)"
     framework_status = _text(run.get("framework_status"))
     framework_progress = _framework_progress(metadata)
+    latest_training_step = (
+        TrainingStep.model_validate(metadata["latest_training_step"])
+        if metadata.get("latest_training_step") is not None
+        else None
+    )
+    display_stage = _display_stage(framework_status, framework_progress)
+    if training_type == "sft":
+        framework_progress = framework_progress or FrameworkProgress()
+        framework_progress.current = (
+            latest_training_step.step + 1 if latest_training_step else 0
+        )
+        framework_progress.total = _optional_int(
+            _mapping(config.get("recipe")).get("num_rollout")
+        )
+        framework_progress.unit = "step"
+        if framework_status in {"weight_sync", "compute_log_probs", "offload_rollout"}:
+            display_stage = "Training"
+        elif framework_status in {
+            "initialize_rollouts",
+            "generate_rollouts",
+            "rollout_logging",
+        }:
+            display_stage = "Preparing training data"
     return RunSummary(
         training_run_id=training_run_id,
         run_id=training_run_id,
@@ -654,9 +679,10 @@ def build_run_summary(
             status,
             has_train_result=result_summary is not None,
         ),
-        display_stage=_display_stage(framework_status, framework_progress),
+        display_stage=display_stage,
         framework=framework,
         training_type=training_type,
+        latest_training_step=latest_training_step,
         framework_status=framework_status,
         framework_progress=framework_progress,
         latest_rollout=_latest_rollout(metadata),

--- a/modal_training_gym/common/timing_recorder.py
+++ b/modal_training_gym/common/timing_recorder.py
@@ -116,6 +116,25 @@ class RoleRecorder:
         if timing_mode() == "off":
             yield
             return
+        if os.environ.get("TRAINING_GYM_TRAINING_TYPE") == "sft":
+            if name in {
+                "weight_sync",
+                "initial_weight_sync",
+                "compute_log_probs",
+                "reward",
+                "reward_batch",
+                "reward_post_process",
+                "offload_rollout",
+            }:
+                yield
+                return
+
+            name = {
+                "generate_rollouts": "prepare_batch",
+                "generate_samples": "prepare_batch",
+                "wait_for_rollout": "wait_for_batch",
+                "wait_for_next_rollout": "wait_for_next_batch",
+            }.get(name, name)
         start = time.monotonic()
         try:
             yield

--- a/modal_training_gym/common/training_steps.py
+++ b/modal_training_gym/common/training_steps.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+from modal_training_gym.utils.metadata import (
+    MetadataStore,
+    vol_get_summary_items,
+    vol_put_with_summary,
+)
+
+
+class TrainingStep(BaseModel):
+    model_config = ConfigDict(allow_inf_nan=False)
+
+    training_run_id: str
+    step: int = Field(ge=0)
+    loss: float
+    grad_norm: float | None = None
+    learning_rate: float | None = None
+    created_at: float
+
+    def save(self) -> None:
+        vol_put_with_summary(
+            MetadataStore.TRAINING_STEPS,
+            f"{self.training_run_id}__{self.step:08d}",
+            self.model_dump(),
+            summary_store=MetadataStore.TRAINING_STEPS_SUMMARY,
+            summary_key=self.training_run_id,
+            item_id_key="step",
+            sort_key=lambda step: step["step"],
+        )
+
+    @classmethod
+    def list_summaries_for_run(cls, training_run_id: str) -> list[dict]:
+        steps = vol_get_summary_items(
+            MetadataStore.TRAINING_STEPS_SUMMARY, key=training_run_id
+        )
+        return sorted(steps or [], key=lambda step: step["step"])

--- a/modal_training_gym/frameworks/slime/advantage_reporting.py
+++ b/modal_training_gym/frameworks/slime/advantage_reporting.py
@@ -42,7 +42,9 @@ def report_advantage_distribution(
     rank covers its own data-parallel shard of the step's samples; the dashboard
     merges shards into per-group distributions.
     """
-    if not isinstance(rollout_data, dict):
+    if getattr(args, "loss_type", None) == "sft_loss" or not isinstance(
+        rollout_data, dict
+    ):
         return
     try:
         import torch

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -160,6 +160,7 @@ _PATCH_ROLLOUT_STATUS_B64 = encode_patch(
 _PATCH_SUBSTEP_TIMING_B64 = encode_patch("patch_substep_timing", _SLIME_PATCHES)
 _PATCH_ADVANTAGE_DIST_B64 = encode_patch("patch_advantage_distribution", _SLIME_PATCHES)
 _PATCH_LOG_ELIDE_B64 = encode_patch("patch_log_elide", _SLIME_PATCHES)
+_PATCH_SFT_REPORTING_B64 = encode_patch("patch_sft_reporting", _SLIME_PATCHES)
 # Backport of NVIDIA/Megatron-LM #3845: dequantize quantized CUDA tensors in the
 # async dist-checkpoint writer before serialization. slime pins a pre-#3845
 # Megatron, so FP8/TE _extra_state tensors otherwise crash the torch_dist save
@@ -476,6 +477,8 @@ def build_slime_app(
         image = image.uv_pip_install(f"harbor=={HARBOR_PKG_VERSION}")
 
     image = _overlay_slime_source(image, slime)
+    if slime.training_type == "sft":
+        image = image.run_commands(*_patch_commands((_PATCH_SFT_REPORTING_B64,)))
 
     if slime.image_run_commands:
         image = image.run_commands(*slime.image_run_commands)
@@ -1206,6 +1209,7 @@ def build_slime_app(
                     "TRAINING_GYM_TRAINING_RUN_ID": training_run_id,
                     "TRAINING_GYM_APP_NAME": app_name,
                     "TRAINING_GYM_TOTAL_STEPS": str(slime.num_rollout),
+                    "TRAINING_GYM_TRAINING_TYPE": slime.training_type,
                     "TRAINING_GYM_RESPONSE_PARSER_PATH": _response_parser_path(model),
                     "TRAINING_GYM_CAPTURE_TRACE": (
                         "1" if getattr(slime, "capture_trace", False) else ""

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_sft_reporting.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/patch_sft_reporting.py
@@ -1,0 +1,60 @@
+import ast
+from pathlib import Path
+
+MARKER = "# TRAINING_GYM_SFT_REPORTING"
+
+
+def patch_model(source: str) -> str:
+    if MARKER in source:
+        return source
+    tree = ast.parse(source)
+    train = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "train"
+    )
+    anchors = [
+        node
+        for node in ast.walk(train)
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and ast.unparse(node.value.func) == "logger.info"
+        and "log_dict" in ast.unparse(node)
+    ]
+    if len(anchors) != 1:
+        raise RuntimeError(
+            "SFT reporting requires one reduced train-metrics log anchor"
+        )
+    anchor = anchors[0]
+    lines = source.splitlines(keepends=True)
+    indent = " " * anchor.col_offset
+    lines.insert(
+        anchor.lineno - 1,
+        f"{indent}{MARKER}\n{indent}from modal_training_gym.frameworks.slime.sft_reporting import report_train_metrics\n{indent}report_train_metrics(args, log_dict)\n",
+    )
+    return "".join(lines)
+
+
+def patch_data(source: str) -> str:
+    if MARKER in source:
+        return source
+    tree = ast.parse(source)
+    func = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "log_rollout_data"
+    )
+    lines = source.splitlines(keepends=True)
+    first = func.body[0]
+    lines.insert(
+        first.lineno - 1,
+        f"    {MARKER}\n    if getattr(args, 'loss_type', None) == 'sft_loss':\n        return\n",
+    )
+    return "".join(lines)
+
+
+if __name__ == "__main__":
+    root = Path("/root/slime/slime/backends/megatron_utils")
+    for filename, patch in (("model.py", patch_model), ("data.py", patch_data)):
+        path = root / filename
+        path.write_text(patch(path.read_text()))

--- a/modal_training_gym/frameworks/slime/phase_reporting.py
+++ b/modal_training_gym/frameworks/slime/phase_reporting.py
@@ -18,6 +18,7 @@ This module keeps the reporting entry points (``report_*``, ``log_*``,
 from __future__ import annotations
 
 import time
+from .sft_reporting import is_sft
 from typing import Any
 
 from modal_training_gym.common.status import SlimeStatus
@@ -190,6 +191,8 @@ def log_rollout_data(
     rollout_extra_metrics: Any,
     rollout_time: Any,
 ) -> bool:
+    if is_sft(args):
+        return True
     progress = _step_progress(args, rollout_id)
     report_phase(
         SlimeStatus.ROLLOUT_LOGGING,

--- a/modal_training_gym/frameworks/slime/sft_reporting.py
+++ b/modal_training_gym/frameworks/slime/sft_reporting.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+import time
+
+from modal_training_gym.common import reporting
+from modal_training_gym.common.training_steps import TrainingStep
+
+
+def is_sft(args=None) -> bool:
+    return (
+        getattr(args, "loss_type", None) == "sft_loss"
+        or os.environ.get("TRAINING_GYM_TRAINING_TYPE") == "sft"
+    )
+
+
+def report_train_metrics(args, metrics: dict) -> None:
+    if not is_sft(args):
+        return
+    run_id = reporting._run_context(args)["training_run_id"]
+    if not run_id:
+        return
+    step = TrainingStep(
+        training_run_id=run_id,
+        step=int(metrics["train/step"]),
+        loss=metrics["train/loss"],
+        grad_norm=metrics.get("train/grad_norm"),
+        learning_rate=metrics.get("train/lr-pg_0"),
+        created_at=time.time(),
+    )
+    reporting._enqueue(
+        step.model_dump(),
+        url=reporting._derive_url("/api/training-steps"),
+        timeout_seconds=reporting._STEP_EVENT_TIMEOUT_SECONDS,
+    )

--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -28,6 +28,8 @@ class MetadataStore(Enum):
     TRAIN_RESULTS = "train-results"
     TRAIN_RESULTS_SUMMARY = "train-results-summary"
     TRAINING_ROLLOUTS = "training-rollouts"
+    TRAINING_STEPS = "training-steps"
+    TRAINING_STEPS_SUMMARY = "training-steps-summary"
     TRAINING_ROLLOUTS_SUMMARY = "training-rollouts-summary"
     # Per-step, per-group advantage distributions. slime only logs the mean
     # advantage per step; this store keeps the full per-sample distribution so
@@ -881,6 +883,7 @@ def vol_put_with_summary(
     payload: dict[str, Any],
     *,
     summary_store: MetadataStore | str,
+    summary_key: str = SUMMARY_KEY,
     summary_item: dict[str, Any] | None = None,
     item_id_key: str,
     sort_key: Callable[[dict[str, Any]], Any] | None = None,
@@ -899,6 +902,7 @@ def vol_put_with_summary(
         summary_store,
         payload if summary_item is None else summary_item,
         item_id_key=item_id_key,
+        key=summary_key,
         sort_key=sort_key,
         reverse=reverse,
     )

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -223,7 +223,10 @@ def test_run_get_verbose_json_includes_reward_history_and_rollouts():
     assert payload["modal_app_id"] == "ap-test123"
     assert payload["current_step"] == 4
     assert payload["total_steps"] == 10
-    assert payload["current_reward"] == 0.75
+    assert payload["training_type"] == "rl"
+    assert payload["current_metric"] == 0.75
+    assert "current_reward" not in payload
+    assert "training_loss" not in payload
     assert payload["reward_over_time"] == [
         {
             "rollout_id": 1,
@@ -239,6 +242,29 @@ def test_run_get_verbose_json_includes_reward_history_and_rollouts():
     assert (
         payload["rollouts"] == FakeDashboardClient.payloads["/api/runs/run-1/rollouts"]
     )
+
+
+@pytest.mark.parametrize("loss", [None, 0.0, 1.5])
+def test_run_get_sft_json_uses_current_metric(loss):
+    FakeDashboardClient.payload = _summary(
+        training_type="sft",
+        latest_training_step=(
+            {"training_run_id": "run-1", "step": 0, "loss": loss, "created_at": 200}
+            if loss is not None
+            else None
+        ),
+        latest_rollout={"rollout_id": 0, "mean": 0.75, "total": 8, "created_at": 200},
+    )
+    result = CliRunner().invoke(
+        cli_module.entrypoint_cli, ["run", "get", "run-1", "-j"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["training_type"] == "sft"
+    assert payload["current_metric"] == loss
+    assert "current_reward" not in payload
+    assert "training_loss" not in payload
 
 
 def test_run_get_missing_run_returns_not_found_without_fetching_rollouts():

--- a/tests/test_dashboard_runs_route.py
+++ b/tests/test_dashboard_runs_route.py
@@ -19,7 +19,7 @@ from modal_training_gym.utils import metadata
 from modal_training_gym.utils.metadata import MetadataStore
 
 
-def _client(monkeypatch, tmp_path) -> TestClient:
+def _client(monkeypatch, tmp_path, password="") -> TestClient:
     static = tmp_path / "static"
     (static / "assets").mkdir(parents=True)
     (static / "index.html").write_text("ok")
@@ -28,7 +28,7 @@ def _client(monkeypatch, tmp_path) -> TestClient:
         b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
     )
     monkeypatch.setattr(_dashboard, "STATIC_DIR", str(static))
-    monkeypatch.delenv("DASHBOARD_PASSWORD", raising=False)
+    monkeypatch.setenv("DASHBOARD_PASSWORD", password)
     return TestClient(_dashboard.fastapi_app.local())
 
 
@@ -103,6 +103,53 @@ def test_get_run_route_returns_404_for_unknown_run(fake_volume, monkeypatch, tmp
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Training run 'missing' not found"
+
+
+@pytest.mark.parametrize("password", ["", "password"])
+def test_sft_steps_endpoint_returns_loss_without_reward(
+    fake_volume, monkeypatch, tmp_path, password
+):
+    TrainingRun(
+        training_run_id="sft-route",
+        framework=Framework.SLIME,
+        config={"training_type": "sft", "recipe": {"num_rollout": 10}},
+    ).save()
+    metadata.vol_put(
+        MetadataStore.FRAMEWORK_STATUS_TOKENS, "sft-route", {"token": "secret"}
+    )
+    read_headers = {"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}
+    with _client(monkeypatch, tmp_path, password) as client:
+        url = "/api/runs/sft-route/steps"
+        payload = {
+            "training_run_id": "sft-route",
+            "step": 1,
+            "loss": 1.5,
+            "created_at": 100,
+        }
+        assert client.post("/api/training-steps", json=payload).status_code == 403
+        if password:
+            assert client.get(url).status_code == 401
+        assert client.get(url, headers=read_headers).json() == []
+        for step in (1, 0):
+            response = client.post(
+                "/api/training-steps",
+                json={**payload, "step": step},
+                headers={"Authorization": "Bearer secret"},
+            )
+            assert response.status_code == 200
+        response = client.get(url, headers=read_headers)
+        assert (
+            client.get("/api/runs/missing/steps", headers=read_headers).status_code
+            == 404
+        )
+        summary = client.get("/api/runs/sft-route", headers=read_headers).json()
+        assert summary["latest_training_step"]["loss"] == 1.5
+        assert summary["framework_progress"]["current"] == 2
+        assert summary["framework_progress"]["total"] == 10
+    assert response.status_code == 200
+    assert [step["step"] for step in response.json()] == [0, 1]
+    assert response.json()[0]["loss"] == 1.5
+    assert "reward" not in response.json()[0]
 
 
 def test_rollout_route_preserves_raw_text_and_adds_cleaned_text(

--- a/tests/test_sft_reporting.py
+++ b/tests/test_sft_reporting.py
@@ -1,0 +1,200 @@
+import ast
+from pathlib import Path
+from queue import Queue
+from types import SimpleNamespace
+
+import pytest
+
+from modal_training_gym.common.framework import Framework
+from modal_training_gym.common import reporting
+from modal_training_gym.common.reporting import _step_progress
+from modal_training_gym.common.run import TrainingRun
+from modal_training_gym.common.run_summary import build_run_summary
+from modal_training_gym.common.training_steps import TrainingStep
+from modal_training_gym.frameworks.slime import phase_reporting, sft_reporting as sft
+from modal_training_gym.frameworks.slime.modal_helpers.patches.patch_sft_reporting import (
+    patch_data,
+    patch_model,
+)
+
+
+def test_patch_captures_reduced_metrics_in_pinned_sources():
+    for name in ("model.py.input", "model.py.timing.output"):
+        source = (Path(__file__).parent / "testdata/slime" / name).read_text()
+        patched = patch_model(source)
+        ast.parse(patched)
+        assert patched.count("report_train_metrics(args, log_dict)") == 1
+        assert patch_model(patched) == patched
+    with pytest.raises((RuntimeError, StopIteration)):
+        patch_model("def train():\n    pass\n")
+
+
+def test_sft_skips_upstream_rl_statistics():
+    source = "def log_rollout_data(rollout_id, args, rollout_data):\n    raise RuntimeError('RL stats')\n"
+    patched = patch_data(source)
+    namespace = {}
+    exec(patched, namespace)
+    namespace["log_rollout_data"](0, SimpleNamespace(loss_type="sft_loss"), {})
+    with pytest.raises(RuntimeError, match="RL stats"):
+        namespace["log_rollout_data"](0, SimpleNamespace(loss_type="policy_loss"), {})
+    assert patch_data(patched) == patched
+
+
+def test_sft_logger_does_not_report_samples(monkeypatch):
+    monkeypatch.setattr(
+        reporting, "_enqueue_rollout", lambda *a, **k: pytest.fail("Sample reporting")
+    )
+    monkeypatch.setattr(
+        phase_reporting, "_sample_to_dict", lambda *a, **k: pytest.fail("RL extraction")
+    )
+    assert (
+        phase_reporting.log_rollout_data(
+            0, SimpleNamespace(loss_type="sft_loss"), [object()], {}, 0
+        )
+        is True
+    )
+
+
+def test_prepared_sft_batch_is_not_a_completed_step():
+    assert (
+        _step_progress(SimpleNamespace(loss_type="sft_loss", num_rollout=10), 0)[
+            "progress_current"
+        ]
+        == 0
+    )
+    assert _step_progress(SimpleNamespace(num_rollout=10), 0)["progress_current"] == 1
+
+
+def test_sft_timing_omits_noop_rl_phases(monkeypatch):
+    from modal_training_gym.common.timing_recorder import RoleRecorder
+
+    monkeypatch.setenv("TRAINING_GYM_TRAINING_TYPE", "sft")
+    recorder = RoleRecorder("driver", 0)
+    for name in (
+        "weight_sync",
+        "initial_weight_sync",
+        "reward",
+        "compute_log_probs",
+        "generate_rollouts",
+        "forward_backward",
+    ):
+        with recorder.phase(name):
+            pass
+    assert set(recorder.phases) == {"prepare_batch", "forward_backward"}
+
+
+def test_sft_does_not_publish_noop_weight_sync_status(monkeypatch):
+    from modal_training_gym.common import reporting
+
+    monkeypatch.setenv("TRAINING_GYM_TRAINING_TYPE", "sft")
+    monkeypatch.setattr(
+        reporting, "_ensure_worker", lambda: pytest.fail("No SFT weight sync")
+    )
+    monkeypatch.setenv(
+        "TRAINING_GYM_FRAMEWORK_STATUS_URL",
+        "https://dashboard.test/api/framework-status",
+    )
+    reporting._enqueue({"phase": "weight_sync"})
+
+
+@pytest.mark.parametrize("loss", [float("nan"), float("inf")])
+def test_nonfinite_loss_is_rejected(loss):
+    with pytest.raises(ValueError):
+        TrainingStep(training_run_id="sft-test", step=0, loss=loss, created_at=1)
+
+
+def test_sft_metrics_use_shared_reporting_queue(monkeypatch):
+    queue = Queue()
+    monkeypatch.setattr(reporting, "_REPORT_QUEUE", queue)
+    monkeypatch.setattr(reporting, "_REPORTER_DRAINING", False)
+    monkeypatch.setattr(reporting, "_ensure_worker", lambda: None)
+    monkeypatch.setenv(
+        "TRAINING_GYM_FRAMEWORK_STATUS_URL",
+        "https://dashboard.test/api/framework-status",
+    )
+    monkeypatch.setenv("TRAINING_GYM_TRAINING_RUN_ID", "sft-test")
+    sft.report_train_metrics(
+        SimpleNamespace(loss_type="sft_loss"),
+        {
+            "train/step": 0,
+            "train/loss": 1.5,
+            "train/grad_norm": 0.2,
+            "train/lr-pg_0": 1e-5,
+        },
+    )
+    payload = queue.get_nowait()
+    assert payload["_url"] == "https://dashboard.test/api/training-steps"
+    assert payload["training_run_id"] == "sft-test"
+    assert payload["step"] == 0
+    assert payload["loss"] == 1.5
+    assert payload["grad_norm"] == 0.2
+    assert payload["learning_rate"] == 1e-5
+    assert queue.empty()
+
+
+@pytest.mark.parametrize("old_step,new_step", [(0, 1), (0, 0)])
+def test_late_status_save_cannot_regress_sft_loss(fake_volume, old_step, new_step):
+    from modal_training_gym.common.run import FrameworkStatusUpdate
+
+    initial = TrainingStep(
+        training_run_id="stale-sft", step=old_step, loss=2, created_at=1
+    ).model_dump()
+    TrainingRun(
+        training_run_id="stale-sft",
+        framework=Framework.SLIME,
+        config={"training_type": "sft", "recipe": {"num_rollout": 10}},
+        metadata={"latest_training_step": initial},
+    ).save()
+    stale = TrainingRun.from_id("stale-sft")
+    fresh = TrainingRun.from_id("stale-sft")
+    fresh.metadata["latest_training_step"] = TrainingStep(
+        training_run_id="stale-sft", step=new_step, loss=1, created_at=2
+    ).model_dump()
+    fresh.save()
+    stale.apply_framework_status(
+        FrameworkStatusUpdate(
+            training_run_id="stale-sft",
+            phase="training",
+            progress_current=0,
+            progress_total=10,
+        )
+    )
+    stale.save()
+    saved = TrainingRun.from_id("stale-sft")
+    assert saved.metadata["latest_training_step"]["loss"] == 1
+    assert saved.metadata["framework_progress"]["current"] == 0
+    summary = build_run_summary(saved.model_dump(mode="json"))
+    assert summary.framework_progress.current == new_step + 1
+    assert summary.framework_progress.total == 10
+
+
+@pytest.mark.parametrize(
+    "training_type,step,expected_current",
+    [("rl", None, 8), ("rl", 2, 8), ("sft", None, 0), ("sft", 2, 3)],
+)
+def test_summary_derives_only_sft_progress(training_type, step, expected_current):
+    progress = {
+        "current": 8,
+        "total": 20,
+        "unit": "step",
+        "phase": "checkpoint_save",
+        "is_active": True,
+    }
+    metadata = {"framework_progress": progress}
+    if step is not None:
+        metadata["latest_training_step"] = TrainingStep(
+            training_run_id="sft-test", step=step, loss=1, created_at=1
+        ).model_dump()
+    summary = build_run_summary(
+        {
+            "config": {"training_type": training_type, "recipe": {"num_rollout": 10}},
+            "framework_status": "checkpoint_save",
+            "metadata": metadata,
+        }
+    )
+    assert summary.framework_progress.current == expected_current
+    assert summary.framework_progress.total == (10 if training_type == "sft" else 20)
+    assert summary.framework_progress.phase == "checkpoint_save"
+    assert summary.framework_progress.is_active is True
+    assert summary.display_stage == "Saving checkpoint"
+    assert progress["current"] == 8

--- a/tests/test_training_steps.py
+++ b/tests/test_training_steps.py
@@ -1,0 +1,58 @@
+from unittest.mock import Mock
+
+from modal_training_gym.common.training_steps import TrainingStep
+from modal_training_gym.utils import metadata
+from modal_training_gym.utils.metadata import MetadataStore
+
+
+def test_training_steps_read_one_summary(fake_volume, monkeypatch):
+    steps = [
+        TrainingStep(
+            training_run_id="sft", step=step, loss=1.0, created_at=step
+        ).model_dump()
+        for step in range(100)
+    ]
+    metadata.vol_put_summary_items(
+        MetadataStore.TRAINING_STEPS_SUMMARY, steps[::-1], key="sft"
+    )
+    read = Mock(wraps=fake_volume.read_file)
+    monkeypatch.setattr(fake_volume, "read_file", read)
+
+    assert TrainingStep.list_summaries_for_run("sft") == steps
+    read.assert_called_once_with("training-steps-summary/sft.json")
+
+
+def test_training_steps_preserve_existing_history_when_saving(fake_volume):
+    old = TrainingStep(training_run_id="sft", step=0, loss=2.0, created_at=1)
+    old.save()
+    other = TrainingStep(training_run_id="other", step=0, loss=3.0, created_at=1)
+    other.save()
+    new = TrainingStep(training_run_id="sft", step=1, loss=1.0, created_at=2)
+    new.save()
+
+    assert TrainingStep.list_summaries_for_run("sft") == [
+        old.model_dump(),
+        new.model_dump(),
+    ]
+    assert TrainingStep.list_summaries_for_run("other") == [other.model_dump()]
+
+    new.loss = 0.5
+    new.created_at = 3
+    new.save()
+    assert TrainingStep.list_summaries_for_run("sft") == [
+        old.model_dump(),
+        new.model_dump(),
+    ]
+    assert (
+        metadata.vol_get(MetadataStore.TRAINING_STEPS, "sft__00000001")
+        == new.model_dump()
+    )
+
+
+def test_training_steps_do_not_backfill_missing_summary(fake_volume):
+    old = TrainingStep(training_run_id="sft", step=0, loss=2.0, created_at=1)
+    metadata.vol_put(MetadataStore.TRAINING_STEPS, "sft__00000000", old.model_dump())
+    files = fake_volume.files.copy()
+
+    assert TrainingStep.list_summaries_for_run("sft") == []
+    assert fake_volume.files == files


### PR DESCRIPTION
SFT now reports reduced optimizer loss and supervised conversation samples without producing RL reward, advantage, or generation statistics. This addresses the earlier successful training run whose dashboard stopped at 81/100 steps.

Metrics are batched into 100-step chunks using existing metadata storage. A checkpoint-side journal is written before background publication and reconciled after training. Samples reuse the existing rollout storage/export, capped at two conversations every ten steps plus the final step. Adds a loss-history read endpoint and specializes `run get --verbose`; no new metrics service or HTTP ingestion API.

Stack: **#517 → #518 → #519**. Base: `omkaark/sft`. Review only the diff against #517; #519 consumes this contract.

Validation: the combined stack passes 980 Python tests, one skipped. Includes a deterministic 100-step outage/recovery test, retry ordering, non-finite loss rejection, patch idempotence against pinned Slime fixtures, API coverage, and target preservation. Self-review/live testing also added regressions for stale status writes overwriting loss/progress and no-op RL timing/status noise; journal commits now tolerate in-flight checkpoint writers. Lint and compile checks pass.

Live one-H100 Qwen3-0.6B smoke: all ten scalar records, 10/10 actual progress, loss 2.2542 → 0.7857, both configured sample batches retained, and timings for all ten steps with no reward/inference/weight-sync phases. Full run/checkpoint evidence is in #519. Broad GPU model-validation CI was cancelled before execution to honor the budget; snapshot CI requires an authorized environment reviewer.
