### PR TITLE
Add SFT dashboard views and workload filtering

### DIFF
--- a/dashboards/frontend/src/App.svelte
+++ b/dashboards/frontend/src/App.svelte
@@ -36,6 +36,7 @@
   let error = $state(null);
   let search = $state("");
   let activeRecipes = $state(new Set());
+  let trainingTypeFilter = $state("");
   let activeStatuses = $state(new Set());
   let activeGroups = $state(new Set());
   let trainingGroupBy = $state("none");
@@ -217,6 +218,7 @@
       group: activeGroups,
     };
     const facets = {};
+    if (trainingTypeFilter) facets.training_type = [trainingTypeFilter];
     for (const [name, selected] of Object.entries(selections)) {
       const universe = universes[name];
       if (!universe.length) continue;
@@ -863,6 +865,7 @@
       />
     {:else if activePage === "training"}
       <TrainingPage
+        bind:trainingTypeFilter
         {totalRuns}
         {matchingRunCount}
         {hasMoreRuns}

--- a/dashboards/frontend/src/components/FilterBar.svelte
+++ b/dashboards/frontend/src/components/FilterBar.svelte
@@ -16,6 +16,7 @@
     activeGroups,
     allGroupsActive,
     search = $bindable(),
+    trainingTypeFilter = $bindable(""),
     groupBy = $bindable(),
     onToggleRecipe,
     onSelectAllRecipes,
@@ -63,6 +64,14 @@
     />
   </label>
 
+  <label class="filter-button">
+    <span>Training type</span>
+    <select aria-label="Filter by training type" bind:value={trainingTypeFilter} class="bg-transparent text-(--text) text-[12px] [border:0]">
+      <option value="">All</option>
+      <option value="rl">RL</option>
+      <option value="sft">SFT</option>
+    </select>
+  </label>
   <div class="filterbar-menu-wrap">
     <button
       class="filter-button ghost-hover"

--- a/dashboards/frontend/src/components/RunSummary.svelte
+++ b/dashboards/frontend/src/components/RunSummary.svelte
@@ -6,6 +6,7 @@
   import TimeAgo from "./TimeAgo.svelte";
   import { formatTagValue, getGroupTags } from "../lib/format.js";
   import { normalizeMetricLinks } from "../lib/metricLinks.js";
+  import { isSft } from "../lib/trainingType.js";
 
   // The run-summary block shared by the list drawer and the detail page's
   // Summary tab, so both render identical metadata: status, stage, model,
@@ -149,6 +150,10 @@
 {#if run}
   <div class="run-summary">
     <section class="summary-section">
+      <div class="kv">
+        <span class="kv-key">Training type</span>
+        <span class="kv-value">{isSft(run) ? "Supervised fine-tuning (SFT)" : "Reinforcement learning (RL)"}</span>
+      </div>
       <div class="kv">
         <span class="kv-key">Status</span>
         <StatusPill status={getStatus(run)} />

--- a/dashboards/frontend/src/components/RunTimeline.svelte
+++ b/dashboards/frontend/src/components/RunTimeline.svelte
@@ -28,6 +28,7 @@
     runOrigin = null,
     asyncOverride = null,
     showOpenRollout = true,
+    trainingType = "rl",
     attemptMarkers = [],
   } = $props();
 
@@ -251,15 +252,16 @@
   }
 
   function tipRole(role) {
+    if (trainingType === "sft" && role === "rollout") return "Data";
     return role ? role[0].toUpperCase() + role.slice(1) : null;
   }
 
-  const roleDescriptions = {
+  const roleDescriptions = $derived({
     driver: "Runs the training loop.",
-    rollout: "Inference engines sampling from the current policy.",
-    actor: "Policy being trained.",
+    rollout: trainingType === "sft" ? "Prepares training batches." : "Inference engines sampling from the current policy.",
+    actor: trainingType === "sft" ? "Model being trained." : "Policy being trained.",
     critic: "Value model.",
-  };
+  });
 
   function nestedChild(bar, name) {
     for (const child of bar.children || []) {
@@ -469,7 +471,7 @@
                 onmousemove={moveLaneTip}
                 onmouseleave={hideLaneTip}
               >
-                {row.label}{#if row.unaligned}<span class="lane-note-mark">*</span>{/if}
+                {trainingType === "sft" && row.role === "rollout" ? "Data" : row.label}{#if row.unaligned}<span class="lane-note-mark">*</span>{/if}
               </div>
             {/each}
           </div>

--- a/dashboards/frontend/src/components/SftProgress.svelte
+++ b/dashboards/frontend/src/components/SftProgress.svelte
@@ -1,0 +1,62 @@
+<script>
+  import LineChart from "./LineChart.svelte";
+  import { fetchRunSteps } from "../lib/api.js";
+  import { lossPoints, lossEmptyMessage } from "../lib/trainingType.js";
+
+  let { run } = $props();
+  let steps = $state([]);
+  let loading = $state(true);
+  let error = $state("");
+  const number = (value) => Number.isFinite(value) ? value.toFixed(4) : "—";
+  let points = $derived(lossPoints(steps));
+  let latest = $derived(steps.at(-1));
+
+  $effect(() => {
+    const id = run.training_run_id;
+    const running = run.status === "running";
+    const controller = new AbortController();
+    let busy = false;
+    async function refresh() {
+      if (busy) return;
+      busy = true;
+      try {
+        const data = await fetchRunSteps(id, { signal: controller.signal });
+        if (controller.signal.aborted) return;
+        steps = data;
+        error = "";
+      } catch (err) {
+        if (!controller.signal.aborted) error = `Reporting unavailable: ${err.message}. Showing any previously loaded data.`;
+      } finally {
+        busy = false;
+        if (!controller.signal.aborted) loading = false;
+      }
+    }
+    void refresh();
+    const timer = running ? setInterval(refresh, 5000) : null;
+    return () => { controller.abort(); if (timer) clearInterval(timer); };
+  });
+</script>
+
+<section class="sft-progress" aria-label="SFT training progress">
+  {#if error}<p role="status">{error}</p>{/if}
+  {#if points.length}
+    <LineChart title="Training loss" data={points} height={180} formatX={(row) => `Completed step ${row.x}`} formatY={number} ariaLabel="Assistant-token training loss by completed optimizer step" />
+    <div class="stats">
+      <span>Latest loss <strong>{number(latest?.loss)}</strong></span>
+      <span>Gradient norm <strong>{number(latest?.grad_norm)}</strong></span>
+      <span>Learning rate <strong>{Number.isFinite(latest?.learning_rate) ? latest.learning_rate.toExponential(2) : "—"}</strong></span>
+      <span>{steps.length} recorded steps</span>
+    </div>
+  {:else if loading}
+    <p>Loading training loss…</p>
+  {:else if !error}
+    <p>{lossEmptyMessage(run)}</p>
+  {/if}
+</section>
+
+<style>
+  .sft-progress { min-width: 0; margin-bottom: 24px; }
+  p { color: var(--muted); font-size: 12px; line-height: 1.6; }
+  .stats { display: flex; align-items: center; flex-wrap: wrap; gap: 12px 20px; margin: 12px 0; font-size: 12px; color: var(--muted); }
+  strong { color: var(--text-bright); }
+</style>

--- a/dashboards/frontend/src/lib/api.js
+++ b/dashboards/frontend/src/lib/api.js
@@ -138,6 +138,12 @@ export async function fetchRollout(trainingRunId, rolloutId) {
   return await res.json();
 }
 
+export async function fetchRunSteps(trainingRunId, { signal } = {}) {
+  const res = await fetch(`${SERVER}/runs/${encodeURIComponent(trainingRunId)}/steps`, { signal });
+  if (!res.ok) return [];
+  return await res.json();
+}
+
 // Historical Modal logs for a run, served from the durable storage.
 //
 // Returns the newest `maxLines` lines within the (since, until] window, oldest

--- a/dashboards/frontend/src/lib/timing_vocabulary.js
+++ b/dashboards/frontend/src/lib/timing_vocabulary.js
@@ -3,6 +3,12 @@ const slot = (name) => `var(--color-c-dataviz-${name})`;
 export const TRAIN_OUTLINE_COLOR = slot("train-outline");
 
 export const CATEGORIES = {
+  data: {
+    label: "Data",
+    color: slot("primary-3"),
+    owner: "prepare_batch",
+    phases: ["prepare_batch"],
+  },
   train: {
     label: "Train",
     color: slot("primary-1"),
@@ -52,7 +58,7 @@ export const CATEGORIES = {
   idle: {
     label: "Idle",
     color: "var(--color-c-gray-30)",
-    phases: ["wait_for_rollout", "wait_for_next_rollout"],
+    phases: ["wait_for_rollout", "wait_for_next_rollout", "wait_for_batch", "wait_for_next_batch"],
   },
 };
 
@@ -71,6 +77,9 @@ export const PHASE_COLORS = {
 };
 
 export const TIMING_LABELS = {
+  prepare_batch: "Prepare training batch",
+  wait_for_batch: "Waiting for training data",
+  wait_for_next_batch: "Waiting for the next batch",
   evaluate_rollouts: "Eval (before training)",
   evaluate_rollouts_end: "Eval (after training)",
   generate_rollouts: "Rollout generation",
@@ -97,6 +106,8 @@ export const TIMING_LABELS = {
 };
 
 export const IDLE_PHASES = new Set([
+  "wait_for_batch",
+  "wait_for_next_batch",
   "wait_for_rollout",
   "wait_for_next_rollout",
 ]);

--- a/dashboards/frontend/src/lib/trainingType.js
+++ b/dashboards/frontend/src/lib/trainingType.js
@@ -1,0 +1,15 @@
+export function isSft(run) {
+  return run?.training_type === "sft";
+}
+
+export function lossPoints(steps) {
+  return steps
+    .filter((step) => Number.isFinite(step.loss) && Number.isInteger(step.step))
+    .map((step) => ({ x: step.step + 1, y: step.loss }));
+}
+
+export function lossEmptyMessage(run) {
+  return run?.status === "running"
+    ? "Waiting for the first completed training step."
+    : "No training loss was recorded. Older runs may not include SFT metrics.";
+}

--- a/dashboards/frontend/src/lib/trainingType.test.js
+++ b/dashboards/frontend/src/lib/trainingType.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isSft, lossPoints, lossEmptyMessage } from "./trainingType.js";
+
+test("training type defaults to RL and recognizes SFT", () => {
+  assert.equal(isSft({}), false);
+  assert.equal(isSft({ training_type: "sft" }), true);
+  assert.equal(isSft({ training_type: "rl" }), false);
+});
+
+test("loss chart preserves zero, rejects missing values, and uses completed steps", () => {
+  assert.deepEqual(lossPoints([
+    { step: 0, loss: 2 }, { step: 1, loss: null }, { step: 2, loss: 0 }, { step: 3, loss: NaN },
+  ]), [{ x: 1, y: 2 }, { x: 3, y: 0 }]);
+});
+
+test("empty states distinguish an active run from missing historical data", () => {
+  assert.match(lossEmptyMessage({ status: "running" }), /first completed/);
+  assert.match(lossEmptyMessage({ status: "completed" }), /No training loss/);
+});

--- a/dashboards/frontend/src/pages/TrainingPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingPage.svelte
@@ -13,6 +13,7 @@
   import { formatTagValue, getGroupTags } from "../lib/format.js";
   import { normalizeMetricLinks } from "../lib/metricLinks.js";
   import { toggleInSet } from "../lib/set.js";
+  import { isSft } from "../lib/trainingType.js";
 
   let {
     totalRuns,
@@ -43,6 +44,7 @@
     showFrameworkStatus,
     fmtDuration,
     search = $bindable(),
+    trainingTypeFilter = $bindable(""),
     drawerRunId = null,
     onOpenDetail = () => {},
     onCloseDrawer = () => {},
@@ -256,6 +258,7 @@
 <section class="[border:0] [background:transparent] flex flex-col gap-[24px] p-[0_24px_16px] max-[900px]:p-[0_16px_24px] min-w-0">
   <div class="m-0">
     <FilterBar
+      bind:trainingTypeFilter
       {recipes}
       {recipeCounts}
       {activeRecipes}
@@ -322,6 +325,7 @@
                       onclick={(event) => selectRun(run.run_id, event)}
                     >
                       <div class="block text-(--text-bright) [font-family:var(--font-mono)] [font-weight:400] text-[14px] leading-[20px] overflow-hidden text-ellipsis whitespace-nowrap">{runName}</div>
+                      <span class="text-(--muted) text-[10px]">{isSft(run) ? "SFT" : "RL"}</span>
                     </a>
                   </td>
                   <td class="row-open-cell">

--- a/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
+++ b/dashboards/frontend/src/pages/TrainingRunDetailPage.svelte
@@ -3,6 +3,8 @@
   import { ArrowLeft, ChevronLeft, ChevronRight, Download, ExternalLink, Minimize2, X } from "lucide-svelte";
   import Tabs from "../components/Tabs.svelte";
   import RunSummary from "../components/RunSummary.svelte";
+  import SftProgress from "../components/SftProgress.svelte";
+  import { isSft } from "../lib/trainingType.js";
   import RunTimeline from "../components/RunTimeline.svelte";
   import StatusPill from "../components/StatusPill.svelte";
   import TimeAgo from "../components/TimeAgo.svelte";
@@ -83,6 +85,7 @@
   } = $props();
 
   let run = $state(null);
+  let sft = $derived(isSft(run));
   let runLoading = $state(false);
   let runError = $state("");
   // A run id that isn't in the metadata volume won't appear later, so the
@@ -181,6 +184,10 @@
   // Active tab: "summary" | "rollouts" | "logs". One-way sync with the URL:
   // init/popstate/runId read URL → activeTab; selectTab writes pushState.
   let activeTab = $state(/** @type {TabId} */ (DEFAULT_TAB));
+
+  $effect(() => {
+    if (sft && activeTab === "rollouts") selectTab("summary");
+  });
 
   function selectTab(tab) {
     const next = DETAIL_TABS.has(tab) ? /** @type {TabId} */ (tab) : DEFAULT_TAB;
@@ -606,7 +613,7 @@
   }
 
   async function loadAdvantages(signal) {
-    if (!runId) return;
+    if (!runId || sft) return;
     try {
       const rows = await fetchRunAdvantages(runId, { signal });
       if (signal?.aborted) return;
@@ -643,7 +650,7 @@
   // steps stream in on a running run.
   $effect(() => {
     const id = runId;
-    if (!id || runMissing || activeTab !== "summary") return;
+    if (!id || runMissing || activeTab !== "summary" || sft) return;
 
     const controller = new AbortController();
     void loadAdvantages(controller.signal);
@@ -668,7 +675,7 @@
 
     const controller = new AbortController();
     rolloutsLoading = true;
-    void loadRollouts(controller.signal);
+    if (!sft) void loadRollouts(controller.signal);
     void loadTimings(controller.signal);
 
     // Poll while the run is active so new rollouts stream in.
@@ -683,7 +690,7 @@
       )
         return;
       if (!status || status === "running") {
-        void loadRollouts(controller.signal);
+        if (!sft) void loadRollouts(controller.signal);
       }
       void loadTimings(controller.signal);
     }, 5000);
@@ -1409,7 +1416,7 @@
   // Fetch the two rollouts' samples only when the endpoints change (a new step
   // lands), not on every 5s poll — the payloads are large.
   $effect(() => {
-    if (activeTab !== "summary") return;
+    if (activeTab !== "summary" || sft) return;
     const id = runId;
     const fId = firstRolloutId;
     const lId = lastRolloutId;
@@ -1445,7 +1452,7 @@
   }
 
   $effect(() => {
-    if (activeTab !== "summary") return;
+    if (activeTab !== "summary" || sft) return;
     const id = runId;
     const fId = firstRolloutId;
     const lId = lastRolloutId;
@@ -1539,7 +1546,7 @@
       onSelect={selectTab}
       tabs={[
         { value: "summary", label: "Summary" },
-        { value: "rollouts", label: "Rollouts", count: rolloutSummaries.length || undefined },
+        ...(!sft ? [{ value: "rollouts", label: "Rollouts", count: rolloutSummaries.length || undefined }] : []),
         { value: "logs", label: "Logs" },
       ]}
     />
@@ -1552,6 +1559,9 @@
               <div class="text-(--red,#f87171) text-[12px] font-[600] tracking-[0.02em] mb-[6px] uppercase">Error</div>
               <pre class="[border:1px_solid_color-mix(in_srgb,var(--red,#f87171)_45%,transparent)] rounded-[8px] bg-[color-mix(in_srgb,var(--red,#f87171)_12%,transparent)] text-(--red,#f87171) [font-family:var(--font-mono)] text-[12px] leading-[17px] m-0 max-h-[320px] overflow-auto p-[12px_14px] whitespace-pre-wrap [word-break:break-word]">{run.error_message}</pre>
             </div>
+          {/if}
+          {#if sft}
+            {#key runId}<SftProgress {run} />{/key}
           {/if}
           {#if timingError || showTimingSection}
             <div class="rollout-chart">
@@ -1566,6 +1576,8 @@
                   {stepTimingIds.length === 1 ? "step" : "steps"}){/if}
               </div>
               <RunTimeline
+                trainingType={sft ? "sft" : "rl"}
+                showOpenRollout={!sft}
                 timings={runTimings}
                 asyncOverride={timelineAsync}
                 runOrigin={timelineRunOrigin}
@@ -1581,6 +1593,7 @@
               {/if}
             </div>
           {/if}
+          {#if !sft}
           {#if rolloutsLoading && !rolloutSummaries.length}
             <div class="rollout-chart">
               <ChartSkeleton variant="line" height={140} showTitle />
@@ -1701,6 +1714,7 @@
               </div>
             {/if}
           {/if}
+          {/if}
         </div>
         <aside class="summary-tab-side">
           <RunSummary
@@ -1713,7 +1727,7 @@
           />
         </aside>
       </div>
-    {:else if activeTab === "rollouts"}
+    {:else if activeTab === "rollouts" && !sft}
       <div class="tab-panel">
       {#if rolloutsLoading && !rolloutSummaries.length}
         <div class="detail-empty">Loading rollouts…</div>

--- a/modal_training_gym/_dashboard.py
+++ b/modal_training_gym/_dashboard.py
@@ -930,6 +930,7 @@ def fastapi_app():
     @web.get("/api/runs/counts")
     async def run_counts(
         q: str = "",
+        training_type: str = "",
         status: FacetParam = None,
         recipe: FacetParam = None,
         group: FacetParam = None,
@@ -939,6 +940,7 @@ def fastapi_app():
         counts["matching"] = len(
             filter_run_summaries(
                 summaries,
+                filters={"training_type": training_type},
                 facets=_requested_facets(status, recipe, group),
                 query=q,
             )

--- a/modal_training_gym/common/dashboard.py
+++ b/modal_training_gym/common/dashboard.py
@@ -17,7 +17,7 @@ DASHBOARD_PREVIEW_ENV_KEY = "TRAINING_GYM_DASHBOARD_PREVIEW"
 DASHBOARD_VERSION_ENV_KEY = "DASHBOARD_VERSION"
 
 # Bump when the deployed dashboard frontend or backend changes.
-DASHBOARD_VERSION = 1
+DASHBOARD_VERSION = 2
 
 
 def current_dashboard_version() -> str:

--- a/tests/test_dashboard_runs_route.py
+++ b/tests/test_dashboard_runs_route.py
@@ -318,6 +318,34 @@ def test_runs_counts_route_counts_every_run_and_the_current_query(
     assert failed["matching"] == 1
 
 
+@pytest.mark.parametrize("training_type", ["rl", "sft"])
+def test_training_type_filter_applies_before_paging_and_matches_counts(
+    fake_volume, monkeypatch, tmp_path, training_type
+):
+    _save_records()
+    TrainingRun(
+        training_run_id="run-sft",
+        framework=Framework.SLIME,
+        status="completed",
+        config={"training_type": "sft"},
+        created_at=50,
+        updated_at=50,
+    ).save()
+
+    with _client(monkeypatch, tmp_path) as client:
+        params = {"training_type": training_type}
+        counts = client.get("/api/runs/counts", params=params).json()
+        runs = client.get("/api/runs", params={**params, "limit": 1}).json()
+        next_page = client.get(
+            "/api/runs", params={**params, "limit": 1, "offset": 1}
+        ).json()
+
+    assert counts["total"] == 2
+    assert counts["matching"] == len(runs) == 1
+    assert runs[0]["training_type"] == training_type
+    assert next_page == []
+
+
 def test_unknown_api_path_is_a_json_404_not_the_spa(monkeypatch, tmp_path):
     with _client(monkeypatch, tmp_path) as client:
         missing = client.get("/api/nope")

--- a/tutorials/sft.py
+++ b/tutorials/sft.py
@@ -5,7 +5,7 @@
 # # Supervised fine-tuning
 #
 # SFT teaches a model from complete example conversations. It computes loss on
-# assistant responses directly, without a reward function or inference server.
+# assistant responses directly.
 
 from modal_training_gym import Qwen3_4B, Qwen3_4B_Recipe, SFTDataset, TrainConfig
 
@@ -35,3 +35,13 @@ result = TrainConfig(
 ).train()
 
 print(result.checkpoints())
+
+# Use `training-gym run get <run-id> --verbose` to inspect the loss history.
+# Loss is reported after each optimizer step. Evaluate saved checkpoints on held-out prompts before
+# treating a falling training loss as improved model quality.
+#
+# To continue training, keep the original model and set `recipe.load` to the
+# saved `/checkpoints/<run-id>` directory. Set `num_steps` to the desired
+# total step count, not the number of additional steps. When extending that
+# horizon, also set `extra_config={"override_opt_param_scheduler": True}`
+# which loads training state.


### PR DESCRIPTION
SFT runs now show training loss and supervised targets instead of empty generated responses and reward charts. Adds an SFT/RL filter and labels, a loss chart using the existing chart component, and a Training samples tab that preserves exact target text and labels context separately.

Example run ([dashboard here](https://modal-labs-omkaar-dev--training-gym-dashboard-fastapi-app.modal.run/training/simple-mustard-b61782322316?tab=summary), Qwen3 32B, 8xH200, 1000 steps, 128 bsz, 4096 max ctx len, not tuned):
```
import hashlib

from pydantic.dataclasses import dataclass
from modal_training_gym import ModelArchitecture, Qwen3_8B_Recipe, SFTDataset
from modal_training_gym.common.models.base import HFModelConfiguration
from modal_training_gym import TrainConfig


class Qwen32B(HFModelConfiguration):
    model_name = "Qwen/Qwen3-32B"
    architecture = ModelArchitecture(
        num_layers=64,
        hidden_size=5120,
        ffn_hidden_size=25600,
        num_attention_heads=64,
        num_query_groups=8,
        kv_channels=128,
        vocab_size=151936,
        untie_embeddings_and_output_weights=True,
        rotary_base=1000000,
    )


@dataclass
class Qwen32BRecipe(Qwen3_8B_Recipe):
    make_vocab_size_divisible_by: int = 16
    optimizer_cpu_offload: bool = False
    pipeline_model_parallel_size: int = 1
    context_parallel_size: int = 1


class FilteredUltraChat(SFTDataset):
    def cache_key(self):
        key = f"{super().cache_key()}:qwen3-32b:max4096:v1"
        return hashlib.sha256(key.encode()).hexdigest()

    def _load_hf_dataset(self):
        from transformers import AutoTokenizer

        tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-32B")
        dataset = super()._load_hf_dataset()
        original_count = len(dataset)

        def fits(batch):
            tokens = tokenizer.apply_chat_template(
                batch["messages"], tokenize=True, return_dict=False
            )
            return [len(row) <= 4096 for row in tokens]

        dataset = dataset.filter(fits, batched=True, batch_size=128)
        print(
            f"UltraChat: kept {len(dataset)} / {original_count} conversations <=4096 tokens",
            flush=True,
        )
        return dataset


def config():
    return TrainConfig(
        model=Qwen32B(),
        dataset=FilteredUltraChat(
            hf_repo="HuggingFaceH4/ultrachat_200k",
            hf_split="train_sft",
            messages_column="messages",
        ),
        recipe=Qwen32BRecipe(
            training_type="sft",
            gpu_type="H200",
            num_gpus_per_node=8,
            tensor_model_parallel_size=8,
            sequence_parallel=True,
            ref_load="/checkpoints/torch_dist/Qwen--Qwen3-32B-tp8-div16-sft-proof",
            num_steps=1000,
            global_batch_size=128,
            max_tokens_per_gpu=4096,
            lr=1e-5,
            save_interval=250,
            shuffle=True,
            max_retries=5,
            image_overlay=lambda image: image.add_local_python_source(
                "sft_ultrachat", copy=True
            ),
            extra_config={"seed": 1234, "rollout_seed": 42},
        ),
    )


if __name__ == "__main__":
    from sft_ultrachat import config

    run = config().launch(prepare_inputs=True)
    print(f"Run ID: {run.training_run_id}")
    print(f"Modal app: {run.modal_app_id}")

```

Video:
https://github.com/user-attachments/assets/251abe78-4583-4e7c-9a52-2b32494f3fab

