### PR TITLE
Rebuild summary from canonical items when the summary file is unreadable

### DIFF
--- a/modal_training_gym/utils/metadata.py
+++ b/modal_training_gym/utils/metadata.py
@@ -738,6 +738,8 @@ def vol_get_summary_items(
     payload_key: str = SUMMARY_ITEMS_KEY,
     is_async: bool = False,
 ) -> list[dict[str, Any]] | None | Awaitable[list[dict[str, Any]] | None]:
+    from modal.exception import ExecutionError
+
     vol = _metadata_volume()
     if is_async:
 
@@ -747,6 +749,12 @@ def vol_get_summary_items(
                 payload = await vol_get(store, key, is_async=True)
             except KeyError:
                 return None
+            except (ExecutionError, ValueError) as exc:
+                print(
+                    f"WARNING: unreadable summary {store}/{key}; "
+                    f"rebuilding from canonical items: {exc}"
+                )
+                return None
             return summary_items_from_payload(payload, payload_key=payload_key)
 
         return _run()
@@ -754,6 +762,12 @@ def vol_get_summary_items(
     try:
         payload = vol_get(store, key)
     except KeyError:
+        return None
+    except (ExecutionError, ValueError) as exc:
+        print(
+            f"WARNING: unreadable summary {store}/{key}; "
+            f"rebuilding from canonical items: {exc}"
+        )
         return None
     return summary_items_from_payload(payload, payload_key=payload_key)
 

--- a/tests/test_metadata_persistence.py
+++ b/tests/test_metadata_persistence.py
@@ -20,6 +20,7 @@ from modal_training_gym.common import run as run_mod
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.train_result import TrainResult
 from modal_training_gym.common.training_rollout import TrainingRolloutResult
+from modal_training_gym.utils import metadata
 from modal_training_gym.utils.metadata import MetadataStore
 
 
@@ -63,6 +64,86 @@ def test_rollout_async_save_survives_unmounted_volume(fake_volume):
     assert summary_item["export_size_bytes"] == len(
         (json.dumps(json.loads(blob), ensure_ascii=False, indent=2) + "\n").encode()
     )
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+def test_summary_upsert_survives_unreadable_summary_file(
+    fake_volume, monkeypatch, is_async
+):
+    """Summary upserts rebuild from canonical items when the cache is unreadable."""
+    summary_path = (
+        f"{metadata._store_path(MetadataStore.TRAINING_RUNS_SUMMARY)}/summary.json"
+    )
+    original_read = fake_volume._read_file
+    original_read_async = fake_volume._read_file_async
+
+    def unreadable_read(path: str):
+        if path == summary_path:
+            from modal.exception import ExecutionError
+
+            raise ExecutionError(
+                "Request failed with status 404 Not Found: block not found"
+            )
+        return original_read(path)
+
+    async def unreadable_read_async(path: str):
+        if path == summary_path:
+            from modal.exception import ExecutionError
+
+            raise ExecutionError(
+                "Request failed with status 404 Not Found: block not found"
+            )
+        async for chunk in original_read_async(path):
+            yield chunk
+
+    def put(*args, **kwargs):
+        return metadata.vol_put(*args, is_async=is_async, **kwargs)
+
+    def put_with_summary(*args, **kwargs):
+        return metadata.vol_put_with_summary(*args, is_async=is_async, **kwargs)
+
+    if is_async:
+        asyncio.run(
+            put(
+                MetadataStore.TRAINING_RUNS,
+                "run-a",
+                {"training_run_id": "run-a"},
+            )
+        )
+    else:
+        put(
+            MetadataStore.TRAINING_RUNS,
+            "run-a",
+            {"training_run_id": "run-a"},
+        )
+
+    with monkeypatch.context() as summary_monkeypatch:
+        summary_monkeypatch.setattr(fake_volume, "_read_file", unreadable_read)
+        summary_monkeypatch.setattr(
+            fake_volume, "_read_file_async", unreadable_read_async
+        )
+        summary_monkeypatch.setattr(fake_volume.read_file, "_sync_fn", unreadable_read)
+        summary_monkeypatch.setattr(fake_volume.read_file, "aio", unreadable_read_async)
+
+        write = put_with_summary(
+            MetadataStore.TRAINING_RUNS,
+            "run-b",
+            {"training_run_id": "run-b"},
+            summary_store=MetadataStore.TRAINING_RUNS_SUMMARY,
+            item_id_key="training_run_id",
+        )
+        if is_async:
+            asyncio.run(write)
+
+    if is_async:
+        items = asyncio.run(
+            metadata.vol_get_summary_items(
+                MetadataStore.TRAINING_RUNS_SUMMARY, is_async=True
+            )
+        )
+    else:
+        items = metadata.vol_get_summary_items(MetadataStore.TRAINING_RUNS_SUMMARY)
+    assert {item["training_run_id"] for item in items or []} == {"run-a", "run-b"}
 
 
 @pytest.mark.parametrize("fw", list(Framework))


### PR DESCRIPTION
The `validate` jobs on #514 (and any run that saves a run record) currently die in `run_record.save()` because reading `training-runs-summary/summary.json` from the `training-gym-metadata` volume raises `modal.exception.ExecutionError: 404 Not Found: block not found` — the summary file references a block that no longer exists in Modal's block store.

The summary is only a denormalized list cache; canonical per-item files are the source of truth. `vol_get_summary_items` now treats an unreadable summary (`ExecutionError`, JSON decode error) like a missing one:

```
try: payload = vol_get(store, key)
except KeyError: return None
except (ExecutionError, ValueError) as exc:   # new
    print("WARNING: unreadable summary ...; rebuilding from canonical items")
    return None
```

`vol_upsert_summary_item` already falls back to `_canonical_items_for(store)` when it gets no items and then overwrites the summary, so the next writer self-heals the corrupt file instead of failing the run. Sync and async paths covered by a parametrized test that simulates the block-not-found read on the summary path only.

Not touched: `vol_get` itself (canonical-file readers still see real errors) and the underlying Modal volume issue, which needs a separate look.

## Checklist

- [x] N/A — library change, not an example


Link to Devin session: https://modal.devinenterprise.com/sessions/0aacaa7b42b34cb19427b36da5d7afd5
Open in Devin Desktop: https://modal.devinenterprise.com/desktop/session/0aacaa7b42b34cb19427b36da5d7afd5?variant=devin
Requested by: @joyliu-q