### PR TITLE
Resolve Miles checkpoint destination from the effective save after YAML precedence

### DIFF
--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -308,6 +308,39 @@ def _is_resumable_checkpoint(path: str) -> bool:
     return True
 
 
+def resolve_effective_save(
+    save: str | None,
+    extra_config: dict[str, Any] | None,
+    *,
+    recipe_default_save_root: str,
+    mounted_save_root: str,
+    training_run_id: str,
+) -> tuple[str | None, str]:
+    """Resolve where Miles will actually write checkpoints.
+
+    Returns ``(effective_save, save_root)``. ``extra_config`` is the inline YAML
+    escape hatch and wins over the same-named ``--save`` flag, so a ``save`` key
+    there (including an explicit ``None``) is the effective destination. A YAML
+    path is used verbatim — Miles reads it as-is — while a top-level ``save`` is
+    run-scoped via ``compute_save_root``. ``effective_save`` is ``None`` when
+    checkpointing is disabled; ``save_root`` is still returned so resume
+    discovery has a directory to scan.
+    """
+    cfg = extra_config or {}
+    effective_save = cfg.get("save") if "save" in cfg else save
+    if "save" in cfg and effective_save:
+        save_root = str(effective_save).rstrip("/")
+        os.makedirs(save_root, exist_ok=True)
+    else:
+        save_root = compute_save_root(
+            effective_save,
+            recipe_default_save_root=recipe_default_save_root,
+            mounted_save_root=mounted_save_root,
+            training_run_id=training_run_id,
+        )
+    return effective_save, save_root
+
+
 def _unresumable_save_dirs(save_root: str) -> list[str]:
     """Save directories that exist but cannot be resumed from."""
     try:
@@ -1125,8 +1158,9 @@ def build_miles_app(
                 if isinstance(miles.metrics, WandbConfig):
                     miles.metrics.key = wandb_key
 
-            save_root = compute_save_root(
+            effective_save, save_root = resolve_effective_save(
                 miles.save,
+                extra_config,
                 recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
                 mounted_save_root=checkpoints_mount_path,
                 training_run_id=training_run_id,
@@ -1135,7 +1169,7 @@ def build_miles_app(
             original_save = miles.save
             original_load = miles.load
             original_start_rollout_id = miles.start_rollout_id
-            miles.save = save_root if original_save else None
+            miles.save = save_root if effective_save else None
             resume_checkpoint = torch_dist_resume_checkpoint(
                 save_root, is_complete=_is_resumable_checkpoint
             )
@@ -1151,6 +1185,7 @@ def build_miles_app(
                     "resuming training from last saved iteration."
                 )
                 miles.load = save_root
+                drop_materialized_config_key(miles, "load")
                 # Continue from the iteration stored in the run's own checkpoint,
                 # even for runs launched with an explicit start_rollout_id.
                 miles.start_rollout_id = None
@@ -1232,10 +1267,7 @@ def build_miles_app(
                 app_name=app_name,
                 framework=Framework.MILES,
                 training_run_id=training_run_id,
-                checkpoint_dir=extra_config.get(
-                    "save", save_root if original_save else ""
-                )
-                or "",
+                checkpoint_dir=save_root if effective_save else "",
                 model=model,
                 checkpoints_volume_name=checkpoints_volume_name,
                 checkpoints_mount_path=checkpoints_mount_path,

--- a/modal_training_gym/frameworks/miles/launcher.py
+++ b/modal_training_gym/frameworks/miles/launcher.py
@@ -308,37 +308,36 @@ def _is_resumable_checkpoint(path: str) -> bool:
     return True
 
 
-def resolve_effective_save(
+def resolve_save_root(
     save: str | None,
     extra_config: dict[str, Any] | None,
     *,
     recipe_default_save_root: str,
     mounted_save_root: str,
     training_run_id: str,
-) -> tuple[str | None, str]:
-    """Resolve where Miles will actually write checkpoints.
+) -> str | None:
+    """Directory Miles will actually write checkpoints to, or ``None`` when
+    checkpointing is disabled.
 
-    Returns ``(effective_save, save_root)``. ``extra_config`` is the inline YAML
-    escape hatch and wins over the same-named ``--save`` flag, so a ``save`` key
-    there (including an explicit ``None``) is the effective destination. A YAML
-    path is used verbatim — Miles reads it as-is — while a top-level ``save`` is
-    run-scoped via ``compute_save_root``. ``effective_save`` is ``None`` when
-    checkpointing is disabled; ``save_root`` is still returned so resume
-    discovery has a directory to scan.
+    ``extra_config`` is the inline YAML escape hatch and wins over the same-named
+    ``--save`` flag, so a ``save`` key there (including an explicit ``None``)
+    decides. A YAML path is used verbatim — Miles reads it as-is — while a
+    top-level ``save`` is run-scoped via ``compute_save_root``.
     """
     cfg = extra_config or {}
     effective_save = cfg.get("save") if "save" in cfg else save
-    if "save" in cfg and effective_save:
+    if not effective_save:
+        return None
+    if "save" in cfg:
         save_root = str(effective_save).rstrip("/")
         os.makedirs(save_root, exist_ok=True)
-    else:
-        save_root = compute_save_root(
-            effective_save,
-            recipe_default_save_root=recipe_default_save_root,
-            mounted_save_root=mounted_save_root,
-            training_run_id=training_run_id,
-        )
-    return effective_save, save_root
+        return save_root
+    return compute_save_root(
+        effective_save,
+        recipe_default_save_root=recipe_default_save_root,
+        mounted_save_root=mounted_save_root,
+        training_run_id=training_run_id,
+    )
 
 
 def _unresumable_save_dirs(save_root: str) -> list[str]:
@@ -1158,7 +1157,7 @@ def build_miles_app(
                 if isinstance(miles.metrics, WandbConfig):
                     miles.metrics.key = wandb_key
 
-            effective_save, save_root = resolve_effective_save(
+            save_root = resolve_save_root(
                 miles.save,
                 extra_config,
                 recipe_default_save_root=str(CHECKPOINTS_PATH).rstrip("/"),
@@ -1169,9 +1168,13 @@ def build_miles_app(
             original_save = miles.save
             original_load = miles.load
             original_start_rollout_id = miles.start_rollout_id
-            miles.save = save_root if effective_save else None
-            resume_checkpoint = torch_dist_resume_checkpoint(
-                save_root, is_complete=_is_resumable_checkpoint
+            miles.save = save_root
+            resume_checkpoint = (
+                torch_dist_resume_checkpoint(
+                    save_root, is_complete=_is_resumable_checkpoint
+                )
+                if save_root
+                else None
             )
             record_resume_checkpoint(run_record, resume_checkpoint)
             await run_record.save(is_async=True)
@@ -1190,7 +1193,7 @@ def build_miles_app(
                 # even for runs launched with an explicit start_rollout_id.
                 miles.start_rollout_id = None
                 drop_materialized_config_key(miles, "start_rollout_id")
-            elif unresumable := _unresumable_save_dirs(save_root):
+            elif save_root and (unresumable := _unresumable_save_dirs(save_root)):
                 print(
                     f"WARNING: {save_root} holds saves that cannot be resumed "
                     f"({', '.join(unresumable)}) — they carry torch_dist shards "
@@ -1267,7 +1270,7 @@ def build_miles_app(
                 app_name=app_name,
                 framework=Framework.MILES,
                 training_run_id=training_run_id,
-                checkpoint_dir=save_root if effective_save else "",
+                checkpoint_dir=save_root or "",
                 model=model,
                 checkpoints_volume_name=checkpoints_volume_name,
                 checkpoints_mount_path=checkpoints_mount_path,

--- a/tests/test_miles_checkpoint_saving.py
+++ b/tests/test_miles_checkpoint_saving.py
@@ -61,9 +61,9 @@ def test_result_without_checkpoint_keeps_original_model_source():
 
 
 def _resolve(save, extra_config, tmp_path):
-    from modal_training_gym.frameworks.miles.launcher import resolve_effective_save
+    from modal_training_gym.frameworks.miles.launcher import resolve_save_root
 
-    return resolve_effective_save(
+    return resolve_save_root(
         save,
         extra_config,
         recipe_default_save_root="/checkpoints",
@@ -72,42 +72,32 @@ def _resolve(save, extra_config, tmp_path):
     )
 
 
-def test_effective_save_uses_yaml_override_verbatim(tmp_path):
+def test_save_root_uses_yaml_override_verbatim(tmp_path):
     override = str(tmp_path / "override")
-    effective, save_root = _resolve(
-        None, {"save": override + "/", "save_interval": 10}, tmp_path
-    )
-    assert effective == override + "/"
+    save_root = _resolve(None, {"save": override + "/", "save_interval": 10}, tmp_path)
     assert save_root == override
     assert os.path.isdir(save_root)
 
 
-def test_effective_save_yaml_wins_over_top_level(tmp_path):
+def test_save_root_yaml_wins_over_top_level(tmp_path):
     override = str(tmp_path / "override")
-    _, save_root = _resolve(str(tmp_path / "top"), {"save": override}, tmp_path)
-    assert save_root == override
+    assert _resolve(str(tmp_path / "top"), {"save": override}, tmp_path) == override
 
 
-def test_effective_save_top_level_is_run_scoped(tmp_path):
-    effective, save_root = _resolve(
-        str(tmp_path / "top"), {"save_interval": 5}, tmp_path
-    )
-    assert effective == str(tmp_path / "top")
+def test_save_root_top_level_is_run_scoped(tmp_path):
+    save_root = _resolve(str(tmp_path / "top"), {"save_interval": 5}, tmp_path)
     assert save_root == str(tmp_path / "top" / "run-1")
 
 
-def test_effective_save_default_redirects_to_mount(tmp_path):
-    _, save_root = _resolve("/checkpoints", None, tmp_path)
-    assert save_root == str(tmp_path / "mounted" / "run-1")
+def test_save_root_default_redirects_to_mount(tmp_path):
+    assert _resolve("/checkpoints", None, tmp_path) == str(
+        tmp_path / "mounted" / "run-1"
+    )
 
 
-@pytest.mark.parametrize("extra_config", [None, {"save": None}])
-def test_effective_save_disabled_reports_none(tmp_path, extra_config):
-    effective, save_root = _resolve(None, extra_config, tmp_path)
-    assert effective is None
-    assert save_root == str(tmp_path / "mounted" / "run-1")
-
-
-def test_yaml_save_none_disables_top_level_save(tmp_path):
-    effective, _ = _resolve(str(tmp_path / "top"), {"save": None}, tmp_path)
-    assert effective is None
+@pytest.mark.parametrize(
+    ("save", "extra_config"),
+    [(None, None), (None, {"save": None}), ("/checkpoints/top", {"save": None})],
+)
+def test_save_root_disabled_is_none(tmp_path, save, extra_config):
+    assert _resolve(save, extra_config, tmp_path) is None

--- a/tests/test_miles_checkpoint_saving.py
+++ b/tests/test_miles_checkpoint_saving.py
@@ -1,3 +1,5 @@
+import os
+
 import yaml
 import pytest
 
@@ -56,3 +58,56 @@ def test_result_without_checkpoint_keeps_original_model_source():
     )
     assert result.checkpoints() == []
     assert result.model.model_path == "/hf/model"
+
+
+def _resolve(save, extra_config, tmp_path):
+    from modal_training_gym.frameworks.miles.launcher import resolve_effective_save
+
+    return resolve_effective_save(
+        save,
+        extra_config,
+        recipe_default_save_root="/checkpoints",
+        mounted_save_root=str(tmp_path / "mounted"),
+        training_run_id="run-1",
+    )
+
+
+def test_effective_save_uses_yaml_override_verbatim(tmp_path):
+    override = str(tmp_path / "override")
+    effective, save_root = _resolve(
+        None, {"save": override + "/", "save_interval": 10}, tmp_path
+    )
+    assert effective == override + "/"
+    assert save_root == override
+    assert os.path.isdir(save_root)
+
+
+def test_effective_save_yaml_wins_over_top_level(tmp_path):
+    override = str(tmp_path / "override")
+    _, save_root = _resolve(str(tmp_path / "top"), {"save": override}, tmp_path)
+    assert save_root == override
+
+
+def test_effective_save_top_level_is_run_scoped(tmp_path):
+    effective, save_root = _resolve(
+        str(tmp_path / "top"), {"save_interval": 5}, tmp_path
+    )
+    assert effective == str(tmp_path / "top")
+    assert save_root == str(tmp_path / "top" / "run-1")
+
+
+def test_effective_save_default_redirects_to_mount(tmp_path):
+    _, save_root = _resolve("/checkpoints", None, tmp_path)
+    assert save_root == str(tmp_path / "mounted" / "run-1")
+
+
+@pytest.mark.parametrize("extra_config", [None, {"save": None}])
+def test_effective_save_disabled_reports_none(tmp_path, extra_config):
+    effective, save_root = _resolve(None, extra_config, tmp_path)
+    assert effective is None
+    assert save_root == str(tmp_path / "mounted" / "run-1")
+
+
+def test_yaml_save_none_disables_top_level_save(tmp_path):
+    effective, _ = _resolve(str(tmp_path / "top"), {"save": None}, tmp_path)
+    assert effective is None


### PR DESCRIPTION
Follow-up to #513. The Miles YAML escape hatch (`extra_config`) wins over the same-named `--save` flag, so with `MilesRecipe(save=None, extra_config={"save": "/checkpoints/override", "save_interval": 10})` Miles writes under `/checkpoints/override` while the launcher scanned the synthesized default run directory for resume checkpoints and set `miles.save = None` for command generation.

New `resolve_save_root(save, extra_config, ...) -> str | None` in `frameworks/miles/launcher.py`:

```
effective_save = extra_config["save"] if "save" in extra_config else save
None                                      if not effective_save   (checkpointing disabled)
effective_save verbatim (mkdir)           if YAML supplied the path
compute_save_root(effective_save, …)      otherwise (run-scoped top-level path)
```

The launcher uses that single value for `miles.save`, `torch_dist_resume_checkpoint` discovery, the unresumable-saves warning, the resume `miles.load`, and `TrainResult.checkpoint_dir` (`save_root or ""`). When it is `None` (top-level `save=None`, or YAML `save: null` over a top-level path) resume discovery is skipped, since a no-save run has nothing to resume from.

On resume, `drop_materialized_config_key(miles, "load")` is also called so a YAML `load` key can't suppress the `--load <save_root>` flag the launcher sets.

Behavior preserved: ordinary top-level `save` paths are still run-scoped via `compute_save_root`; no-save configs still produce an empty `TrainResult.checkpoint_dir`.

Tests: `tests/test_miles_checkpoint_saving.py` covers YAML-verbatim, YAML-over-top-level, run-scoping, default-mount redirect, and disabled cases.

## Checklist

N/A (library change, not an example).


Link to Devin session: https://modal.devinenterprise.com/sessions/d86ae337ed7e41ed809fbe4688f55705
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/d86ae337ed7e41ed809fbe4688f55705?variant=devin
Requested by: @joyliu-q