### PR TITLE
Add TrainConfig modality gates and Qwen3.5-VL slime provider

### DIFF
--- a/modal_training_gym/common/audio.py
+++ b/modal_training_gym/common/audio.py
@@ -1,14 +1,15 @@
 """Generic audio helpers shared across audio tasks and frameworks.
 
-No framework or model coupling: decode base64 / data-URI audio references to raw
-bytes, and bytes to a mono waveform at a target sample rate. The heavy decode deps
-(soundfile, librosa) are imported lazily so importing this module stays cheap and
-safe outside the training image.
+No framework or model coupling: read path or bytes audio references, and decode
+to a mono waveform at a target sample rate. The heavy decode deps (soundfile,
+librosa) are imported lazily so importing this module stays cheap and safe
+outside the training image.
 """
 
 from __future__ import annotations
 
 import base64
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -26,14 +27,17 @@ def data_uri_to_bytes(data_uri: str) -> bytes:
 def coerce_audio_to_bytes(value: Any) -> bytes | None:
     """Coerce one audio reference to raw bytes.
 
-    Accepts ``bytes``, a base64 / data-URI ``str``, or a 1-element list/tuple of
-    either (datasets often wrap a single clip in a list). Returns ``None`` when
-    *value* carries no usable audio.
+    Accepts ``bytes``, a filesystem path, a ``data:`` URI, a raw base64
+    string, or a 1-element list/tuple of any of those. Returns ``None``
+    when *value* carries no usable audio.
     """
     first = value[0] if isinstance(value, (list, tuple)) and value else value
     if isinstance(first, (bytes, bytearray)):
         return bytes(first)
     if isinstance(first, str) and first:
+        path = Path(first)
+        if path.is_file():
+            return path.read_bytes()
         return data_uri_to_bytes(first)
     return None
 

--- a/modal_training_gym/common/dataset.py
+++ b/modal_training_gym/common/dataset.py
@@ -11,16 +11,76 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from enum import Enum
 from typing import Any, Literal
+import base64
 import hashlib
 import json
 import random
 import shutil
+import tempfile
 import tomllib
+import uuid
 from pathlib import Path
 
 from modal_training_gym.common.errors import TrainingGymConfigError
 
 DatasetRow = dict[str, Any]
+
+_DATA_URI_PREFIX = "data:"
+_MIME_EXT = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/wave": "wav",
+    "audio/mpeg": "mp3",
+    "audio/mp3": "mp3",
+    "audio/mp4": "m4a",
+    "audio/ogg": "ogg",
+    "audio/flac": "flac",
+    "video/mp4": "mp4",
+    "video/webm": "webm",
+}
+
+
+def _materialize_data_uri(uri: str, dest_dir: Path, index: int) -> str:
+    header, sep, payload = uri.partition(",")
+    if not sep or not header.startswith(_DATA_URI_PREFIX):
+        raise TrainingGymConfigError(f"invalid data URI: {uri[:64]!r}")
+    mime = (
+        header[len(_DATA_URI_PREFIX) :].split(";", 1)[0].lower()
+        or "application/octet-stream"
+    )
+    if ";base64" in header:
+        raw = base64.b64decode(payload)
+    else:
+        raw = payload.encode()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    path = dest_dir / f"{index:06d}.{_MIME_EXT.get(mime, 'bin')}"
+    path.write_bytes(raw)
+    return str(path.resolve())
+
+
+def _as_media_path(item: Any, dest_dir: Path, index: int) -> Any:
+    if isinstance(item, (bytes, bytearray)):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        path = dest_dir / f"{index:06d}.bin"
+        path.write_bytes(bytes(item))
+        return str(path.resolve())
+    if isinstance(item, str) and item.startswith(_DATA_URI_PREFIX):
+        return _materialize_data_uri(item, dest_dir, index)
+    if isinstance(item, str):
+        src = Path(item)
+        if src.is_file():
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest = dest_dir / f"{index:06d}{src.suffix}"
+            if src.resolve() != dest.resolve():
+                shutil.copy2(src, dest)
+            return str(dest.resolve())
+        return item
+    return item
 
 
 def _materialization_fingerprint(fields: dict[str, Any]) -> str:
@@ -38,6 +98,7 @@ class DatasetConfig(ABC):
     """Dataset fields and materialization behavior shared across training frameworks."""
 
     _type: DatasetType = DatasetType.DEFAULT
+    multimodal_keys: dict[str, str] | None = None
 
     def cache_key(self) -> str | None:
         return None
@@ -81,6 +142,8 @@ class DatasetConfig(ABC):
             cols.add(self.input_key())
         if self.label_key():
             cols.add(self.label_key())
+        if self.multimodal_keys:
+            cols.update(self.multimodal_keys.values())
         return cols
 
     def validate_written(self, path: str) -> None:
@@ -168,10 +231,17 @@ class HuggingFaceDataset(DatasetConfig):
         system_prompt: str = "",
         prompt_template: str = "{input}",
         always_download: bool = False,
+        multimodal_keys: dict[str, str] | None = None,
     ):
         if input_format not in ("text", "messages", "raw"):
             raise TrainingGymConfigError(
                 f"input_format must be one of text/messages/raw, got {input_format!r}"
+            )
+        if multimodal_keys:
+            raise TrainingGymConfigError(
+                f"{type(self).__name__} does not materialize media files for "
+                f"multimodal_keys={multimodal_keys!r}. Use MultimodalDataset "
+                "when trainers need path-only media columns."
             )
         self.hf_repo = hf_repo
         self.hf_split = hf_split
@@ -599,7 +669,17 @@ class HarborDataset(DatasetConfig):
 
 
 class MultimodalDataset(DatasetConfig):
-    """Dataset of text prompts paired with image, audio, or video data."""
+    """Dataset of text prompts paired with image or audio data.
+
+    Each row pairs a text ``prompt`` with one or more ``media`` items and a
+    ``label``. ``write()`` and ``load()`` write media as file paths. ``data:``
+    URIs are decoded to files so trainers that only accept paths can load them.
+    Other media items (paths, URLs) are written unchanged. The media column is
+    surfaced via ``multimodal_keys`` (``{modality: media_column}``).
+
+    Pass ``rows=[{"prompt": str, "media": list, "label": Any}, ...]`` or
+    subclass and override ``source_rows()``.
+    """
 
     # TODO(ben/joy): gate-check media at this boundary so the evals dashboard can
     # reliably visualize it. Two parts: (1) normalize each emitted media item to a
@@ -612,13 +692,13 @@ class MultimodalDataset(DatasetConfig):
         self,
         rows: Iterable[dict[str, Any]] | None = None,
         *,
-        modality: Literal["image", "audio", "video"] = "audio",
+        modality: Literal["image", "audio"] = "audio",
         media_column: str | None = None,
     ) -> None:
         self.modality = modality
-        if modality not in ("image", "audio", "video"):
+        if modality not in ("image", "audio"):
             raise TrainingGymConfigError(
-                f"modality must be one of image/audio/video, got {modality!r}"
+                f"modality must be one of image/audio, got {modality!r}"
             )
         self.media_column = media_column or f"{modality}s"
         if (
@@ -629,6 +709,7 @@ class MultimodalDataset(DatasetConfig):
                 "media_column must differ from input_key and label_key"
             )
         self.multimodal_keys = {modality: self.media_column}
+        self.dataset_id = f"mm-{modality}-{uuid.uuid4()}"
         self._source_rows = list(rows or [])
 
     def input_key(self) -> str:
@@ -636,6 +717,9 @@ class MultimodalDataset(DatasetConfig):
 
     def label_key(self) -> str:
         return "label"
+
+    def apply_chat_template(self) -> bool:
+        return self.modality != "audio"
 
     def source_rows(self) -> Iterable[dict[str, Any]]:
         return self._source_rows
@@ -653,6 +737,45 @@ class MultimodalDataset(DatasetConfig):
     def rows(self) -> Iterable[DatasetRow]:
         for row in self.source_rows():
             yield self._to_row(row)
+
+    def _media_cache(self) -> Path:
+        return Path(tempfile.gettempdir()) / "training-gym-mm" / self.dataset_id
+
+    def _rows_with_paths(
+        self, rows: list[DatasetRow], dest_dir: Path
+    ) -> list[DatasetRow]:
+        n = 0
+        out: list[DatasetRow] = []
+        for row in rows:
+            media = row.get(self.media_column)
+            if not isinstance(media, list):
+                out.append(row)
+                continue
+            written = [
+                _as_media_path(item, dest_dir, n + i) for i, item in enumerate(media)
+            ]
+            n += len(media)
+            out.append({**row, self.media_column: written})
+        return out
+
+    def load(self) -> list[DatasetRow]:
+        return self._rows_with_paths(list(self.rows()), self._media_cache())
+
+    def _write_jsonl(self, rows: list[dict[str, Any]], path: str) -> None:
+        dest = Path(path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        rows = self._rows_with_paths(rows, dest.parent / "media")
+        with dest.open("w") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+
+    def write(self, path: str) -> None:
+        dest = Path(path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        rows = self._rows_with_paths(list(self.rows()), dest.parent / "media")
+        with dest.open("w") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
 
 
 class OnlineRollout(DatasetConfig):

--- a/modal_training_gym/common/modality.py
+++ b/modal_training_gym/common/modality.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Literal, Protocol
+
+from modal_training_gym.common.dataset import DatasetConfig
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.models.base import ModelConfig
+
+MediaModality = Literal["image", "audio", "video"]
+
+
+class _ServedMedia(Protocol):
+    def served_media(self) -> frozenset[str]: ...
+
+
+_MEDIA: tuple[MediaModality, ...] = ("image", "audio", "video")
+
+
+def requested_media_modalities(dataset: DatasetConfig) -> frozenset[MediaModality]:
+    keys = dataset.multimodal_keys
+    if not keys:
+        return frozenset()
+    return frozenset(key for key in _MEDIA if key in keys)
+
+
+def validate_served_modalities(
+    recipe: _ServedMedia, model: ModelConfig, dataset: DatasetConfig
+) -> None:
+    requested = requested_media_modalities(dataset)
+    if not requested:
+        return
+
+    served = recipe.served_media()
+    unsupported_fw = sorted(requested - served)
+    if unsupported_fw:
+        allowed = ", ".join(sorted(served)) or "none"
+        raise TrainingGymConfigError(
+            f"{type(recipe).__name__} cannot serve {', '.join(unsupported_fw)} "
+            f"(serves {allowed})."
+        )
+
+    unsupported_model = sorted(requested - model.supported_modalities)
+    if unsupported_model:
+        raise TrainingGymConfigError(
+            f"{type(model).__name__} cannot serve {', '.join(unsupported_model)} "
+            f"(supports {', '.join(sorted(model.supported_modalities))})."
+        )

--- a/modal_training_gym/common/models/base.py
+++ b/modal_training_gym/common/models/base.py
@@ -172,6 +172,10 @@ class ModelConfig:
     response_parser: ResponseParser | None = None
     requires_bshd: bool = False
     audio_placeholder: str = ""
+    supported_modalities: frozenset[str] = frozenset()
+    thd_forward: bool = True
+    has_vision_tower: bool = False
+    needs_qwen35_vl_provider: bool = False
 
     def __init__(self, **kwargs: Any) -> None:
         for k, v in kwargs.items():

--- a/modal_training_gym/common/models/gemma4_26b_a4b.py
+++ b/modal_training_gym/common/models/gemma4_26b_a4b.py
@@ -10,11 +10,10 @@ class Gemma4_26B_A4B(HFModelConfiguration):
 
     model_name = "google/gemma-4-26B-A4B-it"
     response_parser = staticmethod(parse_gemma4_response)
+    supported_modalities = frozenset({"image"})
+    thd_forward = False
 
     architecture = ModelArchitecture(
-        # text_config from config.json. The recipe sets ``miles_model_script``, so
-        # these are not emitted as flags, but they drive the expert-parallel
-        # validator; keep them in step with that script.
         num_layers=30,
         hidden_size=2816,
         ffn_hidden_size=2112,

--- a/modal_training_gym/common/models/inkling_small.py
+++ b/modal_training_gym/common/models/inkling_small.py
@@ -31,3 +31,4 @@ class Inkling_Small(HFModelConfiguration):
 
     model_name = "thinkingmachines/Inkling-Small"
     response_parser = staticmethod(parse_inkling_response)
+    supported_modalities = frozenset({"image", "audio"})

--- a/modal_training_gym/common/models/qwen3_5_0_8b.py
+++ b/modal_training_gym/common/models/qwen3_5_0_8b.py
@@ -9,6 +9,9 @@ class Qwen3_5_0_8B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.5-0.8B"
+    supported_modalities = frozenset({"image"})
+    has_vision_tower = True
+    needs_qwen35_vl_provider = True
     architecture = ModelArchitecture(
         num_layers=24,
         hidden_size=1024,

--- a/modal_training_gym/common/models/qwen3_5_2b.py
+++ b/modal_training_gym/common/models/qwen3_5_2b.py
@@ -9,6 +9,9 @@ class Qwen3_5_2B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.5-2B"
+    supported_modalities = frozenset({"image"})
+    has_vision_tower = True
+    needs_qwen35_vl_provider = True
     architecture = ModelArchitecture(
         num_layers=24,
         hidden_size=2048,

--- a/modal_training_gym/common/models/qwen3_5_4b.py
+++ b/modal_training_gym/common/models/qwen3_5_4b.py
@@ -9,6 +9,9 @@ class Qwen3_5_4B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.5-4B"
+    supported_modalities = frozenset({"image"})
+    has_vision_tower = True
+    needs_qwen35_vl_provider = True
     architecture = ModelArchitecture(
         num_layers=32,
         hidden_size=2560,

--- a/modal_training_gym/common/models/qwen3_5_9b.py
+++ b/modal_training_gym/common/models/qwen3_5_9b.py
@@ -9,6 +9,9 @@ class Qwen3_5_9B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.5-9B"
+    supported_modalities = frozenset({"image"})
+    has_vision_tower = True
+    needs_qwen35_vl_provider = True
     architecture = ModelArchitecture(
         num_layers=32,
         hidden_size=4096,

--- a/modal_training_gym/common/models/qwen3_6_27b.py
+++ b/modal_training_gym/common/models/qwen3_6_27b.py
@@ -9,6 +9,9 @@ class Qwen3_6_27B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.6-27B"
+    supported_modalities = frozenset({"image"})
+    has_vision_tower = True
+    needs_qwen35_vl_provider = True
     architecture = ModelArchitecture(
         num_layers=64,
         hidden_size=5120,

--- a/modal_training_gym/common/models/qwen3_6_35b.py
+++ b/modal_training_gym/common/models/qwen3_6_35b.py
@@ -9,6 +9,9 @@ class Qwen3_6_35B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.6-35B-A3B"
+    supported_modalities = frozenset({"image"})
+    has_vision_tower = True
+    needs_qwen35_vl_provider = True
     architecture = ModelArchitecture(
         num_layers=40,
         hidden_size=2048,

--- a/modal_training_gym/common/models/qwen3_8_27b.py
+++ b/modal_training_gym/common/models/qwen3_8_27b.py
@@ -9,6 +9,9 @@ class Qwen3_8_27B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_6_response)
 
     model_name = "Qwen/Qwen3.8-27B"
+    supported_modalities = frozenset({"image"})
+    has_vision_tower = True
+    needs_qwen35_vl_provider = True
     architecture = ModelArchitecture(
         num_layers=64,
         hidden_size=5120,

--- a/modal_training_gym/common/models/qwen3_asr_1_7b.py
+++ b/modal_training_gym/common/models/qwen3_asr_1_7b.py
@@ -32,6 +32,8 @@ class Qwen3_ASR_1_7B(HFModelConfiguration):
     """Alibaba Qwen3-ASR-1.7B speech recognition model."""
 
     model_name = "Qwen/Qwen3-ASR-1.7B"
+    supported_modalities = frozenset({"audio"})
+    thd_forward = False
 
     # Qwen3 dense backbone, same ``<|im_start|>``/``<|im_end|>`` delimiters as the
     # rest of the family. ASR output is plain transcription (no tool calls), so
@@ -39,6 +41,11 @@ class Qwen3_ASR_1_7B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_response)
 
     requires_bshd = True
+    # The processor expands this single <|audio_pad|> to N tokens (N = the audio
+    # encoder's output length for the clip), aligning audio embeddings with token
+    # positions. It must appear in the prompt text; the raw audio path or payload
+    # must not, or it tokenizes into ~100k-1M text tokens (scales with clip
+    # duration) and OOMs the actor.
     audio_placeholder = "<|audio_start|><|audio_pad|><|audio_end|>"
 
     # thinker_config.text_config (Qwen3 dense backbone), verbatim from config.json.

--- a/modal_training_gym/common/models/qwen3_vl_8b.py
+++ b/modal_training_gym/common/models/qwen3_vl_8b.py
@@ -22,8 +22,10 @@ class Qwen3_VL_8B(HFModelConfiguration):
     response_parser = staticmethod(parse_qwen3_response)
 
     model_name = "Qwen/Qwen3-VL-8B-Instruct"
-
     requires_bshd = True
+    supported_modalities = frozenset({"image"})
+    thd_forward = False
+    has_vision_tower = True
 
     architecture = ModelArchitecture(
         # text_config from config.json

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -348,7 +348,6 @@ class TrainConfig:
         validate_served_modalities(self.recipe, self.model, self.dataset)
         return self
 
-
     def _generate_training_run_id(self) -> str:
         """Mint a new run id. ``launch()`` calls this once per invocation, so
         each launch of the same config gets its own TrainingRun record."""

--- a/modal_training_gym/common/train.py
+++ b/modal_training_gym/common/train.py
@@ -8,7 +8,7 @@ import warnings
 from contextlib import nullcontext
 from typing import Any
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 from pydantic.dataclasses import dataclass
 
 from modal_training_gym.common.checkpoint import Checkpoint, CheckpointType
@@ -17,6 +17,7 @@ from modal_training_gym.common.errors import TrainingGymConfigError
 from modal_training_gym.common.framework import Framework
 from modal_training_gym.common.ids import create_hash
 from modal_training_gym.common.modal_urls import modal_app_dashboard_url
+from modal_training_gym.common.modality import validate_served_modalities
 from modal_training_gym.common.models import ModelConfig
 from modal_training_gym.common.run import TrainingRun, metric_run_id_for_attempt
 from modal_training_gym.common.status import (
@@ -341,6 +342,12 @@ class TrainConfig:
                 "OnlineRollout requires recipe.custom_generate_function or "
                 "recipe.extra_config['custom_generate_function_path']"
             )
+
+    @model_validator(mode="after")
+    def _validate_served_modalities(self) -> "TrainConfig":
+        validate_served_modalities(self.recipe, self.model, self.dataset)
+        return self
+
 
     def _generate_training_run_id(self) -> str:
         """Mint a new run id. ``launch()`` calls this once per invocation, so

--- a/modal_training_gym/frameworks/slime/audio_transcription_rollout.py
+++ b/modal_training_gym/frameworks/slime/audio_transcription_rollout.py
@@ -41,18 +41,19 @@ def _iter_content_items(prompt: Any):
 
 
 def _audio_ref(sample: Any) -> Any:
-    """Pull the raw audio reference (data-URI / bytes) off a slime Sample.
+    """Pull the audio path off a slime Sample.
 
     The audio transcription dataset returns ``False`` from
     ``apply_chat_template()``, so slime keeps ``sample.prompt`` a conversation list
     and the audio rides in the message content as
-    ``{"type": "audio", "audio": <data-uri>}`` (slime's ``process_vision_info``
+    ``{"type": "audio", "audio": <path>}`` (slime's ``process_vision_info``
     extracts only images/videos, so audio never reaches ``multimodal_inputs``).
     Fail loudly if it's missing — a silent miss would train on audio-free prompts.
 
     This is the slime ``Sample -> data`` seam; decoding ``data -> bytes`` is the
     framework-agnostic :func:`modal_training_gym.common.audio.coerce_audio_to_bytes`.
     """
+
     for item in _iter_content_items(getattr(sample, "prompt", None)):
         if isinstance(item, dict) and (item.get("type") == "audio" or "audio" in item):
             ref = item.get("audio") or item.get("audio_url")
@@ -60,7 +61,7 @@ def _audio_ref(sample: Any) -> Any:
                 return ref
     raise RuntimeError(
         "transcription_rollout: no audio on the slime Sample. Expected a "
-        "conversation-list prompt with a {'type': 'audio', 'audio': <data-uri>} item."
+        "conversation-list prompt with a {'type': 'audio', 'audio': <path>} item."
     )
 
 
@@ -179,11 +180,11 @@ async def transcription_rollout(args: Any, sample: Any, sampling_params: dict) -
     """
     import aiohttp
 
-    audio_bytes = coerce_audio_to_bytes(_audio_ref(sample))  # Sample -> data -> bytes
+    audio_bytes = coerce_audio_to_bytes(_audio_ref(sample))
     if audio_bytes is None:
         raise RuntimeError(
             "transcription_rollout: the Sample's audio reference did not decode to "
-            "bytes (expected raw bytes or a base64 / data-URI string)."
+            "bytes (expected a file path or raw bytes)."
         )
     model = getattr(args, "served_model_name", None) or "qwen3-asr"
     temperature = float(sampling_params.get("temperature", 1.0))

--- a/modal_training_gym/frameworks/slime/launcher.py
+++ b/modal_training_gym/frameworks/slime/launcher.py
@@ -83,6 +83,7 @@ from modal_training_gym.train_recipes.slime_recipe.recipe import (
     DATA_PATH,
     HF_CACHE_PATH,
     SlimeRecipe,
+    qwen35_vl_image_train,
 )
 from .modal_helpers.utils import (
     build_train_cmd,
@@ -202,6 +203,30 @@ _SLIME_EXTERNAL_PATCHES_B64 = (
 
 def _patch_commands(patches: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(f"echo {patch} | base64 -d | python3" for patch in patches)
+
+
+_QWEN35_VL_PLUGIN = _SLIME_PATCHES / "model_specific_patches" / "qwen3_5_vl"
+
+
+def _with_qwen35_vl_plugin(image: "Image") -> "Image":
+    models = f"{SLIME_ROOT}/slime_plugins/models"
+    for name in ("qwen3_5_vl.py", "qwen3_5_vl_utils.py"):
+        image = image.add_local_file(
+            str(_QWEN35_VL_PLUGIN / name),
+            remote_path=f"{models}/{name}",
+            copy=True,
+        )
+    return image
+
+
+def _apply_qwen35_vl_image_train(
+    slime: SlimeRecipe, model: ModelConfig, dataset: DatasetConfig | None
+) -> None:
+    if not qwen35_vl_image_train(model, dataset):
+        return
+    slime._qwen35_vl_provider_fields()
+    if getattr(slime, "megatron_to_hf_mode", "") != "bridge":
+        object.__setattr__(slime, "megatron_to_hf_mode", "bridge")
 
 
 def _build_slime_base_image(*, apply_root_patches: bool = True) -> "Image":
@@ -393,20 +418,7 @@ def build_slime_app(
         if eval_dataset is not None
         else None
     )
-
-    # Models that can't do THD packing (model.requires_bshd, e.g. Qwen3-ASR) must
-    # train on padded (bshd) batches; fail fast with the fix if the recipe didn't.
-    if model and getattr(model, "requires_bshd", False):
-        cfg = slime.extra_config or {}
-        if cfg.get("qkv_format") != "bshd" or slime.use_dynamic_batch_size:
-            raise ValueError(
-                f"{model.model_name} requires padded (bshd) batches: its "
-                "megatron-bridge forward doesn't implement THD sequence packing. "
-                'Set extra_config={"qkv_format": "bshd", "micro_batch_size": N} and '
-                "use_dynamic_batch_size=False — or use Qwen3_ASR_1_7B_Recipe, which sets "
-                f"these. Got qkv_format={cfg.get('qkv_format')!r}, "
-                f"use_dynamic_batch_size={slime.use_dynamic_batch_size}."
-            )
+    _apply_qwen35_vl_image_train(slime, model, dataset)
 
     if (
         model
@@ -467,6 +479,8 @@ def build_slime_app(
         image = image.uv_pip_install(f"harbor=={HARBOR_PKG_VERSION}")
 
     image = _overlay_slime_source(image, slime)
+    if qwen35_vl_image_train(model, dataset):
+        image = _with_qwen35_vl_plugin(image)
 
     if slime.image_run_commands:
         image = image.run_commands(*slime.image_run_commands)

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_5_vl/qwen3_5_vl.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_5_vl/qwen3_5_vl.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import torch
+from megatron.core import mpu, tensor_parallel
+from megatron.core.models.common.embeddings.rotary_pos_embedding import (
+    MultimodalRotaryEmbedding,
+)
+from megatron.core.models.gpt import GPTModel
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_mtp_block_spec
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer.module import MegatronModule
+from transformers import AutoConfig
+
+from .qwen3_5 import get_qwen3_5_spec
+from .qwen3_5_vl_utils import (
+    build_packed_mrope_position_ids,
+    gather_packed_input_ids,
+    get_packed_cp_local_indices,
+)
+
+
+class Qwen3_5MultimodalRotaryEmbedding(MultimodalRotaryEmbedding):
+    """Qwen3.5's interleaved temporal/height/width MRoPE layout."""
+
+    def forward(
+        self,
+        position_ids: torch.Tensor,
+        mrope_section: list[int],
+        packed_seq: bool = False,
+        cp_group=None,
+    ) -> torch.Tensor:
+        seq = position_ids.to(device=self.inv_freq.device, dtype=torch.float32)
+        if self.seq_len_interpolation_factor is not None:
+            seq *= 1 / self.seq_len_interpolation_factor
+
+        inv_freq = self.inv_freq[None, None, :, None].expand(3, seq.shape[1], -1, 1)
+        freqs = (inv_freq @ seq[:, :, None, :]).transpose(2, 3)
+
+        mixed_freqs = freqs[0].clone()
+        for axis, offset in ((1, 1), (2, 2)):
+            mixed_freqs[..., offset : mrope_section[axis] * 3 : 3] = freqs[
+                axis, ..., offset : mrope_section[axis] * 3 : 3
+            ]
+
+        emb = (
+            torch.cat((mixed_freqs, mixed_freqs), dim=-1)[..., None, :]
+            .transpose(0, 1)
+            .contiguous()
+        )
+        cp_group = cp_group or self.cp_group
+        if cp_group is not None and cp_group.size() > 1 and not packed_seq:
+            from megatron.core.models.common.embeddings.rope_utils import (
+                get_pos_emb_on_this_cp_rank,
+            )
+
+            emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
+        return emb
+
+
+def _load_vision_model(hf_config, dtype: torch.dtype, use_cpu_initialization: bool):
+    if hf_config.model_type == "qwen3_5_moe":
+        from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+            Qwen3_5MoeVisionModel,
+        )
+
+        vision_model_cls = Qwen3_5MoeVisionModel
+    else:
+        from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5VisionModel
+
+        vision_model_cls = Qwen3_5VisionModel
+
+    device = (
+        torch.device("cpu")
+        if use_cpu_initialization
+        else torch.device("cuda", torch.cuda.current_device())
+    )
+    with torch.device(device):
+        vision_model = vision_model_cls._from_config(hf_config.vision_config)
+    vision_model.to(dtype=dtype)
+
+    # HF modules are replicated across TP ranks. Mark them explicitly so slime's
+    # direct weight exporter does not try to tensor-parallel all-gather them.
+    for parameter in vision_model.parameters():
+        parameter.tensor_model_parallel = False
+        parameter.partition_dim = -1
+        parameter.partition_stride = 1
+    return vision_model
+
+
+class Qwen3_5VLModel(MegatronModule):
+    """Megatron Qwen3.5 language model with a replicated Transformers ViT."""
+
+    def __init__(
+        self,
+        config,
+        language_layer_spec,
+        hf_config,
+        args,
+        *,
+        pre_process: bool,
+        post_process: bool,
+        vp_stage: int | None,
+    ) -> None:
+        super().__init__(config=config)
+        self.pre_process = pre_process
+        self.post_process = post_process
+        self.image_token_id = hf_config.image_token_id
+        self.video_token_id = hf_config.video_token_id
+        self.vision_start_token_id = hf_config.vision_start_token_id
+        self.spatial_merge_size = hf_config.vision_config.spatial_merge_size
+
+        config.mrope_section = list(
+            hf_config.text_config.rope_parameters["mrope_section"]
+        )
+        config.apply_rope_fusion = False
+
+        mtp_block_spec = None
+        if args.mtp_num_layers:
+            mtp_block_spec = get_gpt_mtp_block_spec(
+                config,
+                language_layer_spec,
+                use_transformer_engine=args.transformer_impl == "transformer_engine",
+                **({"vp_stage": vp_stage} if vp_stage is not None else {}),
+            )
+
+        self.language_model = GPTModel(
+            config=config,
+            transformer_layer_spec=language_layer_spec,
+            vocab_size=args.padded_vocab_size,
+            max_sequence_length=args.max_position_embeddings,
+            pre_process=pre_process,
+            post_process=post_process,
+            fp16_lm_cross_entropy=args.fp16_lm_cross_entropy,
+            parallel_output=True,
+            share_embeddings_and_output_weights=not args.untie_embeddings_and_output_weights,
+            position_embedding_type="mrope",
+            rotary_percent=args.rotary_percent,
+            rotary_base=args.rotary_base,
+            rope_scaling=args.use_rope_scaling,
+            scatter_embedding_sequence_parallel=False,
+            mtp_block_spec=mtp_block_spec,
+            **({"vp_stage": vp_stage} if vp_stage is not None else {}),
+        )
+        self.language_model.rotary_pos_emb = Qwen3_5MultimodalRotaryEmbedding(
+            kv_channels=config.kv_channels,
+            rotary_percent=args.rotary_percent,
+            rotary_interleaved=config.rotary_interleaved,
+            rotary_base=args.rotary_base,
+        )
+
+        self.model = torch.nn.Module()
+        self.model.visual = (
+            _load_vision_model(
+                hf_config, config.params_dtype, config.use_cpu_initialization
+            )
+            if pre_process
+            else None
+        )
+        self.share_embeddings_and_output_weights = (
+            self.language_model.share_embeddings_and_output_weights
+        )
+
+    @property
+    def decoder(self):
+        return self.language_model.decoder
+
+    def shared_embedding_or_output_weight(self):
+        return self.language_model.shared_embedding_or_output_weight()
+
+    def set_input_tensor(self, input_tensor) -> None:
+        self.language_model.set_input_tensor(input_tensor)
+
+    def _inject_vision_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        full_input_ids: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        cp_group,
+        pixel_values: torch.Tensor | None,
+        pixel_values_videos: torch.Tensor | None,
+        image_grid_thw: torch.Tensor | None,
+        video_grid_thw: torch.Tensor | None,
+    ) -> torch.Tensor:
+        embeddings = self.language_model.embedding(
+            input_ids=input_ids, position_ids=None
+        ).clone()
+        embeddings_bsh = embeddings.transpose(0, 1).contiguous()
+        local_indices = get_packed_cp_local_indices(
+            cu_seqlens,
+            cp_group.size() if cp_group is not None else 1,
+            cp_group.rank() if cp_group is not None else 0,
+            input_ids.device,
+        )
+
+        for values, grids, token_id in (
+            (pixel_values, image_grid_thw, self.image_token_id),
+            (pixel_values_videos, video_grid_thw, self.video_token_id),
+        ):
+            if values is None:
+                continue
+            if grids is None:
+                raise ValueError("Qwen3.5-VL pixel values require matching grid_thw")
+            vision_output = self.model.visual(
+                values.to(dtype=self.model.visual.dtype), grid_thw=grids
+            )
+            vision_embeddings = vision_output.pooler_output.to(
+                device=embeddings.device, dtype=embeddings.dtype
+            )
+            full_vision_positions = (
+                (full_input_ids[0] == token_id).nonzero(as_tuple=False).flatten()
+            )
+            if full_vision_positions.numel() != vision_embeddings.shape[0]:
+                raise ValueError(
+                    f"Qwen3.5-VL token/features mismatch: {full_vision_positions.numel()} tokens, "
+                    f"{vision_embeddings.shape[0]} features"
+                )
+
+            feature_indices = torch.full(
+                (full_input_ids.shape[1],),
+                -1,
+                dtype=torch.long,
+                device=input_ids.device,
+            )
+            feature_indices[full_vision_positions] = torch.arange(
+                vision_embeddings.shape[0], device=input_ids.device
+            )
+            local_feature_indices = feature_indices[local_indices]
+            local_vision_mask = local_feature_indices >= 0
+            if not torch.equal(local_vision_mask, input_ids[0] == token_id):
+                raise ValueError(
+                    "Qwen3.5-VL CP token layout does not match its full packed sequence"
+                )
+            embeddings_bsh[0, local_vision_mask] = vision_embeddings[
+                local_feature_indices[local_vision_mask]
+            ]
+
+        embeddings = embeddings_bsh.transpose(0, 1).contiguous()
+        if self.config.sequence_parallel:
+            embeddings = tensor_parallel.scatter_to_sequence_parallel_region(
+                embeddings
+            ).contiguous()
+        return embeddings
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        labels: torch.Tensor | None = None,
+        packed_seq_params: PackedSeqParams | None = None,
+        loss_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if packed_seq_params is None:
+            raise ValueError(
+                "Qwen3.5-VL native training currently requires packed sequences"
+            )
+
+        cp_group = mpu.get_context_parallel_group()
+        full_input_ids = gather_packed_input_ids(
+            input_ids, packed_seq_params.cu_seqlens_q, cp_group
+        )
+
+        decoder_input = None
+        if self.pre_process:
+            decoder_input = self._inject_vision_embeddings(
+                input_ids,
+                full_input_ids,
+                packed_seq_params.cu_seqlens_q,
+                cp_group,
+                pixel_values,
+                pixel_values_videos,
+                image_grid_thw,
+                video_grid_thw,
+            )
+
+        if position_ids is None:
+            position_ids = build_packed_mrope_position_ids(
+                full_input_ids,
+                packed_seq_params.cu_seqlens_q,
+                image_grid_thw,
+                video_grid_thw,
+                image_token_id=self.image_token_id,
+                video_token_id=self.video_token_id,
+                vision_start_token_id=self.vision_start_token_id,
+                spatial_merge_size=self.spatial_merge_size,
+            )
+            if cp_group is not None and cp_group.size() > 1:
+                local_indices = get_packed_cp_local_indices(
+                    packed_seq_params.cu_seqlens_q,
+                    cp_group.size(),
+                    cp_group.rank(),
+                    position_ids.device,
+                )
+                position_ids = position_ids.index_select(2, local_indices)
+
+        return self.language_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            decoder_input=decoder_input,
+            labels=labels,
+            packed_seq_params=packed_seq_params,
+            loss_mask=loss_mask,
+            **kwargs,
+        )
+
+
+def get_qwen3_5_vl_model_provider(args, config, vp_stage):
+    hf_config = AutoConfig.from_pretrained(args.hf_checkpoint, trust_remote_code=True)
+    if not hasattr(hf_config, "vision_config"):
+        raise ValueError(f"{args.hf_checkpoint} is not a Qwen3.5-VL checkpoint")
+    language_layer_spec = get_qwen3_5_spec(args, config, vp_stage)
+
+    def model_provider(
+        pre_process: bool = True,
+        post_process: bool = True,
+        vp_stage: int | None = None,
+    ) -> Qwen3_5VLModel:
+        return Qwen3_5VLModel(
+            config,
+            language_layer_spec,
+            hf_config,
+            args,
+            pre_process=pre_process,
+            post_process=post_process,
+            vp_stage=vp_stage,
+        )
+
+    return model_provider
+
+
+def provide_qwen3_5_vl(
+    pre_process: bool = True,
+    post_process: bool = True,
+    vp_stage: int | None = None,
+) -> Qwen3_5VLModel:
+    """Slime ``custom_model_provider_path`` entry for Qwen3.5 image training."""
+    from megatron.training import get_args
+    from megatron.training.arguments import core_transformer_config_from_args
+
+    args = get_args()
+    config = core_transformer_config_from_args(args)
+    return get_qwen3_5_vl_model_provider(args, config, vp_stage)(
+        pre_process=pre_process,
+        post_process=post_process,
+        vp_stage=vp_stage,
+    )

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_5_vl/qwen3_5_vl_utils.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_5_vl/qwen3_5_vl_utils.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import torch.distributed as dist
+
+
+def get_packed_cp_local_indices(
+    cu_seqlens: Sequence[int] | torch.Tensor,
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Map a THD CP rank's local tokens back to the full packed token stream."""
+
+    boundaries = [int(value) for value in cu_seqlens]
+    if cp_size <= 1:
+        start = boundaries[0] if boundaries else 0
+        end = boundaries[-1] if boundaries else 0
+        return torch.arange(start, end, device=device, dtype=torch.long)
+    indices = []
+    for start, end in zip(boundaries[:-1], boundaries[1:], strict=True):
+        sequence_length = end - start
+        if sequence_length % (2 * cp_size) != 0:
+            raise ValueError(
+                f"Packed sequence length {sequence_length} must be divisible by 2 * CP size {cp_size}"
+            )
+        chunk_size = sequence_length // (2 * cp_size)
+        first = start + cp_rank * chunk_size
+        second = start + (2 * cp_size - cp_rank - 1) * chunk_size
+        indices.extend(
+            (
+                torch.arange(first, first + chunk_size, device=device),
+                torch.arange(second, second + chunk_size, device=device),
+            )
+        )
+    return (
+        torch.cat(indices)
+        if indices
+        else torch.empty(0, dtype=torch.long, device=device)
+    )
+
+
+def gather_packed_input_ids(
+    input_ids: torch.Tensor,
+    cu_seqlens: Sequence[int] | torch.Tensor,
+    cp_group,
+) -> torch.Tensor:
+    """Reconstruct the full THD token stream from Megatron's two-chunk CP layout."""
+
+    if cp_group is None or cp_group.size() == 1:
+        return input_ids
+
+    local_tokens = input_ids.flatten()
+    gathered_tokens = [torch.empty_like(local_tokens) for _ in range(cp_group.size())]
+    dist.all_gather(gathered_tokens, local_tokens, group=cp_group)
+
+    full_tokens = torch.empty(
+        int(cu_seqlens[-1]), dtype=input_ids.dtype, device=input_ids.device
+    )
+    for rank, rank_tokens in enumerate(gathered_tokens):
+        indices = get_packed_cp_local_indices(
+            cu_seqlens, cp_group.size(), rank, input_ids.device
+        )
+        if indices.numel() != rank_tokens.numel():
+            raise ValueError(
+                f"CP rank {rank} has {rank_tokens.numel()} tokens, expected {indices.numel()} from cu_seqlens"
+            )
+        full_tokens[indices] = rank_tokens
+    return full_tokens.unsqueeze(0)
+
+
+def _vision_positions(
+    start_position: int,
+    grid_thw: torch.Tensor,
+    spatial_merge_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    grid_t, grid_h, grid_w = (int(value) for value in grid_thw.tolist())
+    grid_h //= spatial_merge_size
+    grid_w //= spatial_merge_size
+
+    temporal = (
+        torch.arange(grid_t, device=device).repeat_interleave(grid_h * grid_w)
+        + start_position
+    )
+    height = (
+        torch.arange(grid_h, device=device).repeat_interleave(grid_w).repeat(grid_t)
+        + start_position
+    )
+    width = torch.arange(grid_w, device=device).repeat(grid_h * grid_t) + start_position
+    return torch.stack((temporal, height, width))
+
+
+def build_packed_mrope_position_ids(
+    input_ids: torch.Tensor,
+    cu_seqlens: Sequence[int] | torch.Tensor,
+    image_grid_thw: torch.Tensor | None,
+    video_grid_thw: torch.Tensor | None,
+    *,
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    """Build Qwen3.5 MRoPE positions while resetting every packed sequence."""
+
+    if input_ids.shape[0] != 1:
+        raise ValueError(
+            f"Packed Qwen3.5-VL input_ids must have batch size 1, got {tuple(input_ids.shape)}"
+        )
+
+    device = input_ids.device
+    positions = torch.zeros(
+        (3, 1, input_ids.shape[1]), dtype=input_ids.dtype, device=device
+    )
+    boundaries = [int(value) for value in cu_seqlens]
+    image_grids = iter(()) if image_grid_thw is None else iter(image_grid_thw)
+
+    if video_grid_thw is None:
+        video_grids = iter(())
+    else:
+        split_video_grids = torch.repeat_interleave(
+            video_grid_thw, video_grid_thw[:, 0], dim=0
+        ).clone()
+        split_video_grids[:, 0] = 1
+        video_grids = iter(split_video_grids)
+
+    for start, end in zip(boundaries[:-1], boundaries[1:], strict=True):
+        tokens = input_ids[0, start:end]
+        token_list = tokens.tolist()
+        pieces = []
+        cursor = 0
+        current_position = 0
+
+        vision_starts = (
+            (tokens == vision_start_token_id).nonzero(as_tuple=False).flatten()
+        )
+        modality_tokens = tokens[vision_starts + 1] if vision_starts.numel() else ()
+
+        for modality_token in modality_tokens:
+            modality_token = int(modality_token)
+            if modality_token not in (image_token_id, video_token_id):
+                continue
+            try:
+                vision_start = token_list.index(modality_token, cursor)
+                grid = next(
+                    image_grids if modality_token == image_token_id else video_grids
+                )
+            except (StopIteration, ValueError) as exc:
+                raise ValueError(
+                    "Qwen3.5-VL tokens and vision grids do not match"
+                ) from exc
+
+            text_length = vision_start - cursor
+            if text_length:
+                pieces.append(
+                    torch.arange(text_length, device=device).view(1, -1).expand(3, -1)
+                    + current_position
+                )
+                current_position += text_length
+
+            vision_position_ids = _vision_positions(
+                current_position, grid, spatial_merge_size, device
+            )
+            pieces.append(vision_position_ids)
+            current_position += max(int(grid[1]), int(grid[2])) // spatial_merge_size
+            cursor = vision_start + vision_position_ids.shape[1]
+
+        if cursor < len(token_list):
+            text_length = len(token_list) - cursor
+            pieces.append(
+                torch.arange(text_length, device=device).view(1, -1).expand(3, -1)
+                + current_position
+            )
+
+        if pieces:
+            sequence_positions = torch.cat(pieces, dim=1)
+            if sequence_positions.shape[1] != len(token_list):
+                raise ValueError(
+                    "Qwen3.5-VL vision token count does not match its grid: "
+                    f"expected {len(token_list)} positions, built {sequence_positions.shape[1]}"
+                )
+            positions[:, 0, start:end] = sequence_positions
+
+    try:
+        next(image_grids)
+        raise ValueError("Unused Qwen3.5-VL image grids")
+    except StopIteration:
+        pass
+    try:
+        next(video_grids)
+        raise ValueError("Unused Qwen3.5-VL video grids")
+    except StopIteration:
+        pass
+    return positions

--- a/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_vl/patch_qwen3_vl_torch_dist.py
+++ b/modal_training_gym/frameworks/slime/modal_helpers/patches/model_specific_patches/qwen3_vl/patch_qwen3_vl_torch_dist.py
@@ -9,10 +9,9 @@ runs.
 
 Fix: skip the frozen vision tower (``vision_model.*``) during conversion and let the
 tool's origin-HF fill copy the ViT verbatim from the base HF checkpoint. This is exact
-because the ViT is frozen during RL (see ``Qwen3_VL_8B_Recipe.freeze_params_name_list``),
-so its weights equal the base weights. The fill only adds tensors whose HF names were
-not already produced by the (trained) language-stack conversion, so trained weights
-always win.
+because the ViT is frozen during RL, so its weights equal the base weights. The fill
+only adds tensors whose HF names were not already produced by the (trained)
+language-stack conversion, so trained weights always win.
 
 Baked into the slime base image (only the deploy/eval conversion runs this tool).
 Additive + idempotent, so non-VL runs are untouched. Report upstream; drop once

--- a/modal_training_gym/train_recipes/base.py
+++ b/modal_training_gym/train_recipes/base.py
@@ -41,6 +41,7 @@ JSON_CONFIG_FIELDS = ("train_env_vars", "apply_chat_template_kwargs", "multimoda
 
 class BaseTrainRecipe(ABC):
     model_config_class: ClassVar["type[ModelConfig] | None"] = None
+    served_media_modalities: ClassVar[frozenset[str]] = frozenset()
 
     # Fields consumed by the Modal launcher (image build, cluster topology,
     # callable shipping) and never forwarded to the framework CLI. Every
@@ -108,6 +109,24 @@ class BaseTrainRecipe(ABC):
     def validate_model_parallelism(self, model: "ModelConfig") -> None:
         """Validate the model's parallelism settings."""
         return None
+
+    def served_media(self) -> frozenset[str]:
+        return self.served_media_modalities
+
+    def overrides(
+        self,
+        dataset: "DatasetConfig | None",
+        model: "ModelConfig | None",
+    ) -> dict[str, Any]:
+        return {}
+
+    def _override_default(
+        self, out: dict[str, Any], key: str, value: Any, default: Any
+    ) -> None:
+        if key in self._escape_hatch_keys():
+            return
+        if getattr(self, key, default) == default:
+            out[key] = value
 
     # ── Container → framework flag converters ────────────────────────────────
 

--- a/modal_training_gym/train_recipes/miles_recipe/gemma4_26b_a4b.py
+++ b/modal_training_gym/train_recipes/miles_recipe/gemma4_26b_a4b.py
@@ -73,12 +73,17 @@ class Gemma4_26B_A4B_Recipe(MilesRecipe):
 
     modality: Literal["text", "vision"] = "text"
 
+    def served_media(self) -> frozenset[str]:
+        if self.modality == "vision":
+            return frozenset({"image"})
+        return frozenset()
+
     gpu_type: str = "H200"
     image_run_commands: list[str] = field(default_factory=_image_patches)
 
     hf_checkpoint: str = "google/gemma-4-26B-A4B-it"
     ref_load: str = "google/gemma-4-26B-A4B-it"
-    miles_model_script: str = "scripts/models/gemma-4-26b-a4b-it.sh"
+    miles_model_name: str = "gemma-4-26b-a4b-it"
     # Model overflows container disk, so reserve 1 TiB.
     train_function_kwargs: dict[str, Any] = field(
         default_factory=lambda: {"ephemeral_disk": _EPHEMERAL_DISK_MIB}
@@ -90,10 +95,6 @@ class Gemma4_26B_A4B_Recipe(MilesRecipe):
     expert_model_parallel_size: int = 8
     expert_tensor_parallel_size: int = 1
 
-    # bshd rules out dynamic batching and miles asserts on the pair (upstream passes
-    # both and trips it), so use an explicit micro batch; max_tokens_per_gpu is inert.
-    use_dynamic_batch_size: bool = False
-    micro_batch_size: int = 1
     max_tokens_per_gpu: int = 1024
 
     rm_type: str | None = "gemma_math"
@@ -130,7 +131,6 @@ class Gemma4_26B_A4B_Recipe(MilesRecipe):
     use_kl_loss: bool = True
 
     attention_backend: str = "unfused"
-    qkv_format: str = "bshd"
     no_gradient_accumulation_fusion: bool = True
     no_check_for_nan_in_loss_and_grad: bool = True
 

--- a/modal_training_gym/train_recipes/miles_recipe/inkling.py
+++ b/modal_training_gym/train_recipes/miles_recipe/inkling.py
@@ -36,10 +36,20 @@ _EPHEMERAL_DISK_MIB = 768 * 1024
 class _InklingSmallRecipe(MilesRecipe):
     _SKIP_FIELDS: ClassVar[frozenset[str]] = MilesRecipe._SKIP_FIELDS | {"modality"}
 
-    # Selects the model provider below, the same way Gemma4_26B_A4B_Recipe's flag picks
-    # its mode. A vision run also needs a MultimodalDataset with apply_chat_template
-    # off and its images materialized as files.
-    modality: Literal["text", "vision"] = "text"
+    modality: Literal["text", "vision", "audio"] = "text"
+
+    def served_media(self) -> frozenset[str]:
+        if self.modality == "vision":
+            return frozenset({"image"})
+        if self.modality == "audio":
+            return frozenset({"audio"})
+        return frozenset()
+
+    def overrides(self, dataset=None, model=None) -> dict[str, Any]:
+        out = super().overrides(dataset, model)
+        if self.modality in {"vision", "audio"}:
+            out["apply_chat_template"] = False
+        return out
 
     # Inkling landed upstream on 2026-08-03 (miles 5c517599 / 92ccb87d), well after
     # MilesRecipe's default image was built, so this recipe pins its own. Do not use
@@ -184,7 +194,7 @@ class _InklingSmallRecipe(MilesRecipe):
         # InklingTrainProcessor off the checkpoint's model_type and forwards its
         # patch tensors into forward() generically.
         if (
-            self.modality == "vision"
+            self.modality in {"vision", "audio"}
             and not self.custom_model_provider_path
             and "custom_model_provider_path" not in self._escape_hatch_keys()
         ):
@@ -200,7 +210,6 @@ class Inkling_Small_Recipe(_InklingSmallRecipe):
 
     # Dynamic token packing exposes a PP-p2p x EP-all-to-all NCCL launch-order race
     # on varlen shapes, so upstream pins a fixed micro-batch for full-parameter runs.
-    # This overrides MilesRecipe's use_dynamic_batch_size=True default.
     use_dynamic_batch_size: bool = False
     micro_batch_size: int = 1
 

--- a/modal_training_gym/train_recipes/miles_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/miles_recipe/recipe.py
@@ -8,6 +8,7 @@ from pydantic.dataclasses import dataclass
 
 from modal_training_gym.common.dataset import DatasetConfig
 from modal_training_gym.common.metrics import MetricConfig
+from modal_training_gym.common.modality import requested_media_modalities
 from modal_training_gym.common.models import ModelConfig
 from modal_training_gym.train_recipes.base import (
     BaseTrainRecipe,
@@ -636,6 +637,7 @@ class MilesRecipe(BaseTrainRecipe):
     sglang_server_concurrency: int | None = None
     sglang_tool_call_parser: str | None = None
     sglang_reasoning_parser: str | None = None
+    sglang_enable_multimodal: bool = False
 
     # ── Config overrides ────────────────────────────────────────────────────
     extra_config: dict | None = None
@@ -667,6 +669,7 @@ class MilesRecipe(BaseTrainRecipe):
     # ── Validators ───────────────────────────────────────────────────────────
 
     _SKIP_FIELDS: ClassVar[frozenset[str]] = frozenset(_MILES_SKIP)
+    served_media_modalities: ClassVar[frozenset[str]] = frozenset()
 
     @model_validator(mode="after")
     def _resolve_callable_paths(self) -> "MilesRecipe":
@@ -795,6 +798,23 @@ class MilesRecipe(BaseTrainRecipe):
     def validate_model_parallelism(self, model: ModelConfig) -> None:
         validate_num_experts_divisible_by_expert_parallel_size(self, model)
 
+    def overrides(
+        self,
+        dataset: DatasetConfig | None,
+        model: ModelConfig | None,
+    ) -> dict[str, Any]:
+        if model is None:
+            return {}
+        media = bool(requested_media_modalities(dataset) if dataset is not None else ())
+        out: dict[str, Any] = {}
+        if not model.thd_forward:
+            out["qkv_format"] = "bshd"
+            self._override_default(out, "use_dynamic_batch_size", False, True)
+            self._override_default(out, "micro_batch_size", 1, None)
+        if media:
+            self._override_default(out, "sglang_enable_multimodal", True, False)
+        return out
+
     # ── Internal ──────────────────────────────────────────────────────────────
 
     def _fields(
@@ -827,6 +847,7 @@ class MilesRecipe(BaseTrainRecipe):
                     eval_dataset_path=eval_dataset_path,
                 )
             )
+        fields.update(self.overrides(dataset, model))
         if self.metrics is not None:
             fields.update(self._metrics_to_fields(self.metrics))
         out = self._emit_fields(fields)

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_asr_1_7b.py
@@ -76,11 +76,6 @@ class Qwen3_ASR_1_7B_Recipe(SlimeRecipe):
     global_batch_size: int = 8
     lr_decay_style: str = "cosine"
 
-    use_dynamic_batch_size: bool = False
-    extra_config: dict | None = field(
-        default_factory=lambda: {"qkv_format": "bshd", "micro_batch_size": 1}
-    )
-
     # Save at the final rollout so the run produces a checkpoint to export to HF.
     save_interval: int = 8
     megatron_to_hf_mode: str = "bridge"

--- a/modal_training_gym/train_recipes/slime_recipe/qwen3_vl_8b.py
+++ b/modal_training_gym/train_recipes/slime_recipe/qwen3_vl_8b.py
@@ -1,7 +1,5 @@
 """Qwen3-VL-8B recipe for vision-language GRPO on 1x8xH100."""
 
-from dataclasses import field
-
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 
@@ -21,20 +19,8 @@ class Qwen3_VL_8B_Recipe(SlimeRecipe):
     rollout_temperature: float = 1.0
     sglang_mem_fraction_static: float = 0.55
 
-    # VL image patches expand to many tokens; padded (bshd) batches avoid the
-    # THD packing path, which needs dynamic batching off + explicit micro batch.
-    use_dynamic_batch_size: bool = False
-    extra_config: dict | None = field(
-        default_factory=lambda: {"qkv_format": "bshd", "micro_batch_size": 1}
-    )
-
     save_interval: int = 10
 
     # AutoBridge loads the VL checkpoint (incl. ViT) at the configured TP; skips
     # slime's torch_dist pre-conversion, which mis-assigns the VL pipeline stage.
     megatron_to_hf_mode: str = "bridge"
-
-    # Freeze the vision tower; RL only updates the language backbone.
-    freeze_params_name_list: list[str] | None = field(
-        default_factory=lambda: ["vision_model"]
-    )

--- a/modal_training_gym/train_recipes/slime_recipe/recipe.py
+++ b/modal_training_gym/train_recipes/slime_recipe/recipe.py
@@ -17,6 +17,7 @@ from pydantic import ConfigDict, model_validator
 from pydantic.dataclasses import dataclass
 
 from modal_training_gym.common.dataset import DatasetConfig
+from modal_training_gym.common.modality import requested_media_modalities
 from modal_training_gym.common.models import (
     ModelArchitecture,
     ModelConfig,
@@ -76,6 +77,19 @@ _SLIME_SKIP = {
 }
 
 YAML_CONFIG_FIELDS = ("eval_config", "extra_config", "sglang_config")
+
+QWEN35_VL_PROVIDER = "slime_plugins.models.qwen3_5_vl.provide_qwen3_5_vl"
+
+
+def qwen35_vl_image_train(
+    model: "ModelConfig | None", dataset: "DatasetConfig | None"
+) -> bool:
+    if model is None or dataset is None:
+        return False
+    if "image" not in requested_media_modalities(dataset):
+        return False
+    return bool(getattr(model, "needs_qwen35_vl_provider", False))
+
 
 _HOOK_PATH_CONFIG_KEYS = {
     "custom_rollout_log_function": "training_gym_custom_rollout_log_function_path",
@@ -592,6 +606,7 @@ class SlimeRecipe(BaseTrainRecipe):
     # ── Validators ───────────────────────────────────────────────────────────
 
     _SKIP_FIELDS: ClassVar[frozenset[str]] = frozenset(_SLIME_SKIP)
+    served_media_modalities: ClassVar[frozenset[str]] = frozenset({"image", "audio"})
 
     @model_validator(mode="after")
     def _validate_slime_source_overlay(self) -> "SlimeRecipe":
@@ -787,6 +802,44 @@ class SlimeRecipe(BaseTrainRecipe):
     def validate_model_parallelism(self, model: "ModelConfig") -> None:
         validate_num_experts_divisible_by_expert_parallel_size(self, model)
 
+    def overrides(
+        self,
+        dataset: "DatasetConfig | None",
+        model: "ModelConfig | None",
+    ) -> dict[str, Any]:
+        if model is None:
+            return {}
+        media = bool(requested_media_modalities(dataset) if dataset is not None else ())
+        out: dict[str, Any] = {}
+        if not model.thd_forward:
+            out["qkv_format"] = "bshd"
+            self._override_default(out, "use_dynamic_batch_size", False, True)
+            self._override_default(out, "micro_batch_size", 1, None)
+        if model.has_vision_tower and (not model.thd_forward or media):
+            freeze = (
+                ["visual"]
+                if qwen35_vl_image_train(model, dataset)
+                else ["vision_model"]
+            )
+            self._override_default(out, "freeze_params_name_list", freeze, None)
+        if qwen35_vl_image_train(model, dataset):
+            out.update(self._qwen35_vl_provider_fields())
+        return out
+
+    def _qwen35_vl_provider_fields(self) -> dict[str, Any]:
+        if "custom_model_provider_path" in self._escape_hatch_keys():
+            return {}
+        if (
+            isinstance(self.extra_config, str)
+            and getattr(self, "_materialized_config_keys", None) is None
+        ):
+            raise TrainingGymConfigError(
+                "Qwen3.5 image training requires custom_model_provider_path. "
+                "Pass extra_config as a dict, or put custom_model_provider_path "
+                "in that YAML. A path-only extra_config would train text-only."
+            )
+        return {"custom_model_provider_path": QWEN35_VL_PROVIDER}
+
     # ── Internal ──────────────────────────────────────────────────────────────
 
     def _fields(
@@ -817,6 +870,7 @@ class SlimeRecipe(BaseTrainRecipe):
             self.validate_model_parallelism(model)
             if not self.slime_model_script:
                 fields.update(self._model_to_fields(model))
+        fields.update(self.overrides(dataset, model))
         if self.metrics is not None:
             fields.update(self._metrics_to_fields(self.metrics))
         out = self._emit_fields(fields)

--- a/scripts/validation_backends/slime.py
+++ b/scripts/validation_backends/slime.py
@@ -36,7 +36,7 @@ class Gsm8kDataset(DatasetConfig):
 
 
 class LibriSpeechASRDataset(MultimodalDataset):
-    """LibriSpeech ASR rows (prompt + audio data-URI + transcript label).
+    """LibriSpeech ASR rows (prompt + audio path + transcript label).
 
     Mirrors the audio_asr tutorial dataset. Audio models validate on a handful
     of LibriSpeech clips. gsm8k is text-only.
@@ -58,8 +58,9 @@ class LibriSpeechASRDataset(MultimodalDataset):
         return False
 
     def source_rows(self):
-        import base64 as b64
         import io
+        import tempfile
+        from pathlib import Path
 
         import soundfile as sf
         from datasets import Audio, load_dataset
@@ -67,7 +68,9 @@ class LibriSpeechASRDataset(MultimodalDataset):
         ds = load_dataset(self.hf_repo, self.hf_config, split=self.hf_split)
         ds = ds.select(range(min(self.n_rows, len(ds))))
         ds = ds.cast_column("audio", Audio(decode=False))
-        for ex in ds:
+        cache = Path(tempfile.gettempdir()) / "training-gym-asr" / self.dataset_id
+        cache.mkdir(parents=True, exist_ok=True)
+        for i, ex in enumerate(ds):
             audio = ex["audio"]
             data = (
                 audio["bytes"]
@@ -75,14 +78,11 @@ class LibriSpeechASRDataset(MultimodalDataset):
                 else open(audio["path"], "rb").read()
             )
             arr, sr = sf.read(io.BytesIO(data))
-            buf = io.BytesIO()
-            sf.write(buf, arr, sr, format="WAV")
-            data_uri = "data:audio/wav;base64," + b64.b64encode(buf.getvalue()).decode(
-                "ascii"
-            )
+            wav_path = cache / f"{i:06d}.wav"
+            sf.write(wav_path, arr, sr, format="WAV")
             yield {
                 "prompt": self._INSTRUCTION,
-                "media": data_uri,
+                "media": str(wav_path),
                 "label": ex["text"].lower().strip(),
             }
 

--- a/tests/test_audio_asr.py
+++ b/tests/test_audio_asr.py
@@ -14,15 +14,17 @@ from modal_training_gym.common.models.qwen3_asr_1_7b import (
     _prompt_user_text,
     render_prompt,
 )
+from modal_training_gym.common.audio import coerce_audio_to_bytes
 from modal_training_gym.frameworks.slime.audio_transcription_rollout import _audio_ref
 
 _PLACEHOLDER = Qwen3_ASR_1_7B.audio_placeholder
 _DATA_URI = "data:audio/wav;base64," + base64.b64encode(b"RIFFxxxx").decode()
+_AUDIO_PATH = "/tmp/training-gym-asr/clip.wav"
 
 
-def _audio_prompt(text="Transcribe the speech."):
+def _audio_prompt(text="Transcribe the speech.", audio=_AUDIO_PATH):
     """A slime conversation-list prompt: one audio item + one text item."""
-    content = [{"type": "audio", "audio": _DATA_URI}, {"type": "text", "text": text}]
+    content = [{"type": "audio", "audio": audio}, {"type": "text", "text": text}]
     return [{"role": "user", "content": content}]
 
 
@@ -30,8 +32,9 @@ def _audio_prompt(text="Transcribe the speech."):
 
 
 def test_render_prompt_never_leaks_audio_payload():
-    out = render_prompt(_audio_prompt())
+    out = render_prompt(_audio_prompt(audio=_DATA_URI))
     assert _DATA_URI not in out and "data:audio" not in out
+    assert _AUDIO_PATH not in render_prompt(_audio_prompt())
     assert _PLACEHOLDER in out
     assert "Transcribe the speech." in out
     assert out.endswith("<|im_start|>assistant\n")
@@ -71,8 +74,15 @@ def test_prompt_user_text_ignores_non_user_roles():
 # ── _audio_ref ───────────────────────────────────────────────────────────────
 
 
-def test_audio_ref_extracts_data_uri():
-    assert _audio_ref(types.SimpleNamespace(prompt=_audio_prompt())) == _DATA_URI
+def test_audio_ref_extracts_path():
+    assert _audio_ref(types.SimpleNamespace(prompt=_audio_prompt())) == _AUDIO_PATH
+
+
+def test_coerce_audio_reads_path(tmp_path):
+    wav = tmp_path / "clip.wav"
+    wav.write_bytes(b"RIFF")
+    assert coerce_audio_to_bytes(str(wav)) == b"RIFF"
+    assert coerce_audio_to_bytes(b"raw") == b"raw"
 
 
 def test_audio_ref_raises_when_no_audio():

--- a/tests/test_multimodal_passthrough.py
+++ b/tests/test_multimodal_passthrough.py
@@ -382,16 +382,21 @@ def test_write_jsonl_materializes_data_uris(tmp_path):
         (Qwen3_8_27B(), Qwen3_8_27B_Recipe),
     ],
 )
-def test_qwen36_38_reject_image(model, recipe_cls):
-    with pytest.raises(ValidationError, match="cannot serve image"):
-        TrainConfig(
-            dataset=_mm("image"),
-            model=model,
-            recipe=recipe_cls(),
-        )
+def test_qwen36_38_accept_image(model, recipe_cls):
+    TrainConfig(
+        dataset=_mm("image"),
+        model=model,
+        recipe=recipe_cls(),
+    )
     recipe = recipe_cls()
     args = recipe.cli_args(dataset=_mm("image"), model=model)
-    assert "--custom-model-provider-path" not in args
+    flags = _flags(args)
+    assert flags["--qkv-format"] == "thd"
+    assert flags["--freeze-params-name-list"] == "visual"
+    assert "--use-dynamic-batch-size" in args
+    assert "--micro-batch-size" not in args
+    assert flags["--custom-model-provider-path"] == _QWEN35_VL_PROVIDER
+    assert not (recipe.extra_config or {}).get("custom_model_provider_path")
 
 
 def test_miles_qwen35_rejects_image():

--- a/tests/test_multimodal_passthrough.py
+++ b/tests/test_multimodal_passthrough.py
@@ -1,25 +1,53 @@
-"""The multimodal passthrough: a dataset names its media column, the recipe
-forwards it to slime as --multimodal-keys. Modality-agnostic (image/audio/video).
-"""
-
 import json
+from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
-from modal_training_gym import HuggingFaceDataset, MultimodalDataset, SlimeRecipe
-
-_RECIPE_KW = dict(
-    gpu_type="H100",
-    colocate=True,
-    tensor_model_parallel_size=1,
-    sequence_parallel=False,
-    rollout_num_gpus_per_engine=1,
-    num_rollout=1,
-    rollout_batch_size=4,
-    rollout_max_response_len=256,
-    rollout_temperature=1.0,
-    save_interval=1,
+from modal_training_gym.common.dataset import HuggingFaceDataset, MultimodalDataset
+from modal_training_gym.common.errors import TrainingGymConfigError
+from modal_training_gym.common.launcher_utils import prepare_launch_config
+from modal_training_gym.common.models import (
+    Gemma4_26B_A4B,
+    Inkling_Small,
+    Qwen3_4B,
+    Qwen3_5_4B,
+    Qwen3_6_27B,
+    Qwen3_6_35B,
+    Qwen3_8_27B,
+    Qwen3_ASR_1_7B,
+    Qwen3_VL_8B,
 )
+from modal_training_gym.common.train import TrainConfig
+from modal_training_gym.frameworks.slime.launcher import _apply_qwen35_vl_image_train
+from modal_training_gym.train_recipes.miles_recipe.gemma4_26b_a4b import (
+    Gemma4_26B_A4B_Recipe,
+)
+from modal_training_gym.train_recipes.miles_recipe.inkling import (
+    Inkling_Small_LoRA_Recipe,
+    Inkling_Small_Recipe,
+)
+from modal_training_gym.train_recipes.miles_recipe.qwen3_5_4b import (
+    Qwen3_5_4B_Miles_Recipe,
+)
+from modal_training_gym.train_recipes.slime_recipe.qwen3_4b import Qwen3_4B_Recipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_5_4b import Qwen3_5_4B_Recipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_6_27b import Qwen3_6_27B_Recipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_6_35b import Qwen3_6_35B_Recipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_8_27b import Qwen3_8_27B_Recipe
+from modal_training_gym.train_recipes.slime_recipe.qwen3_asr_1_7b import (
+    Qwen3_ASR_1_7B_Recipe,
+)
+from modal_training_gym.train_recipes.slime_recipe.qwen3_vl_8b import Qwen3_VL_8B_Recipe
+
+_QWEN35_VL_PROVIDER = "slime_plugins.models.qwen3_5_vl.provide_qwen3_5_vl"
+
+
+def _mm(modality):
+    return MultimodalDataset(
+        rows=[{"prompt": "p", "media": ["ref"], "label": "l"}],
+        modality=modality,
+    )
 
 
 def _flags(args):
@@ -28,36 +56,62 @@ def _flags(args):
     }
 
 
-@pytest.mark.parametrize("modality", ["image", "audio", "video"])
+@pytest.mark.parametrize("modality", ["image", "audio"])
 def test_multimodal_keys_emitted(modality):
-    rows = [{"prompt": "p", "media": ["ref"], "label": "l"}]
-    ds = MultimodalDataset(rows=rows, modality=modality)
+    ds = _mm(modality)
     assert ds.multimodal_keys == {modality: f"{modality}s"}
-
-    flags = _flags(SlimeRecipe(**_RECIPE_KW).cli_args(dataset=ds))
+    if modality == "image":
+        flags = _flags(Qwen3_VL_8B_Recipe().cli_args(dataset=ds, model=Qwen3_VL_8B()))
+    else:
+        flags = _flags(
+            Qwen3_ASR_1_7B_Recipe().cli_args(dataset=ds, model=Qwen3_ASR_1_7B())
+        )
     assert json.loads(flags["--multimodal-keys"]) == {modality: f"{modality}s"}
     assert flags["--input-key"] == "prompt"
     assert flags["--label-key"] == "label"
-    assert ds.apply_chat_template() is True
+    assert ds.apply_chat_template() is (modality == "image")
 
 
 def test_multimodal_dataset_can_disable_chat_template():
-    class AudioDataset(MultimodalDataset):
+    class ImageDataset(MultimodalDataset):
         def apply_chat_template(self) -> bool:
             return False
 
-    assert AudioDataset(rows=[]).apply_chat_template() is False
+    assert ImageDataset(rows=[], modality="image").apply_chat_template() is False
 
 
 def test_write_writes_media_column(tmp_path):
-    rows = [{"prompt": "p", "media": ["a.wav", "b.wav"], "label": "l"}]
-    ds = MultimodalDataset(rows=rows, modality="audio")
+    ds = MultimodalDataset(
+        rows=[{"prompt": "p", "media": ["a.wav", "b.wav"], "label": "l"}],
+        modality="audio",
+    )
     out = str(tmp_path / "train.jsonl")
     ds.write(out)
-    ds.validate_written(out)  # must not raise
+    ds.validate_written(out)
     row = json.loads(open(out).readline())
     assert row["audios"] == ["a.wav", "b.wav"]
     assert row["prompt"] == "p" and row["label"] == "l"
+
+
+def test_huggingface_dataset_rejects_multimodal_keys():
+    with pytest.raises(TrainingGymConfigError, match="MultimodalDataset"):
+        HuggingFaceDataset(
+            hf_repo="statworx/haiku",
+            input_column="keywords",
+            output_column="text",
+            multimodal_keys={"image": "images"},
+        )
+
+
+def test_load_returns_file_paths():
+    png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    ds = MultimodalDataset(
+        rows=[{"prompt": "p", "media": [f"data:image/png;base64,{png}"], "label": "l"}],
+        modality="image",
+    )
+    path = Path(ds.load()[0]["images"][0])
+    assert path.is_file()
+    assert path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
 
 def test_text_dataset_unaffected():
@@ -67,8 +121,10 @@ def test_text_dataset_unaffected():
         output_column="text",
         input_format="text",
     )
-    assert getattr(ds, "multimodal_keys", None) is None
-    assert "--multimodal-keys" not in SlimeRecipe(**_RECIPE_KW).cli_args(dataset=ds)
+    assert ds.multimodal_keys is None
+    assert "--multimodal-keys" not in Qwen3_4B_Recipe().cli_args(
+        dataset=ds, model=Qwen3_4B()
+    )
 
 
 @pytest.mark.parametrize(
@@ -134,5 +190,265 @@ def test_hugging_face_rejects_unknown_input_format():
 
 
 def test_media_column_must_be_distinct():
-    with pytest.raises(ValueError):
+    with pytest.raises(TrainingGymConfigError, match="media_column"):
         MultimodalDataset(rows=[], modality="image", media_column="prompt")
+
+
+def test_multimodal_dataset_rejects_video():
+    with pytest.raises(TrainingGymConfigError, match="image/audio"):
+        MultimodalDataset(
+            rows=[{"prompt": "p", "media": ["ref"], "label": "l"}],
+            modality="video",
+        )
+
+
+def test_train_config_rejects_video():
+    ds = _mm("image")
+    ds.multimodal_keys = {"video": "videos"}
+    with pytest.raises(ValidationError, match="cannot serve video"):
+        TrainConfig(
+            dataset=ds,
+            model=Qwen3_VL_8B(),
+            recipe=Qwen3_VL_8B_Recipe(),
+        )
+
+
+@pytest.mark.parametrize("modality", ["audio", "image"])
+def test_train_config_rejects_media_on_text_model(modality):
+    with pytest.raises(ValidationError, match=f"cannot serve {modality}"):
+        TrainConfig(
+            dataset=_mm(modality),
+            model=Qwen3_4B(),
+            recipe=Qwen3_4B_Recipe(),
+        )
+
+
+def test_train_config_accepts_qwen35_image():
+    TrainConfig(
+        dataset=_mm("image"),
+        model=Qwen3_5_4B(),
+        recipe=Qwen3_5_4B_Recipe(),
+    )
+
+
+def test_train_config_accepts_asr_audio():
+    TrainConfig(
+        dataset=_mm("audio"),
+        model=Qwen3_ASR_1_7B(),
+        recipe=Qwen3_ASR_1_7B_Recipe(),
+    )
+
+
+def test_train_config_rejects_inkling_text_mode_with_audio():
+    with pytest.raises(ValidationError, match="cannot serve audio"):
+        TrainConfig(
+            dataset=_mm("audio"),
+            model=Inkling_Small(),
+            recipe=Inkling_Small_Recipe(),
+        )
+
+
+def test_train_config_accepts_inkling_audio():
+    TrainConfig(
+        dataset=_mm("audio"),
+        model=Inkling_Small(),
+        recipe=Inkling_Small_Recipe(modality="audio"),
+    )
+
+
+def test_qwen35_image_cli_emits_vl_provider(tmp_path):
+    recipe = Qwen3_5_4B_Recipe()
+    model = Qwen3_5_4B()
+    ds = _mm("image")
+    args = recipe.cli_args(dataset=ds, model=model)
+    flags = _flags(args)
+    assert flags["--qkv-format"] == "thd"
+    assert flags["--freeze-params-name-list"] == "visual"
+    assert "--use-dynamic-batch-size" in args
+    assert "--micro-batch-size" not in args
+    assert flags["--custom-model-provider-path"] == _QWEN35_VL_PROVIDER
+    assert not (recipe.extra_config or {}).get("custom_model_provider_path")
+
+    object.__setattr__(recipe, "extra_config", {"custom_rm_path": "reward.score"})
+    prepare_launch_config(
+        recipe, None, str(tmp_path), yaml_config_fields=("extra_config",)
+    )
+    launched = _flags(recipe.cli_args(dataset=ds, model=model))
+    assert launched["--custom-model-provider-path"] == _QWEN35_VL_PROVIDER
+    assert launched["--custom-config-path"] == recipe.extra_config
+
+
+def test_qwen35_image_launch_uses_bridge():
+    recipe = Qwen3_5_4B_Recipe()
+    _apply_qwen35_vl_image_train(recipe, Qwen3_5_4B(), _mm("image"))
+    assert recipe.megatron_to_hf_mode == "bridge"
+    text = Qwen3_5_4B_Recipe()
+    _apply_qwen35_vl_image_train(text, Qwen3_5_4B(), None)
+    assert text.megatron_to_hf_mode == ""
+
+
+def test_qwen35_image_path_extra_config_fails_fast(tmp_path):
+    recipe = Qwen3_5_4B_Recipe()
+    object.__setattr__(recipe, "extra_config", "configs/extra.yaml")
+    with pytest.raises(TrainingGymConfigError, match="custom_model_provider_path"):
+        recipe.cli_args(dataset=_mm("image"), model=Qwen3_5_4B())
+    launch = Qwen3_5_4B_Recipe()
+    object.__setattr__(launch, "extra_config", "configs/extra.yaml")
+    with pytest.raises(TrainingGymConfigError, match="custom_model_provider_path"):
+        _apply_qwen35_vl_image_train(launch, Qwen3_5_4B(), _mm("image"))
+
+    materialized = Qwen3_5_4B_Recipe()
+    object.__setattr__(materialized, "extra_config", {"custom_rm_path": "reward.score"})
+    prepare_launch_config(
+        materialized,
+        None,
+        str(tmp_path),
+        yaml_config_fields=("extra_config",),
+    )
+    flags = _flags(materialized.cli_args(dataset=_mm("image"), model=Qwen3_5_4B()))
+    assert flags["--custom-model-provider-path"] == _QWEN35_VL_PROVIDER
+
+    owned = Qwen3_5_4B_Recipe()
+    object.__setattr__(
+        owned,
+        "extra_config",
+        {"custom_model_provider_path": "slime_plugins.models.other.provide"},
+    )
+    owned_dir = tmp_path / "owned"
+    owned_dir.mkdir()
+    prepare_launch_config(
+        owned, None, str(owned_dir), yaml_config_fields=("extra_config",)
+    )
+    owned_flags = _flags(owned.cli_args(dataset=_mm("image"), model=Qwen3_5_4B()))
+    assert "--custom-model-provider-path" not in owned_flags
+    assert owned_flags["--custom-config-path"] == owned.extra_config
+
+
+def test_qwen35_recipe_reuse_does_not_stick_vl_provider():
+    recipe = Qwen3_5_4B_Recipe()
+    image_args = recipe.cli_args(dataset=_mm("image"), model=Qwen3_5_4B())
+    text_args = recipe.cli_args(model=Qwen3_5_4B())
+    assert _flags(image_args)["--custom-model-provider-path"] == _QWEN35_VL_PROVIDER
+    assert "--custom-model-provider-path" not in text_args
+    assert not (recipe.extra_config or {}).get("custom_model_provider_path")
+
+
+def test_qwen35_text_cli_leaves_vl_provider_unset():
+    recipe = Qwen3_5_4B_Recipe()
+    args = recipe.cli_args(model=Qwen3_5_4B())
+    assert "--custom-model-provider-path" not in args
+    assert not (recipe.extra_config or {}).get("custom_model_provider_path")
+
+
+def test_write_jsonl_materializes_data_uris(tmp_path):
+    png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    wav = "UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA="
+    ds = MultimodalDataset(
+        rows=[
+            {
+                "prompt": "p",
+                "media": [f"data:image/png;base64,{png}", "/already/a/path.png"],
+                "label": "l",
+            }
+        ],
+        modality="image",
+    )
+    path = tmp_path / "train.jsonl"
+    ds._write_jsonl(ds.load(), str(path))
+    row = json.loads(path.read_text().splitlines()[0])
+    written, leftover = row["images"]
+    assert leftover == "/already/a/path.png"
+    assert written == str((tmp_path / "media" / "000000.png").resolve())
+    assert path.with_name("media").joinpath("000000.png").read_bytes()[:8] == (
+        b"\x89PNG\r\n\x1a\n"
+    )
+
+    audio = MultimodalDataset(
+        rows=[{"prompt": "p", "media": [f"data:audio/wav;base64,{wav}"], "label": "l"}],
+        modality="audio",
+    )
+    audio_path = tmp_path / "audio.jsonl"
+    audio._write_jsonl(audio.load(), str(audio_path))
+    audio_row = json.loads(audio_path.read_text().splitlines()[0])
+    assert audio_row["audios"] == [str((tmp_path / "media" / "000000.wav").resolve())]
+    assert (tmp_path / "media" / "000000.wav").read_bytes()[:4] == b"RIFF"
+
+
+@pytest.mark.parametrize(
+    ("model", "recipe_cls"),
+    [
+        (Qwen3_6_27B(), Qwen3_6_27B_Recipe),
+        (Qwen3_6_35B(), Qwen3_6_35B_Recipe),
+        (Qwen3_8_27B(), Qwen3_8_27B_Recipe),
+    ],
+)
+def test_qwen36_38_reject_image(model, recipe_cls):
+    with pytest.raises(ValidationError, match="cannot serve image"):
+        TrainConfig(
+            dataset=_mm("image"),
+            model=model,
+            recipe=recipe_cls(),
+        )
+    recipe = recipe_cls()
+    args = recipe.cli_args(dataset=_mm("image"), model=model)
+    assert "--custom-model-provider-path" not in args
+
+
+def test_miles_qwen35_rejects_image():
+    with pytest.raises(ValidationError, match="cannot serve image"):
+        TrainConfig(
+            dataset=_mm("image"),
+            model=Qwen3_5_4B(),
+            recipe=Qwen3_5_4B_Miles_Recipe(),
+        )
+
+
+def test_vl_always_emits_bshd():
+    flags = _flags(Qwen3_VL_8B_Recipe().cli_args(model=Qwen3_VL_8B()))
+    assert flags["--qkv-format"] == "bshd"
+    assert flags["--freeze-params-name-list"] == "vision_model"
+
+
+def test_asr_audio_cli_uses_bshd():
+    args = Qwen3_ASR_1_7B_Recipe().cli_args(
+        dataset=_mm("audio"), model=Qwen3_ASR_1_7B()
+    )
+    flags = _flags(args)
+    assert flags["--qkv-format"] == "bshd"
+    assert "--use-dynamic-batch-size" not in args
+    assert flags["--micro-batch-size"] == "1"
+    assert "--apply-chat-template" not in args
+
+
+def test_gemma_image_cli_uses_bshd():
+    recipe = Gemma4_26B_A4B_Recipe(modality="vision", rm_type="gemma_math")
+    args = recipe.cli_args(dataset=_mm("image"), model=Gemma4_26B_A4B())
+    flags = _flags(args)
+    assert flags["--qkv-format"] == "bshd"
+    assert "--use-dynamic-batch-size" not in args
+    assert flags["--micro-batch-size"] == "1"
+    assert "--sglang-enable-multimodal" in args
+
+
+def test_inkling_vision_omits_chat_template():
+    recipe = Inkling_Small_Recipe(modality="vision")
+    args = recipe.cli_args(dataset=_mm("image"), model=Inkling_Small())
+    assert "--apply-chat-template" not in args
+    flags = _flags(args)
+    assert (
+        flags["--custom-model-provider-path"]
+        == "miles_plugins.models.inkling.model.inkling_mm_model_provider"
+    )
+
+
+@pytest.mark.parametrize(
+    ("modality", "recipe_modality"),
+    [("image", "vision"), ("audio", "audio")],
+)
+def test_inkling_lora_media_keeps_thd_and_dynamic_packing(modality, recipe_modality):
+    recipe = Inkling_Small_LoRA_Recipe(modality=recipe_modality)
+    args = recipe.cli_args(dataset=_mm(modality), model=Inkling_Small())
+    flags = _flags(args)
+    assert flags["--qkv-format"] == "thd"
+    assert "--use-dynamic-batch-size" in args
+    assert "--micro-batch-size" not in args

--- a/tutorials/audio_asr.py
+++ b/tutorials/audio_asr.py
@@ -12,7 +12,7 @@
 # in terms of WER. But there's no reason to stop there: we can achieve state-of-the-art
 # performance by post-training open models to redefine your task's Pareto frontier.
 # As an example, we show how to post-train
-# [Qwen3-ASR-1.7B](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) on the 
+# [Qwen3-ASR-1.7B](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) on the
 # [hf-internal-testing/librispeech_asr_dummy](https://huggingface.co/datasets/hf-internal-testing/librispeech_asr_dummy)
 # dataset.
 
@@ -21,9 +21,10 @@ import requests
 import soundfile as sf
 from datasets import Audio, load_dataset
 
-import base64
 import io
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 from modal_training_gym import (
     CustomDeployment,
@@ -53,6 +54,7 @@ print(f"base model deployed to {base_deployment.url}")
 # As mentioned before, we measure capability by lower WER, so that's what we'll use.
 # We can use the `jiwer` library to calculate this so we don't have to ourselves.
 
+
 def score_transcript(response: str, label: str) -> float:
     response = (response or "").lower().strip()
     label = (label or "").lower().strip()
@@ -60,13 +62,13 @@ def score_transcript(response: str, label: str) -> float:
         return 0.0
     return float(jiwer.wer(label, response))
 
+
 # ## Get the dataset
 #
 # Since this dataset contains audio files, we create a `MultimodalDataset`
-# to pass the audio clips to rollouts. We do some pre-processing with
-# `soundfile` and store as base64 inline for demonstration purposes.
-# In a production use case, you'd likely instead store references and
-# resolve them in a custom `generate` function.
+# to pass the audio clips to rollouts. Clips are written as WAV files.
+# Trainers and the transcription rollout read those paths.
+
 
 class LibriSpeechASRDataset(MultimodalDataset):
     hf_repo = "hf-internal-testing/librispeech_asr_dummy"
@@ -81,8 +83,12 @@ class LibriSpeechASRDataset(MultimodalDataset):
 
     def source_rows(self):
         ds = load_dataset(self.hf_repo, self.hf_config, split=self.hf_split)
-        ds = ds.cast_column("audio", Audio(decode=False))  # decode with soundfile instead of torchcodec
-        for ex in ds:
+        ds = ds.cast_column(
+            "audio", Audio(decode=False)
+        )  # decode with soundfile instead of torchcodec
+        cache = Path(tempfile.gettempdir()) / "training-gym-asr" / self.dataset_id
+        cache.mkdir(parents=True, exist_ok=True)
+        for i, ex in enumerate(ds):
             audio = ex["audio"]
             data = (
                 audio["bytes"]
@@ -90,16 +96,14 @@ class LibriSpeechASRDataset(MultimodalDataset):
                 else open(audio["path"], "rb").read()
             )
             arr, sr = sf.read(io.BytesIO(data))
-            buf = io.BytesIO()
-            sf.write(buf, arr, sr, format="WAV")
-            data_uri = "data:audio/wav;base64," + base64.b64encode(
-                buf.getvalue()
-            ).decode("ascii")
+            wav_path = cache / f"{i:06d}.wav"
+            sf.write(wav_path, arr, sr, format="WAV")
             yield {
                 "prompt": "<audio>\nTranscribe the speech to text. Respond with only the transcript.",
-                "media": data_uri,
+                "media": str(wav_path),
                 "label": ex["text"].lower().strip(),
             }
+
 
 train_dataset = LibriSpeechASRDataset(hf_split="validation[:8]")
 
@@ -109,14 +113,14 @@ eval_dataset = LibriSpeechASRDataset(hf_split="validation[8:16]")
 #
 # Let's get our baseline measure of performance.
 
+
 def run_eval(deployment, max_concurrency: int = 2) -> float:
     deployment.wait_until_ready(timeout=15 * 60)
 
     def _score_one(example):
-        data_uri = example["audios"][0]
+        audio_path = example["audios"][0]
         reference = (example["label"] or "").lower().strip()
-        b64 = data_uri.split(",", 1)[1] if data_uri.startswith("data:") else data_uri
-        arr, sr = sf.read(io.BytesIO(base64.b64decode(b64)))
+        arr, sr = sf.read(audio_path)
 
         buf = io.BytesIO()
         sf.write(buf, arr, sr, format="WAV")
@@ -138,6 +142,7 @@ def run_eval(deployment, max_concurrency: int = 2) -> float:
         wers = list(executor.map(_score_one, eval_dataset.rows()))
     return sum(wers) / len(wers) if wers else float("nan")
 
+
 print("running base model evaluation...")
 base_mean = run_eval(base_deployment)
 print(f"average WER: {base_mean:.1%}")
@@ -147,8 +152,10 @@ print(f"average WER: {base_mean:.1%}")
 # To make our scoring function a reward function, we must return the
 # negative WER so that lower WER leads to higher rewards.
 
+
 async def wer_rm(args, sample, **kwargs) -> float:
     return -score_transcript(sample.response, sample.label)
+
 
 # ## Begin training
 #

--- a/tutorials/computer_use.py
+++ b/tutorials/computer_use.py
@@ -21,7 +21,10 @@
 # element scores +1 (a real click succeeds), and predictions that miss decay
 # toward −1 over a margin scaled to the element's own size.
 
+import base64
 import re
+import tempfile
+from pathlib import Path
 
 from modal_training_gym import (
     CustomDeployment,
@@ -59,6 +62,7 @@ GROUNDING_PROMPT = (
     "horizontal and vertical position on the screen."
 )
 
+
 class ScreenSpotDataset(MultimodalDataset):
     """GUI grounding dataset from ScreenSpot."""
 
@@ -71,29 +75,24 @@ class ScreenSpotDataset(MultimodalDataset):
         super().__init__(modality="image")
 
     def source_rows(self):
-        import base64
-        import io
-
         from datasets import load_dataset
 
         ds = load_dataset(self.hf_repo, split=self.hf_split)
         start = min(self.row_offset, len(ds))
         stop = min(start + self.n_rows, len(ds))
-        # Demo-scale: inline base64 rows in memory; stream large corpora.
-        for row in ds.select(range(start, stop)):
+        cache = Path(tempfile.gettempdir()) / "training-gym-mm" / self.dataset_id
+        cache.mkdir(parents=True, exist_ok=True)
+        for i, row in enumerate(ds.select(range(start, stop))):
             left, top, right, bottom = row["bbox"]
             instruction = row["instruction"]
-
-            buf = io.BytesIO()
-            row["image"].save(buf, format="PNG")
-            img_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
-            data_uri = f"data:image/png;base64,{img_b64}"
-
+            img_path = cache / f"{i:06d}.png"
+            row["image"].save(img_path, format="PNG")
             yield {
                 "prompt": GROUNDING_PROMPT.format(instruction=instruction),
-                "media": data_uri,
+                "media": str(img_path),
                 "label": f"{left:.4f},{top:.4f},{right:.4f},{bottom:.4f}",
             }
+
 
 train_dataset = ScreenSpotDataset(n_rows=800)
 
@@ -124,6 +123,7 @@ eval_dataset = ScreenSpotDataset(n_rows=200, row_offset=800)
 #
 # The model also gets −1 if it fails to output parseable coordinates.
 
+
 def _parse_coordinates(text: str) -> tuple[float, float] | None:
     """Extract (x, y) from model output like '(0.45, 0.32)' or '0.45, 0.32'."""
     nums = re.findall(r"([\d.]+)", text)
@@ -137,10 +137,12 @@ def _parse_coordinates(text: str) -> tuple[float, float] | None:
         pass
     return None
 
+
 def _parse_bbox(label: str) -> tuple[float, float, float, float]:
     """Parse a 'left,top,right,bottom' label into floats."""
     left, top, right, bottom = (float(v) for v in label.split(","))
     return left, top, right, bottom
+
 
 def _distance_outside_box(
     x: float, y: float, box: tuple[float, float, float, float]
@@ -150,6 +152,7 @@ def _distance_outside_box(
     dx = max(left - x, 0.0, x - right)
     dy = max(top - y, 0.0, y - bottom)
     return (dx * dx + dy * dy) ** 0.5
+
 
 async def grounding_reward(args, sample, **kwargs) -> float:
     response = getattr(sample, "response", "") or ""
@@ -175,14 +178,21 @@ async def grounding_reward(args, sample, **kwargs) -> float:
         return -1.0
     return 1.0 - 2.0 * outside / margin
 
+
 # ## Baseline Eval
 #
 # Let's evaluate the base Qwen3-VL-8B model on our held-out set before
 # training to see how well it grounds UI elements out of the box.
 
-def grounding_eval_fn(
-    deployment: CustomDeployment, example: dict
-) -> dict:
+
+def _image_url(img: str) -> str:
+    if img.startswith(("data:", "http://", "https://")):
+        return img
+    raw = Path(img).read_bytes()
+    return "data:image/png;base64," + base64.b64encode(raw).decode("ascii")
+
+
+def grounding_eval_fn(deployment: CustomDeployment, example: dict) -> dict:
     # Eval sends the screenshot as a separate image_url, so drop the marker.
     prompt = example["prompt"].replace("<image>", "").strip()
     label = example["label"]
@@ -191,7 +201,7 @@ def grounding_eval_fn(
     # OpenAI multimodal user message: text + one image_url part per screenshot.
     content = [
         {"type": "text", "text": prompt},
-        *({"type": "image_url", "image_url": {"url": img}} for img in images),
+        *({"type": "image_url", "image_url": {"url": _image_url(img)}} for img in images),
     ]
     msg = deployment.chat(
         [{"role": "user", "content": content}],
@@ -216,9 +226,8 @@ def grounding_eval_fn(
         "label": label,
     }
 
-def run_eval(
-    deployment, *, max_concurrency: int = 2
-) -> tuple[float, list[dict]]:
+
+def run_eval(deployment, *, max_concurrency: int = 2) -> tuple[float, list[dict]]:
     from concurrent.futures import ThreadPoolExecutor
 
     deployment.wait_until_ready(timeout=3000)
@@ -230,6 +239,7 @@ def run_eval(
         rows = list(executor.map(_score_one, eval_dataset.rows()))
     mean = sum(r["score"] for r in rows) / len(rows) if rows else float("nan")
     return mean, rows
+
 
 model = Qwen3_VL_8B()
 base_deployment = CustomDeployment.launch(
@@ -249,11 +259,10 @@ print(
 # ## Training
 #
 # We use `Qwen3_VL_8B_Recipe` which carries VL-specific defaults:
-# - **Frozen vision tower** (`freeze_params_name_list=["vision_model"]`) — RL
-#   only updates the language backbone. This is the standard recipe for VLM RL:
-#   a single sparse reward is too noisy to safely fine-tune a pretrained visual
-#   encoder (you'd risk collapsing its features), and grounding is really about
-#   teaching the decoder to *read out* coordinates from features the ViT already
+# - **Frozen vision tower** — the recipe freezes `vision_model` so RL only
+#   updates the language backbone. A single sparse reward is too noisy to
+#   safely fine-tune a pretrained visual encoder, and grounding is about
+#   teaching the decoder to read out coordinates from features the ViT already
 #   provides. It's also cheaper — no optimizer state or backward pass for the ViT.
 # - Padded (bshd) batches for the vision encoder
 # - TP=4 for the 8B model across 8 H100s


### PR DESCRIPTION
## Summary
- Gate image/audio at TrainConfig; reject video and Miles Qwen3.5 image
- Path-only multimodal media; ASR/computer-use tutorials write files
- Qwen3.5 slime image uses in-repo qwen3_5_vl provider; Qwen3.6/3.8 stay text-only
- BSHD / vision freeze from model flags

## Test plan
- [x] pytest test_multimodal_passthrough.py test_audio_asr.py (post-rebase)
- [x] live 1-step: Qwen3.5-0.8B VL, ASR, Qwen3-VL-8B BSHD, Gemma text+vision, Inkling audio
- [x] live 1-step solo Inkling vision (`dry-set-97e3cedffb60`)
- [ ] PR CI

Other live 1-step run ids: `independent-anchor` (Inkling audio), `icy-echo` (Gemma vision), `chill-father` (Qwen3.5 VL), `optimal-nickel` (ASR), `tense-delta` (VL-8B), `creamy-fjord` (Gemma text).

## Known follow-ups
- Four ModelConfig bools vs one capability record
- Possible double materialization (load + _write_jsonl)
- Launcher setattr vs overrides() dual path
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/training-gym/pull/533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->